### PR TITLE
refactor: hierarchical hub config

### DIFF
--- a/cmd/hub/main.go
+++ b/cmd/hub/main.go
@@ -10,7 +10,11 @@ import (
 	"github.com/noxiouz/zapctx/ctxlog"
 	"go.uber.org/zap"
 
+	"github.com/sonm-io/core/common"
 	"github.com/sonm-io/core/insonmnia/hub"
+	"github.com/sonm-io/core/insonmnia/logging"
+
+	log "github.com/noxiouz/zapctx/ctxlog"
 )
 
 var (
@@ -21,13 +25,16 @@ func main() {
 	flag.Parse()
 	ctx := context.Background()
 
-	conf, err := hub.NewConfig(*configPath)
+	cfg, err := hub.NewConfig(*configPath)
 	if err != nil {
-		ctxlog.GetLogger(ctx).Error("Cannot load config", zap.Error(err))
+		ctxlog.GetLogger(ctx).Error("failed to load config", zap.Error(err))
 		os.Exit(1)
 	}
 
-	h, err := hub.New(ctx, conf)
+	logger := logging.BuildLogger(cfg.Logging.Level, common.DevelopmentMode)
+	ctx = log.WithLogger(ctx, logger)
+
+	h, err := hub.New(ctx, cfg)
 	if err != nil {
 		ctxlog.GetLogger(ctx).Error("failed to create a new Hub", zap.Error(err))
 		os.Exit(1)

--- a/hub.yaml
+++ b/hub.yaml
@@ -1,9 +1,17 @@
-logger:
-  level: -1
+# The main endpoint for miner connections.
+endpoint: ":10002"
 
-hub:
-  grpc_endpoint: ":10001"
-  miner_endpoint: ":10002"
-  bootnodes:
-    - "enode://aaff8b588b3c2bde265504c78cb33449d8b5659bc172278e50abc73a2521fbd938aefd097c077efae316754b115f4e27b5126c6785cd51932331ba224c8734c1@127.0.0.1:30348"
-    - "enode://aaff8b588b3c2bde265504c78cb33449d8b5659bc172278e50abc73a2521fbd938aefd097c077efae316754b115f4e27b5126c6785cd51932331ba224c8734c2@127.0.0.1:30348"
+# Ethereum boot nodes.
+bootnodes:
+  - "enode://aaff8b588b3c2bde265504c78cb33449d8b5659bc172278e50abc73a2521fbd938aefd097c077efae316754b115f4e27b5126c6785cd51932331ba224c8734c1@127.0.0.1:30348"
+  - "enode://aaff8b588b3c2bde265504c78cb33449d8b5659bc172278e50abc73a2521fbd938aefd097c077efae316754b115f4e27b5126c6785cd51932331ba224c8734c2@127.0.0.1:30348"
+
+# Monitoring settings.
+monitoring:
+  # An endpoint which serves using gRPC protocol.
+  endpoint: ":10001"
+
+# Logging settings.
+logging:
+  # The desired logging level.
+  level: -1

--- a/insonmnia/hub/config.go
+++ b/insonmnia/hub/config.go
@@ -4,17 +4,22 @@ import (
 	"github.com/jinzhu/configor"
 )
 
-type HubConfig struct {
-	Logger struct {
-		Level int `required:"true" default:"1"`
-	} `yaml:"logger"`
-	Hub struct {
-		GRPCEndpoint  string   `required:"true" yaml:"grpc_endpoint"`
-		MinerEndpoint string   `required:"true" yaml:"miner_endpoint"`
-		Bootnodes     []string `required:"false" yaml:"bootnodes"`
-	} `yaml:"hub"`
+type LoggingConfig struct {
+	Level int `required:"true" default:"1"`
 }
 
+type MonitoringConfig struct {
+	Endpoint string `required:"true" yaml:"endpoint"`
+}
+
+type HubConfig struct {
+	Endpoint   string           `required:"true" yaml:"endpoint"`
+	Bootnodes  []string         `required:"false" yaml:"bootnodes"`
+	Monitoring MonitoringConfig `required:"true" yaml:"monitoring"`
+	Logging    LoggingConfig    `yaml:"logging"`
+}
+
+// NewConfig loads a hub config from the specified YAML file.
 func NewConfig(path string) (*HubConfig, error) {
 	conf := &HubConfig{}
 	err := configor.Load(conf, path)
@@ -22,4 +27,11 @@ func NewConfig(path string) (*HubConfig, error) {
 		return nil, err
 	}
 	return conf, nil
+}
+
+// TODO: Currently stubbed for simplifying testing.
+type Config interface {
+	Endpoint() string
+	MonitoringEndpoint() string
+	Logging() LoggingConfig
 }

--- a/insonmnia/hub/config_test.go
+++ b/insonmnia/hub/config_test.go
@@ -22,27 +22,29 @@ func deleteTestConfigFile() {
 
 func TestLoadConfig(t *testing.T) {
 	defer deleteTestConfigFile()
-	raw := `hub:
-  grpc_endpoint: ":10001"
-  miner_endpoint: ":10002"`
+	raw := `
+endpoint: ":10002"
+monitoring:
+  endpoint: ":10001"`
 	err := createTestConfigFile(raw)
 	assert.Nil(t, err)
 
 	conf, err := NewConfig(testHubConfigPath)
 	assert.Nil(t, err)
 
-	assert.Equal(t, ":10001", conf.Hub.GRPCEndpoint)
-	assert.Equal(t, ":10002", conf.Hub.MinerEndpoint)
+	assert.Equal(t, ":10002", conf.Endpoint)
+	assert.Equal(t, ":10001", conf.Monitoring.Endpoint)
 }
 
 func TestLoadConfigWithBootnodes(t *testing.T) {
 	defer deleteTestConfigFile()
-	raw := `hub:
-  grpc_endpoint: ":10001"
-  miner_endpoint: ":10002"
-  bootnodes:
-    - "enode://node1"
-    - "enode://node2"`
+	raw := `
+endpoint: ":10002"
+bootnodes:
+  - "enode://node1"
+  - "enode://node2"
+monitoring:
+  endpoint: ":10001"`
 
 	err := createTestConfigFile(raw)
 	assert.Nil(t, err)
@@ -50,30 +52,32 @@ func TestLoadConfigWithBootnodes(t *testing.T) {
 	conf, err := NewConfig(testHubConfigPath)
 	assert.Nil(t, err)
 
-	assert.Len(t, conf.Hub.Bootnodes, 2)
+	assert.Len(t, conf.Bootnodes, 2)
 }
 
 func TestLoadInvalidConfig(t *testing.T) {
 	defer deleteTestConfigFile()
-	raw := `hub:
-  grpc_endpoint: ""
-  miner_endpoint: ":10002"`
+	raw := `
+endpoint: ""
+monitoring:
+  endpoint: ":10002"`
 
 	err := createTestConfigFile(raw)
 	assert.Nil(t, err)
 
 	conf, err := NewConfig(testHubConfigPath)
 	assert.Nil(t, conf)
-	assert.Contains(t, err.Error(), "GRPCEndpoint is required")
+	assert.Contains(t, err.Error(), "Endpoint is required")
 }
 
 func TestLoadConfigLogger(t *testing.T) {
 	defer deleteTestConfigFile()
-	raw := `logger:
-  level: -1
-hub:
-  grpc_endpoint: ":10001"
-  miner_endpoint: ":10002"`
+	raw := `
+endpoint: ":10002"
+monitoring:
+  endpoint: ":10001"
+logging:
+  level: -1`
 
 	err := createTestConfigFile(raw)
 	assert.Nil(t, err)
@@ -81,19 +85,20 @@ hub:
 	conf, err := NewConfig(testHubConfigPath)
 	assert.Nil(t, err)
 
-	assert.Equal(t, -1, conf.Logger.Level)
+	assert.Equal(t, -1, conf.Logging.Level)
 }
 
 func TestLoadConfigLoggerDefault(t *testing.T) {
 	defer deleteTestConfigFile()
-	raw := `hub:
-  grpc_endpoint: ":10001"
-  miner_endpoint: ":10002"`
+	raw := `
+endpoint: ":10002"
+monitoring:
+  endpoint: ":10001"`
 	err := createTestConfigFile(raw)
 	assert.Nil(t, err)
 
 	conf, err := NewConfig(testHubConfigPath)
 	assert.Nil(t, err)
 
-	assert.Equal(t, 1, conf.Logger.Level)
+	assert.Equal(t, 1, conf.Logging.Level)
 }

--- a/insonmnia/logging/logging.go
+++ b/insonmnia/logging/logging.go
@@ -1,4 +1,4 @@
-package logger
+package logging
 
 import (
 	"go.uber.org/zap"
@@ -22,7 +22,7 @@ func BuildLogger(level int, development bool) *zap.Logger {
 	}
 
 	atom.SetLevel(zapcore.Level(level))
-	loggrConfig := zap.Config{
+	loggerConfig := zap.Config{
 		Development:      development,
 		Level:            atom,
 		OutputPaths:      []string{"stdout"},
@@ -31,6 +31,6 @@ func BuildLogger(level int, development bool) *zap.Logger {
 		EncoderConfig:    encodingConfig,
 	}
 
-	loggr, _ := loggrConfig.Build()
-	return loggr
+	log, _ := loggerConfig.Build()
+	return log
 }

--- a/insonmnia/miner/server.go
+++ b/insonmnia/miner/server.go
@@ -16,7 +16,7 @@ import (
 	log "github.com/noxiouz/zapctx/ctxlog"
 
 	"github.com/sonm-io/core/common"
-	"github.com/sonm-io/core/insonmnia/logger"
+	"github.com/sonm-io/core/insonmnia/logging"
 	pb "github.com/sonm-io/core/proto/miner"
 	"github.com/sonm-io/core/util"
 
@@ -379,7 +379,7 @@ func (m *Miner) Close() {
 
 // New returns new Miner
 func New(ctx context.Context, config *MinerConfig) (*Miner, error) {
-	loggr := logger.BuildLogger(config.Logger.Level, common.DevelopmentMode)
+	loggr := logging.BuildLogger(config.Logger.Level, common.DevelopmentMode)
 	ctx = log.WithLogger(ctx, loggr)
 
 	addr, err := util.GetPublicIP()


### PR DESCRIPTION
Preparation for Hub testing with handshakes and other.

Changed:
- Hierarchical hub config.
- Add comments to the default hub config.
- Configure logging in main instead of server.
- Renamed `logger` package to `logging` to avoid naming conflicts.