### PR TITLE
fix: parse port from endpoint string

### DIFF
--- a/insonmnia/hub/server.go
+++ b/insonmnia/hub/server.go
@@ -447,7 +447,12 @@ func (h *Hub) Serve() error {
 		return err
 	}
 
-	srv, err := frd.NewServer(h.ethKey, ip.String()+h.endpoint)
+	port, err := util.ParseEndpointPort(h.endpoint)
+	if err != nil {
+		return err
+	}
+
+	srv, err := frd.NewServer(h.ethKey, ip.String()+port)
 	if err != nil {
 		return err
 	}

--- a/insonmnia/hub/server.go
+++ b/insonmnia/hub/server.go
@@ -452,7 +452,7 @@ func (h *Hub) Serve() error {
 		return err
 	}
 
-	srv, err := frd.NewServer(h.ethKey, ip.String()+port)
+	srv, err := frd.NewServer(h.ethKey, ip.String()+":"+port)
 	if err != nil {
 		return err
 	}

--- a/util/util.go
+++ b/util/util.go
@@ -5,9 +5,11 @@ import (
 	"net"
 
 	"bytes"
+	"errors"
 	"io/ioutil"
 	"net/http"
 	"os/user"
+	"strconv"
 )
 
 // GetLocalIP find local non-loopback ip addr
@@ -65,4 +67,22 @@ func GetUserHomeDir() (homeDir string, err error) {
 		return "", err
 	}
 	return usr.HomeDir, nil
+}
+
+func ParseEndpointPort(s string) (string, error) {
+	_, port, err := net.SplitHostPort(s)
+	if err != nil {
+		return "", err
+	}
+
+	intPort, err := strconv.Atoi(port)
+	if err != nil {
+		return "", err
+	}
+
+	if intPort < 1 || intPort > 65535 {
+		return "", errors.New("Invalid port value")
+	}
+
+	return port, nil
 }

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -1,0 +1,50 @@
+package util
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestParseEndpoint(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+		mustErr  bool
+	}{
+		{
+			input:    "192.168.0.1:10001",
+			expected: "10001",
+			mustErr:  false,
+		},
+		{
+			input:    ":10002",
+			expected: "10002",
+			mustErr:  false,
+		},
+		{
+			input:    "192.168.0.1",
+			expected: "",
+			mustErr:  true,
+		},
+		{
+			input:    "192.168.0.1:qwer",
+			expected: "",
+			mustErr:  true,
+		},
+		{
+			input:    "192.168.0.1:99999",
+			expected: "",
+			mustErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		port, err := ParseEndpointPort(tt.input)
+		assert.Equal(t, tt.expected, port)
+		if tt.mustErr {
+			assert.Error(t, err)
+		} else {
+			assert.NoError(t, err)
+		}
+	}
+}


### PR DESCRIPTION
This PR fixes invalid address assigning for Fusrodah server.
Happens only if set ip+port for Hub, in that case, discovery responses looks like `213.159.214.60213.159.214.60:10001`