### PR TITLE
Feat/base metrics

### DIFF
--- a/insonmnia/miner/builder.go
+++ b/insonmnia/miner/builder.go
@@ -139,7 +139,8 @@ func (b *MinerBuilder) Build() (miner *Miner, err error) {
 
 	log.G(ctx).Info("collected Hardware info", zap.Any("hardware", hardwareInfo))
 
-	grpcServer := grpc.NewServer(grpc.RPCCompressor(grpc.NewGZIPCompressor()), grpc.RPCDecompressor(grpc.NewGZIPDecompressor()))
+	grpcServer := grpc.NewServer(grpc.RPCCompressor(grpc.NewGZIPCompressor()), grpc.RPCDecompressor(grpc.NewGZIPDecompressor()),
+		grpc.StatsHandler(grpcStatsHandler{}))
 
 	deleter, err := initializeControlGroup(b.cfg.HubResources())
 	if err != nil {

--- a/insonmnia/miner/config.go
+++ b/insonmnia/miner/config.go
@@ -30,12 +30,17 @@ type LoggingConfig struct {
 	Level int `required:"true" default:"1"`
 }
 
+type DebugServerConfig struct {
+	Endpoint string `required:"false" yaml:"endpoint"`
+}
+
 type config struct {
-	HubConfig      *HubConfig      `required:"false" yaml:"hub"`
-	FirewallConfig *FirewallConfig `required:"false" yaml:"firewall"`
-	GPUConfig      *GPUConfig      `required:"false"`
-	SSHConfig      *SSHConfig      `required:"false" yaml:"ssh"`
-	LoggingConfig  LoggingConfig   `yaml:"logging"`
+	HubConfig         *HubConfig         `required:"false" yaml:"hub"`
+	FirewallConfig    *FirewallConfig    `required:"false" yaml:"firewall"`
+	GPUConfig         *GPUConfig         `required:"false"`
+	SSHConfig         *SSHConfig         `required:"false" yaml:"ssh"`
+	LoggingConfig     LoggingConfig      `yaml:"logging"`
+	DebugServerConfig *DebugServerConfig `required:"false" yaml:"debugserver"`
 }
 
 func (c *config) HubEndpoint() string {
@@ -68,6 +73,10 @@ func (c *config) Logging() LoggingConfig {
 	return c.LoggingConfig
 }
 
+func (c *config) DebugServer() *DebugServerConfig {
+	return c.DebugServerConfig
+}
+
 // NewConfig creates a new Miner config from the specified YAML file.
 func NewConfig(path string) (Config, error) {
 	cfg := &config{}
@@ -93,4 +102,6 @@ type Config interface {
 	SSH() *SSHConfig
 	// Logging returns logging settings.
 	Logging() LoggingConfig
+	// DebugServer returns a configuration for HTTP debug server
+	DebugServer() *DebugServerConfig
 }

--- a/insonmnia/miner/metrics.go
+++ b/insonmnia/miner/metrics.go
@@ -1,0 +1,52 @@
+package miner
+
+import (
+	"expvar"
+
+	"golang.org/x/net/context"
+	"google.golang.org/grpc/stats"
+)
+
+var (
+	statsMap = expvar.NewMap("miner_stats")
+
+	bytesSentToHub       expvar.Int
+	bytesReceivedFromHub expvar.Int
+	uncompressedRPCBytes expvar.Int
+)
+
+func init() {
+	statsMap.Set("bytes_sent_to_hub", &bytesSentToHub)
+	statsMap.Set("bytes_received_from_hub", &bytesReceivedFromHub)
+	statsMap.Set("uncompressed_rpc_bytes", &uncompressedRPCBytes)
+}
+
+type grpcStatsHandler struct{}
+
+func (grpcStatsHandler) TagRPC(ctx context.Context, _ *stats.RPCTagInfo) context.Context {
+	return ctx
+}
+
+func (grpcStatsHandler) HandleRPC(_ context.Context, s stats.RPCStats) {
+	// Count compressed ingress traffic from hub connection
+	// Count compressed outgress and raw rpc bytes to estimate compression efficiency
+	switch s := s.(type) {
+	case *stats.InHeader:
+		bytesReceivedFromHub.Add(int64(s.WireLength))
+	case *stats.InPayload:
+		bytesReceivedFromHub.Add(int64(s.WireLength))
+	case *stats.InTrailer:
+		bytesReceivedFromHub.Add(int64(s.WireLength))
+	case *stats.OutHeader:
+		bytesSentToHub.Add(int64(s.WireLength))
+	case *stats.OutPayload:
+		bytesSentToHub.Add(int64(s.WireLength))
+		uncompressedRPCBytes.Add(int64(s.Length))
+	case *stats.OutTrailer:
+		bytesSentToHub.Add(int64(s.WireLength))
+	}
+}
+
+func (grpcStatsHandler) TagConn(ctx context.Context, _ *stats.ConnTagInfo) context.Context { return ctx }
+
+func (grpcStatsHandler) HandleConn(context.Context, stats.ConnStats) {}

--- a/miner.yaml
+++ b/miner.yaml
@@ -18,3 +18,7 @@ logging:
 # automatically.
 # firewall:
 #   server: "stun.ekiga.net:3478"
+
+debugserver:
+  # Endpoint for HTTP debug server
+  endpoint: "127.0.0.1:9000"


### PR DESCRIPTION
Count bytes sent/received for RPC
```bash
curl http://127.0.0.1:9000/debug/vars | jq ".miner_stats"
{
  "bytes_received_from_hub": 0,
  "bytes_sent_to_hub": 1127,
  "uncompressed_rpc_bytes": 9054
}
```

chained with #107 