### PR TITLE
fix: MinerBuilder mandatory param + pass context in main

### DIFF
--- a/cmd/miner/main.go
+++ b/cmd/miner/main.go
@@ -35,6 +35,8 @@ func main() {
 	ctx = log.WithLogger(ctx, logger)
 
 	builder := miner.MinerBuilder{}
+	builder.Config(cfg)
+	builder.Context(ctx)
 	m, err := builder.Build()
 	if err != nil {
 		ctxlog.GetLogger(ctx).Fatal("failed to create a new Miner", zap.Error(err))

--- a/cmd/miner/main.go
+++ b/cmd/miner/main.go
@@ -34,8 +34,7 @@ func main() {
 	logger := logging.BuildLogger(cfg.Logging().Level, common.DevelopmentMode)
 	ctx = log.WithLogger(ctx, logger)
 
-	builder := miner.MinerBuilder{}
-	builder.Config(cfg)
+	builder := miner.NewMinerBuilder(cfg)
 	builder.Context(ctx)
 	m, err := builder.Build()
 	if err != nil {

--- a/insonmnia/miner/builder.go
+++ b/insonmnia/miner/builder.go
@@ -7,6 +7,7 @@ import (
 
 	log "github.com/noxiouz/zapctx/ctxlog"
 	"github.com/pborman/uuid"
+	"github.com/pkg/errors"
 	"github.com/sonm-io/core/insonmnia/resource"
 	pb "github.com/sonm-io/core/proto"
 	"github.com/sonm-io/core/util"
@@ -42,6 +43,19 @@ func (b *MinerBuilder) Overseer(ovs Overseer) {
 }
 
 func (b *MinerBuilder) Build() (miner *Miner, err error) {
+	if b.ctx == nil {
+		b.ctx = context.Background()
+	}
+	ctx, cancel := context.WithCancel(b.ctx)
+
+	if b.cfg == nil {
+		return nil, errors.New("config is mandatory for MinerBuilder")
+	}
+
+	if b.collector == nil {
+		b.collector = resource.New()
+	}
+
 	if b.ip == nil {
 		addr, err := util.GetPublicIP()
 		if err != nil {
@@ -49,15 +63,6 @@ func (b *MinerBuilder) Build() (miner *Miner, err error) {
 		}
 		b.ip = addr
 	}
-
-	if b.collector == nil {
-		b.collector = resource.New()
-	}
-
-	if b.ctx == nil {
-		b.ctx = context.Background()
-	}
-	ctx, cancel := context.WithCancel(b.ctx)
 
 	if b.ovs == nil {
 		b.ovs, err = NewOverseer(ctx, b.cfg.GPU())

--- a/insonmnia/miner/builder.go
+++ b/insonmnia/miner/builder.go
@@ -46,7 +46,6 @@ func (b *MinerBuilder) Build() (miner *Miner, err error) {
 	if b.ctx == nil {
 		b.ctx = context.Background()
 	}
-	ctx, cancel := context.WithCancel(b.ctx)
 
 	if b.cfg == nil {
 		return nil, errors.New("config is mandatory for MinerBuilder")
@@ -64,6 +63,7 @@ func (b *MinerBuilder) Build() (miner *Miner, err error) {
 		b.ip = addr
 	}
 
+	ctx, cancel := context.WithCancel(b.ctx)
 	if b.ovs == nil {
 		b.ovs, err = NewOverseer(ctx, b.cfg.GPU())
 		if err != nil {
@@ -74,6 +74,7 @@ func (b *MinerBuilder) Build() (miner *Miner, err error) {
 
 	resources, err := b.collector.OS()
 	if err != nil {
+		cancel()
 		return nil, err
 	}
 
@@ -81,6 +82,7 @@ func (b *MinerBuilder) Build() (miner *Miner, err error) {
 
 	deleter, err := initializeControlGroup(b.cfg.HubResources())
 	if err != nil {
+		cancel()
 		return nil, err
 	}
 

--- a/insonmnia/miner/builder.go
+++ b/insonmnia/miner/builder.go
@@ -111,3 +111,9 @@ func (b *MinerBuilder) Build() (miner *Miner, err error) {
 	pb.RegisterMinerServer(grpcServer, m)
 	return m, nil
 }
+
+func NewMinerBuilder(cfg Config) MinerBuilder {
+	b := MinerBuilder{}
+	b.Config(cfg)
+	return b
+}


### PR DESCRIPTION
Config is mandatory for builder, also we need to pass param in main when creating server