### PR TITLE
Prevent useless blockchain rebuilds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ build_cli_win32:
 
 build_blockchain:
 	@echo "+ $@"
-	$(MAKE) -C blockchain build
+	$(MAKE) -C blockchain build_contract_wrappers
 
 build: build_blockchain build_bootnode build_hub build_miner build_cli
 

--- a/blockchain/Makefile
+++ b/blockchain/Makefile
@@ -4,16 +4,27 @@ GO=go
 TRUFFLE=./node_modules/truffle/build/cli.bundled.js
 TESTRPC=./node_modules/ethereumjs-testrpc/build/cli.node.js
 
+
+SOL_SOURCES=$(wildcard contracts/*.sol)
+GO_BUILDS=$(SOL_SOURCES:contracts/%.sol=api/%.go)
+
+
 .PHONY: build test clean
 
-build:
-	@echo "+ $@"
+node_modules:
 	npm install
+
+build/contracts/%.json: contracts/%.sol node_modules
 	${TRUFFLE} compile
+
+api/%.go: build/contracts/%.json
 	${GO} generate ./api.go
+
+build_contract_wrappers: $(GO_BUILDS)
+	@echo "+ $@"
 	${GO} build .
 
-test:
+test: $(GO_BUILDS) node_modules
 	@echo "+ $@"
 	TESTRPC="$(shell pwd)/${TESTRPC}" ${GO} test ./tests
 


### PR DESCRIPTION
This uses `make`'s dependency tracking mechanisms to prevent unnecessary rebuildings in blockchain directory.