### PR TITLE
feat: self resource control on miner

### DIFF
--- a/insonmnia/miner/builder.go
+++ b/insonmnia/miner/builder.go
@@ -90,7 +90,7 @@ func (b *MinerBuilder) Build() (miner *Miner, err error) {
 		ovs:        b.ovs,
 
 		name:      uuid.New(),
-		resources: resources,
+		resources: resource.NewPool(resources),
 
 		pubAddress: b.ip.String(),
 		hubAddress: b.cfg.HubEndpoint(),

--- a/insonmnia/miner/overseer.go
+++ b/insonmnia/miner/overseer.go
@@ -18,6 +18,7 @@ import (
 	"github.com/docker/docker/client"
 	"github.com/docker/go-connections/nat"
 	log "github.com/noxiouz/zapctx/ctxlog"
+	"github.com/sonm-io/core/insonmnia/resource"
 	pb "github.com/sonm-io/core/proto"
 )
 
@@ -37,9 +38,10 @@ type Description struct {
 
 // ContainerInfo is a brief information about containers
 type ContainerInfo struct {
-	status *pb.TaskStatusReply
-	ID     string
-	Ports  nat.PortMap
+	status    *pb.TaskStatusReply
+	ID        string
+	Ports     nat.PortMap
+	Resources resource.Resources
 }
 
 // ContainerMetrics are metrics collected from Docker about running containers
@@ -337,9 +339,10 @@ func (o *overseer) Start(ctx context.Context, description Description) (status c
 		return
 	}
 	cinfo = ContainerInfo{
-		status: &pb.TaskStatusReply{Status: pb.TaskStatusReply_RUNNING},
-		ID:     cjson.ID,
-		Ports:  cjson.NetworkSettings.Ports,
+		status:    &pb.TaskStatusReply{Status: pb.TaskStatusReply_RUNNING},
+		ID:        cjson.ID,
+		Ports:     cjson.NetworkSettings.Ports,
+		Resources: resource.NewResources(1, description.Resources.Memory),
 	}
 	return status, cinfo, nil
 }

--- a/insonmnia/miner/server.go
+++ b/insonmnia/miner/server.go
@@ -30,7 +30,7 @@ type Miner struct {
 
 	// Miner name for nice self-representation.
 	name      string
-	resources *resource.OS
+	resources *resource.Pool
 
 	hubAddress string
 	// NOTE: do not use static detection
@@ -132,8 +132,8 @@ func (m *Miner) Handshake(ctx context.Context, request *pb.MinerHandshakeRequest
 	resp := &pb.MinerHandshakeReply{
 		Miner: m.name,
 		Limits: &pb.Limits{
-			Cores:  uint64(len(m.resources.CPU.List)),
-			Memory: m.resources.Mem.Total,
+			Cores:  uint64(len(m.resources.OS.CPU.List)),
+			Memory: m.resources.OS.Mem.Total,
 		},
 	}
 
@@ -214,6 +214,16 @@ func (m *Miner) Start(ctx context.Context, request *pb.MinerStartRequest) (*pb.M
 	}
 	log.G(m.ctx).Info("handling Start request", zap.Any("req", request))
 
+	var mem = int64(0)
+	if request.Resources != nil {
+		mem = request.Resources.Memory
+	}
+	var usage = resource.NewResources(1, mem)
+
+	if err := m.resources.Consume(&usage); err != nil {
+		return nil, status.Errorf(codes.ResourceExhausted, "failed to Start %v", err)
+	}
+
 	m.setStatus(&pb.TaskStatusReply{Status: pb.TaskStatusReply_SPOOLING}, request.Id)
 
 	log.G(m.ctx).Info("spooling an image")
@@ -221,6 +231,7 @@ func (m *Miner) Start(ctx context.Context, request *pb.MinerStartRequest) (*pb.M
 	if err != nil {
 		log.G(ctx).Error("failed to Spool an image", zap.Error(err))
 		m.setStatus(&pb.TaskStatusReply{Status: pb.TaskStatusReply_BROKEN}, request.Id)
+		m.resources.Retain(&usage)
 		return nil, status.Errorf(codes.Internal, "failed to Spool %v", err)
 	}
 
@@ -230,6 +241,7 @@ func (m *Miner) Start(ctx context.Context, request *pb.MinerStartRequest) (*pb.M
 	if err != nil {
 		log.G(ctx).Error("failed to spawn an image", zap.Error(err))
 		m.setStatus(&pb.TaskStatusReply{Status: pb.TaskStatusReply_BROKEN}, request.Id)
+		m.resources.Retain(&usage)
 		return nil, status.Errorf(codes.Internal, "failed to Spawn %v", err)
 	}
 
@@ -274,6 +286,7 @@ func (m *Miner) Stop(ctx context.Context, request *pb.StopTaskRequest) (*pb.Stop
 		return nil, status.Errorf(codes.Internal, "failed to stop container %v", err)
 	}
 	m.setStatus(&pb.TaskStatusReply{Status: pb.TaskStatusReply_FINISHED}, request.Id)
+	m.resources.Retain(&containerInfo.Resources)
 	return &pb.StopTaskReply{}, nil
 }
 

--- a/insonmnia/miner/server_test.go
+++ b/insonmnia/miner/server_test.go
@@ -69,7 +69,7 @@ func TestServerNewSavesResources(t *testing.T) {
 
 	assert.NotNil(t, m)
 	assert.Nil(t, err)
-	assert.Equal(t, uint64(42), m.resources.Mem.Total)
+	assert.Equal(t, uint64(42), m.resources.OS.Mem.Total)
 }
 
 func TestMinerInfo(t *testing.T) {

--- a/insonmnia/resource/pool.go
+++ b/insonmnia/resource/pool.go
@@ -1,0 +1,61 @@
+package resource
+
+import (
+	"errors"
+	"sync"
+)
+
+type Resources struct {
+	numCPUs int
+	memory  int64
+	// TODO: It's unclear how to calculate GPU usage.
+}
+
+func NewResources(numCPUs int, memory int64) Resources {
+	return Resources{
+		numCPUs: numCPUs,
+		memory:  memory,
+	}
+}
+
+type Pool struct {
+	OS    *OS
+	mu    sync.Mutex
+	usage Resources
+}
+
+func NewPool(os *OS) *Pool {
+	return &Pool{
+		OS:    os,
+		usage: Resources{},
+	}
+}
+
+// TODO: May be return some kind of Retainer to be able to auto-retain?
+func (p *Pool) Consume(usage *Resources) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	free := NewResources(len(p.OS.CPU.List)-p.usage.numCPUs, int64(p.OS.Mem.Total)-p.usage.memory)
+
+	if usage.numCPUs > free.numCPUs {
+		return errors.New("not enough CPU available")
+	}
+
+	if usage.memory > free.memory {
+		return errors.New("not enough memory available")
+	}
+
+	p.usage.numCPUs += usage.numCPUs
+	p.usage.memory += usage.memory
+
+	return nil
+}
+
+func (p *Pool) Retain(usage *Resources) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	p.usage.numCPUs -= usage.numCPUs
+	p.usage.memory -= usage.memory
+}

--- a/insonmnia/resource/resource.go
+++ b/insonmnia/resource/resource.go
@@ -1,6 +1,8 @@
 package resource
 
-import "github.com/cloudfoundry/gosigar"
+import (
+	"github.com/cloudfoundry/gosigar"
+)
 
 // OS represents available resources on the OS, where a Miner is running.
 type OS struct {


### PR DESCRIPTION
This commit activages self resource control on a miner, disallowing it
to start new tasks if its resources are exhausted. On stop these
allocated resources are freed.

```bash
esafronov@5:~/go/src/github.com/sonm-io/core|master⚡
⇒  ./sonmcli miner list --addr="[::]:10001"
Miner: 127.0.0.1:56905
Miner is idle


esafronov@5:~/go/src/github.com/sonm-io/core|master⚡
⇒  ./sonmcli task start "127.0.0.1:56905" cocaine/cocaine-core --addr="[::]:10001"
Starting "cocaine/cocaine-core" on miner 127.0.0.1:56905...
ID 31afe394-cc14-4a45-84b1-5536c70cb21c, Endpoint [10053/tcp->5.255.232.237:32778]

esafronov@5:~/go/src/github.com/sonm-io/core|master⚡
⇒  ./sonmcli miner list --addr="[::]:10001"
Miner: 127.0.0.1:56905
Tasks:
  1) 31afe394-cc14-4a45-84b1-5536c70cb21c

...
>>> Start until no more free cores left. <<<
...

esafronov@5:~/go/src/github.com/sonm-io/core|master⚡
⇒  ./sonmcli miner list --addr="[::]:10001"
Miner: 127.0.0.1:56905
Tasks:
  1) 920a195d-871e-495d-a800-f85e79fb919b
  2) 634561bc-2a8b-480b-a45a-580b1bb0b11a
  3) 443c719d-ac35-4a5a-9fa5-c3ba2a2ae164
  4) 31afe394-cc14-4a45-84b1-5536c70cb21c

esafronov@5:~/go/src/github.com/sonm-io/core|master⚡
⇒  ./sonmcli task start "127.0.0.1:56905" cocaine/cocaine-core --addr="[::]:10001"
Starting "cocaine/cocaine-core" on miner 127.0.0.1:56905...
[ERR] Cannot start task: rpc error: code = Internal desc = failed to start rpc error: code = ResourceExhausted desc = failed to Start not enough CPU available

>>> Free some resources. <<<

esafronov@5:~/go/src/github.com/sonm-io/core|feat/self-control-on-miner
⇒  ./sonmcli task stop "127.0.0.1:56905" 634561bc-2a8b-480b-a45a-580b1bb0b11a --addr="[::]:10001"
Stopping task 634561bc-2a8b-480b-a45a-580b1bb0b11a at 127.0.0.1:56905...OK
OK

esafronov@5:~/go/src/github.com/sonm-io/core|feat/self-control-on-miner
⇒  ./sonmcli miner list --addr="[::]:10001"
Miner: 127.0.0.1:56905
Tasks:
  1) 31afe394-cc14-4a45-84b1-5536c70cb21c
  2) 920a195d-871e-495d-a800-f85e79fb919b
  3) 443c719d-ac35-4a5a-9fa5-c3ba2a2ae164

>>> And start again. <<<

esafronov@5:~/go/src/github.com/sonm-io/core|feat/self-control-on-miner
⇒  ./sonmcli task start "127.0.0.1:56905" cocaine/cocaine-core --addr="[::]:10001"
Starting "cocaine/cocaine-core" on miner 127.0.0.1:56905...
ID 13d2effc-afe2-40d3-8367-97970679ae1e, Endpoint [10053/tcp->5.255.232.237:32782]
```