### PR TITLE
fix: do not use testing retrier in consul

### DIFF
--- a/vendor/github.com/hashicorp/consul/testutil/server.go
+++ b/vendor/github.com/hashicorp/consul/testutil/server.go
@@ -192,7 +192,7 @@ func NewTestServer() (*TestServer, error) {
 }
 
 func NewTestServerConfig(cb ServerConfigCallback) (*TestServer, error) {
-	return NewTestServerConfigT(nil, cb)
+	return newTestServerConfigT(nil, cb)
 }
 
 // NewTestServerConfig creates a new TestServer, and makes a call to an optional


### PR DESCRIPTION
this is a hotfix of https://github.com/sonm-io/core/issues/141, however I think we need to run consul programmatically in this case.