### PR TITLE
feat: virtual services statistics

### DIFF
--- a/insonmnia/gateway/gateway_linux.go
+++ b/insonmnia/gateway/gateway_linux.go
@@ -248,8 +248,16 @@ func (g *Gateway) getMetrics(vsID string) (*Metrics, error) {
 			s := stat.GetStats()
 			return &Metrics{
 				Connections: s["CONNS"],
+				InPackets:   s["INPKTS"],
+				OutPackets:  s["OUTPKTS"],
 				InBytes:     s["INBYTES"],
 				OutBytes:    s["OUTBYTES"],
+
+				ConnectionsPerSecond: s["CPS"],
+				InPacketsPerSecond:   s["INPPS"],
+				OutPacketsPerSecond:  s["OUTPPS"],
+				InBytesPerSecond:     s["INBPS"],
+				OutBytesPerSecond:    s["OUTBPS"],
 			}, nil
 		}
 	}

--- a/insonmnia/gateway/metrics.go
+++ b/insonmnia/gateway/metrics.go
@@ -1,0 +1,14 @@
+package gateway
+
+// Metrics describes a virtual service metrics.
+type Metrics struct {
+	Connections uint64
+	InBytes     uint64
+	OutBytes    uint64
+}
+
+func (m *Metrics) Add(metrics *Metrics) {
+	m.Connections += metrics.Connections
+	m.InBytes += metrics.InBytes
+	m.OutBytes += metrics.OutBytes
+}

--- a/insonmnia/gateway/metrics.go
+++ b/insonmnia/gateway/metrics.go
@@ -3,12 +3,28 @@ package gateway
 // Metrics describes a virtual service metrics.
 type Metrics struct {
 	Connections uint64
+	InPackets   uint64
+	OutPackets  uint64
 	InBytes     uint64
 	OutBytes    uint64
+
+	ConnectionsPerSecond uint64
+	InPacketsPerSecond   uint64
+	OutPacketsPerSecond  uint64
+	InBytesPerSecond     uint64
+	OutBytesPerSecond    uint64
 }
 
 func (m *Metrics) Add(metrics *Metrics) {
 	m.Connections += metrics.Connections
+	m.InPackets += metrics.InPackets
+	m.OutPackets += metrics.OutPackets
 	m.InBytes += metrics.InBytes
 	m.OutBytes += metrics.OutBytes
+
+	m.ConnectionsPerSecond += metrics.ConnectionsPerSecond
+	m.InPacketsPerSecond += metrics.InPacketsPerSecond
+	m.OutPacketsPerSecond += metrics.OutPacketsPerSecond
+	m.InBytesPerSecond += metrics.InBytesPerSecond
+	m.OutBytesPerSecond += metrics.OutBytesPerSecond
 }

--- a/insonmnia/hub/miner_ctx.go
+++ b/insonmnia/hub/miner_ctx.go
@@ -109,7 +109,7 @@ func (m *MinerCtx) handshake(h *Hub) error {
 	m.uuid = resp.Miner
 	m.capabilities = capabilities
 
-	if m.router, err = h.newRouter(resp.NatType); err != nil {
+	if m.router, err = h.newRouter(m.uuid, resp.NatType); err != nil {
 		log.G(m.ctx).Warn("failed to create router for a miner",
 			zap.String("uuid", m.uuid),
 			zap.Error(err),
@@ -122,13 +122,13 @@ func (m *MinerCtx) handshake(h *Hub) error {
 }
 
 // NewRouter constructs a new router that will route requests to bypass miner's firewall.
-func (h *Hub) newRouter(natType pb.NATType) (router, error) {
+func (h *Hub) newRouter(id string, natType pb.NATType) (router, error) {
 	if h.gateway == nil || natType == pb.NATType_NONE {
 		return newDirectRouter(), nil
 	}
 
 	if gateway.PlatformSupportIPVS {
-		return newIPVSRouter(h.ctx, h.gateway, h.portPool), nil
+		return newIPVSRouter(h.ctx, id, h.gateway, h.portPool), nil
 	}
 
 	return nil, errors.New("miner has firewall configured, but Hub's host OS has no IPVS support")

--- a/insonmnia/hub/router.go
+++ b/insonmnia/hub/router.go
@@ -1,5 +1,7 @@
 package hub
 
+import "github.com/sonm-io/core/insonmnia/gateway"
+
 type route struct {
 	ID          string
 	Protocol    string
@@ -12,6 +14,7 @@ type route struct {
 type router interface {
 	RegisterRoute(ID string, protocol string, realIP string, realPort uint16) (*route, error)
 	DeregisterRoute(ID string) error
+	GetMetrics() (*gateway.Metrics, error)
 	Close() error
 }
 
@@ -37,6 +40,10 @@ func (r *directRouter) RegisterRoute(ID string, protocol string, realIP string, 
 
 func (r *directRouter) DeregisterRoute(ID string) error {
 	return nil
+}
+
+func (r *directRouter) GetMetrics() (*gateway.Metrics, error) {
+	return &gateway.Metrics{}, nil
 }
 
 func (r *directRouter) Close() error {

--- a/insonmnia/hub/router_linux.go
+++ b/insonmnia/hub/router_linux.go
@@ -12,7 +12,7 @@ type ipvsRouter struct {
 	pool     *gateway.PortPool
 	minerID  string
 	metrics  map[string]*gateway.Metrics
-	services map[string]bool
+	services map[string]struct{}
 	mu       sync.Mutex
 }
 
@@ -22,7 +22,7 @@ func newIPVSRouter(ctx context.Context, minerID string, gate *gateway.Gateway, p
 		pool:     pool,
 		minerID:  minerID,
 		metrics:  make(map[string]*gateway.Metrics, 0),
-		services: make(map[string]bool, 0),
+		services: make(map[string]struct{}, 0),
 	}
 }
 
@@ -58,7 +58,7 @@ func (r *ipvsRouter) RegisterRoute(ID string, protocol string, realIP string, re
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.metrics[ID] = &gateway.Metrics{}
-	r.services[ID] = true
+	r.services[ID] = struct{}{}
 
 	route := &route{
 		ID:          ID,

--- a/insonmnia/hub/router_nonlinux.go
+++ b/insonmnia/hub/router_nonlinux.go
@@ -7,6 +7,6 @@ import (
 	"github.com/sonm-io/core/insonmnia/gateway"
 )
 
-func newIPVSRouter(context.Context, *gateway.Gateway, *gateway.PortPool) router {
+func newIPVSRouter(context.Context, string, *gateway.Gateway, *gateway.PortPool) router {
 	return newDirectRouter()
 }


### PR DESCRIPTION
This commit allows to collect virtual services statistics for further traffic accouting.

All requests that are redirected through the gateway consumes network, which is the limited resource for us. Collecting bytes transmitted and received as like as the number of connections consumed allows to properly calculate how much a specific miner affects our network.

There are separate metrics for a specific miner, allowing us to gain statistics for each miner connected (still cleared after disconnection).

Dead virtual services does not clear their accounted traffic consumed.