### PR TITLE
Fix/cli output flag

### DIFF
--- a/cmd/cli/commands/common.go
+++ b/cmd/cli/commands/common.go
@@ -3,9 +3,8 @@ package commands
 import (
 	"encoding/json"
 	"errors"
-	"time"
-
 	"os"
+	"time"
 
 	"github.com/sonm-io/core/cmd/cli/config"
 	"github.com/spf13/cobra"
@@ -15,6 +14,7 @@ const (
 	appName        = "sonm"
 	hubAddressFlag = "addr"
 	hubTimeoutFlag = "timeout"
+	outputModeFlag = "out"
 
 	// log flag names
 	logTypeFlag       = "type"
@@ -29,6 +29,7 @@ var (
 	rootCmd    = &cobra.Command{Use: appName}
 	version    string
 	hubAddress string
+	outputMode string
 	timeout    = 60 * time.Second
 	cfg        config.Config
 
@@ -50,6 +51,7 @@ var (
 func init() {
 	rootCmd.PersistentFlags().StringVar(&hubAddress, hubAddressFlag, "", "hub addr")
 	rootCmd.PersistentFlags().DurationVar(&timeout, hubTimeoutFlag, 60*time.Second, "Connection timeout")
+	rootCmd.PersistentFlags().StringVar(&outputMode, outputModeFlag, "", "Output mode: simple or json")
 	rootCmd.AddCommand(hubRootCmd, minerRootCmd, tasksRootCmd, versionCmd)
 }
 
@@ -89,7 +91,7 @@ func newCommandError(message string, err error) *commandError {
 }
 
 func showError(cmd *cobra.Command, message string, err error) {
-	if cfg.OutputFormat() == config.OutputModeSimple {
+	if isSimpleFormat() {
 		showErrorInSimple(cmd, message, err)
 	} else {
 		showErrorInJSON(cmd, message, err)
@@ -110,7 +112,7 @@ func showErrorInJSON(cmd *cobra.Command, message string, err error) {
 }
 
 func showOk(cmd *cobra.Command) {
-	if cfg.OutputFormat() == config.OutputModeSimple {
+	if isSimpleFormat() {
 		showOkSimple(cmd)
 	} else {
 		showOkJson(cmd)
@@ -128,5 +130,13 @@ func showOkJson(cmd *cobra.Command) {
 }
 
 func isSimpleFormat() bool {
-	return cfg.OutputFormat() == config.OutputModeSimple
+	if outputMode == "" && cfg.OutputFormat() == "" {
+		return true
+	}
+
+	if outputMode == config.OutputModeJSON || cfg.OutputFormat() == config.OutputModeJSON {
+		return false
+	}
+
+	return true
 }

--- a/cmd/cli/commands/err_test.go
+++ b/cmd/cli/commands/err_test.go
@@ -61,8 +61,6 @@ func TestShowErrorJsonNilErr(t *testing.T) {
 	showError(rootCmd, "test error", nil)
 	out := buf.String()
 
-	fmt.Printf("OUT :: %s\r\n ", out)
-
 	cmdErr, err := stringToCommandError(out)
 	assert.NoError(t, err)
 	assert.Equal(t, "", cmdErr.Error)

--- a/cmd/cli/commands/err_test.go
+++ b/cmd/cli/commands/err_test.go
@@ -61,6 +61,8 @@ func TestShowErrorJsonNilErr(t *testing.T) {
 	showError(rootCmd, "test error", nil)
 	out := buf.String()
 
+	fmt.Printf("OUT :: %s\r\n ", out)
+
 	cmdErr, err := stringToCommandError(out)
 	assert.NoError(t, err)
 	assert.Equal(t, "", cmdErr.Error)

--- a/cmd/cli/commands/tasks.go
+++ b/cmd/cli/commands/tasks.go
@@ -102,7 +102,7 @@ func printTaskStatus(cmd *cobra.Command, miner, id string, taskStatus *pb.TaskSt
 			"status": taskStatus.Status.String(),
 			"image":  taskStatus.GetImageName(),
 			"ports":  taskStatus.GetPorts(),
-			"uptime": time.Duration(taskStatus.GetUptime()).String(),
+			"uptime": fmt.Sprintf("%d", time.Duration(taskStatus.GetUptime())),
 		}
 		if taskStatus.GetUsage() != nil {
 			v["cpu"] = fmt.Sprintf("%d", taskStatus.GetUsage().GetCpu().GetTotal())

--- a/cmd/cli/commands/tasks_test.go
+++ b/cmd/cli/commands/tasks_test.go
@@ -356,7 +356,7 @@ func TestTaskStatusWithPortsJson(t *testing.T) {
 	assert.Equal(t, "httpd:latest", outJson["image"])
 
 	assert.Contains(t, outJson, "uptime")
-	assert.Equal(t, "60ns", outJson["uptime"])
+	assert.Equal(t, "60", outJson["uptime"])
 
 	// extra checks for ports
 	assert.Contains(t, outJson, "ports")

--- a/cmd/cli/config/config.go
+++ b/cmd/cli/config/config.go
@@ -22,7 +22,7 @@ type Config interface {
 // cliConfig implements Config interface
 type cliConfig struct {
 	HubAddr   string `required:"false" default:"" yaml:"hub_address"`
-	OutFormat string `required:"false" default:"simple" yaml:"output_format"`
+	OutFormat string `required:"false" default:"" yaml:"output_format"`
 }
 
 func (cc *cliConfig) OutputFormat() string {

--- a/cmd/cli/config/config_test.go
+++ b/cmd/cli/config/config_test.go
@@ -52,7 +52,7 @@ func TestConfigDefaults(t *testing.T) {
 
 	cfg, err := NewConfig()
 	assert.NoError(t, err)
-	assert.Equal(t, "simple", cfg.OutputFormat())
+	assert.Equal(t, "", cfg.OutputFormat())
 	assert.Equal(t, "", cfg.HubAddress())
 }
 


### PR DESCRIPTION
This PR allows setting CLI output format via the flag.
Useful in integration tests;