### PR TITLE
fix: do not use a nil variable

### DIFF
--- a/insonmnia/miner/overseer.go
+++ b/insonmnia/miner/overseer.go
@@ -176,6 +176,7 @@ func (o *overseer) collectStats() {
 				resp, err := o.client.ContainerStats(o.ctx, id, false)
 				if err != nil {
 					log.G(o.ctx).Warn("failed to get Stats", zap.String("id", id), zap.Error(err))
+					continue
 				}
 				var stats types.Stats
 				err = json.NewDecoder(resp.Body).Decode(&stats)


### PR DESCRIPTION
This commit fixes use a response variable after returning error.

Found by @antmat. Annoying for me.