### PR TITLE
opencl: support OpenCL API

### DIFF
--- a/cmd/miner/main.go
+++ b/cmd/miner/main.go
@@ -14,9 +14,10 @@ import (
 	"github.com/sonm-io/core/insonmnia/logging"
 	"github.com/sonm-io/core/insonmnia/miner"
 
+	"io/ioutil"
+
 	log "github.com/noxiouz/zapctx/ctxlog"
 	"github.com/pborman/uuid"
-	"io/ioutil"
 )
 
 var (

--- a/insonmnia/miner/config.go
+++ b/insonmnia/miner/config.go
@@ -45,7 +45,7 @@ type config struct {
 	HubConfig      *HubConfig      `required:"false" yaml:"hub"`
 	FirewallConfig *FirewallConfig `required:"false" yaml:"firewall"`
 	Eth            *EthConfig      `yaml:"ethereum"`
-	GPUConfig      *GPUConfig      `required:"false" yaml:"GPUConfig"`
+	GPUConfig      *gpu.Config     `required:"false" yaml:"GPUConfig"`
 	SSHConfig      *SSHConfig      `required:"false" yaml:"ssh"`
 	LoggingConfig  LoggingConfig   `yaml:"logging"`
 	UUIDPathConfig string          `required:"false" yaml:"uuid_path"`

--- a/insonmnia/miner/config.go
+++ b/insonmnia/miner/config.go
@@ -3,6 +3,7 @@ package miner
 import (
 	"github.com/jinzhu/configor"
 	"github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/sonm-io/core/insonmnia/miner/gpu"
 )
 
 // HubConfig describes Hub configuration.
@@ -68,7 +69,7 @@ func (c *config) Firewall() *FirewallConfig {
 	return c.FirewallConfig
 }
 
-func (c *config) GPU() *GPUConfig {
+func (c *config) GPU() *gpu.Config {
 	return c.GPUConfig
 }
 
@@ -111,7 +112,7 @@ type Config interface {
 	// Firewall returns firewall detection settings.
 	Firewall() *FirewallConfig
 	// GPU returns options about NVIDIA GPU support via nvidia-docker-plugin
-	GPU() *GPUConfig
+	GPU() *gpu.Config
 	// SSH returns settings for built-in ssh server
 	SSH() *SSHConfig
 	// Logging returns logging settings.

--- a/insonmnia/miner/config_test.go
+++ b/insonmnia/miner/config_test.go
@@ -55,14 +55,17 @@ hub:
 logging:
   level: -1
 GPUConfig:
-  nvidiadockerdriver: "localhost:3476"
+  type: nvidiadocker
+  args: { nvidiadockerdriver: "localhost:3476" }
 `)
 	assert.NoError(t, err)
 	defer deleteTestConfigFile()
 
 	conf, err := NewConfig(testMinerConfigPath)
 	assert.Nil(t, err)
-	assert.Equal(t, "localhost:3476", conf.GPU().NvidiaDockerDriver)
+	assert.Equal(t, "nvidiadocker", conf.GPU().Type)
+	assert.NotEmpty(t, conf.GPU().Args)
+	assert.Equal(t, "localhost:3476", conf.GPU().Args["nvidiadockerdriver"])
 }
 
 func TestLoadConfigWithoutEndpoint(t *testing.T) {

--- a/insonmnia/miner/container.go
+++ b/insonmnia/miner/container.go
@@ -14,6 +14,7 @@ import (
 	"github.com/docker/docker/client"
 	"github.com/gliderlabs/ssh"
 	log "github.com/noxiouz/zapctx/ctxlog"
+	"github.com/sonm-io/core/insonmnia/miner/gpu"
 )
 
 type containerDescriptor struct {
@@ -27,7 +28,7 @@ type containerDescriptor struct {
 	stats       types.StatsJSON
 }
 
-func newContainer(ctx context.Context, dockerClient *client.Client, d Description, tuner nvidiaGPUTuner) (*containerDescriptor, error) {
+func newContainer(ctx context.Context, dockerClient *client.Client, d Description, tuner gpu.Tuner) (*containerDescriptor, error) {
 	log.G(ctx).Info("start container with application")
 
 	ctx, cancel := context.WithCancel(ctx)

--- a/insonmnia/miner/gpu/config.go
+++ b/insonmnia/miner/gpu/config.go
@@ -1,0 +1,10 @@
+package gpu
+
+// Config contains options related to NVIDIA GPU support
+type Config struct {
+	Type string `yaml:"type"`
+	Args Args   `yaml:"args"`
+}
+
+// Args are mode dependant options
+type Args map[string]interface{}

--- a/insonmnia/miner/gpu/gpu_tuner.go
+++ b/insonmnia/miner/gpu/gpu_tuner.go
@@ -1,0 +1,55 @@
+package gpu
+
+import (
+	"context"
+	"errors"
+
+	"github.com/docker/docker/api/types/container"
+)
+
+type factory func(ctx context.Context, args Args) (Tuner, error)
+
+var (
+	modes = map[string]factory{
+		"nil": nilFactory,
+	}
+
+	// ErrUnsupportedGPUType means that requeted GPU/OpenCL isolation type is not supported
+	ErrUnsupportedGPUType = errors.New("requeted GPU type is not supported")
+)
+
+// Tuner is responsible for preparing GPU-friendly environment and baking proper options in container.HostConfig
+type Tuner interface {
+	Tune(hostconfig *container.HostConfig) error
+	Close() error
+}
+
+// New creates Tuner based on provided config.
+// It may return ErrUnsupportedGPUType if the platform does not support requested iso type
+// Currently supported type: nil, nvidiadocker, embedded
+func New(ctx context.Context, cfg *Config) (Tuner, error) {
+	switch cfg.Type {
+	case "":
+		return NilTuner{}, nil
+	default:
+		factory, ok := modes[cfg.Type]
+		if !ok {
+			return nil, ErrUnsupportedGPUType
+		}
+
+		return factory(ctx, cfg.Args)
+	}
+}
+
+// NilTuner is just a null pattern
+type NilTuner struct{}
+
+func nilFactory(context.Context, Args) (Tuner, error) {
+	return NilTuner{}, nil
+}
+
+func (NilTuner) Tune(hostconfig *container.HostConfig) error {
+	return nil
+}
+
+func (NilTuner) Close() error { return nil }

--- a/insonmnia/miner/gpu/graphic_driver_volume.go
+++ b/insonmnia/miner/gpu/graphic_driver_volume.go
@@ -1,3 +1,5 @@
+// +build linux,embeddednvidia
+
 package gpu
 
 import (

--- a/insonmnia/miner/gpu/graphic_driver_volume.go
+++ b/insonmnia/miner/gpu/graphic_driver_volume.go
@@ -1,0 +1,164 @@
+package gpu
+
+import (
+	"errors"
+	"fmt"
+	"log"
+	"path"
+	"regexp"
+
+	"github.com/NVIDIA/nvidia-docker/src/nvidia"
+	"github.com/docker/go-plugins-helpers/volume"
+)
+
+var (
+	// ErrVolumeBadFormat means that volume name does not fit pattern name_version
+	ErrVolumeBadFormat = errors.New("bad volume format")
+	// ErrVolumeUnsupported means that Volume map does not have such volume
+	ErrVolumeUnsupported = errors.New("unsupported volume")
+	//ErrVolumeNotFound means that requested volume does not exist
+	ErrVolumeNotFound = errors.New("no such volume")
+	// ErrVolumeVersion means that version is invalid
+	ErrVolumeVersion = errors.New("invalid volume version")
+
+	volVersionRegex = regexp.MustCompile("^([a-zA-Z0-9_.-]+)_([0-9.]+)$")
+)
+
+// NewPlugin returns plugin.Driver implementation
+// NOTE: volumes is immutable structure!
+func NewPlugin(volumes nvidia.VolumeMap) volume.Driver {
+	return &volumePlugin{Volumes: volumes}
+}
+
+type volumePlugin struct {
+	Volumes nvidia.VolumeMap
+}
+
+func (p *volumePlugin) Create(req *volume.CreateRequest) error {
+	log.Printf("Received create request for volume '%s'", req.Name)
+	vol, version, err := p.getVolume(req.Name)
+	if err != nil {
+		return err
+	}
+
+	if version != vol.Version {
+		return ErrVolumeVersion
+	}
+
+	ok, err := vol.Exists()
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return vol.Create(nvidia.LinkStrategy{})
+	}
+	return nil
+}
+
+func (p *volumePlugin) List() (*volume.ListResponse, error) {
+	var resp volume.ListResponse
+
+	for _, vol := range p.Volumes {
+		versions, err := vol.ListVersions()
+		if err != nil {
+			return nil, err
+		}
+
+		for _, v := range versions {
+			resp.Volumes = append(resp.Volumes, &volume.Volume{
+				Name:       fmt.Sprintf("%s_%s", vol.Name, v),
+				Mountpoint: path.Join(vol.Path, v),
+			})
+		}
+	}
+	return &resp, nil
+}
+
+func (p *volumePlugin) Get(req *volume.GetRequest) (*volume.GetResponse, error) {
+	log.Printf("Received get request for volume '%s'", req.Name)
+	vol, version, err := p.getVolume(req.Name)
+	if err != nil {
+		return nil, err
+	}
+	ok, err := vol.Exists(version)
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		return nil, ErrVolumeNotFound
+	}
+
+	var resp = volume.GetResponse{
+		Volume: &volume.Volume{
+			Name:       req.Name,
+			Mountpoint: path.Join(vol.Path, version),
+		},
+	}
+	return &resp, nil
+}
+
+func (p *volumePlugin) Remove(req *volume.RemoveRequest) error {
+	log.Printf("Received remove request for volume '%s'", req.Name)
+	volume, version, err := p.getVolume(req.Name)
+	if err != nil {
+		return err
+	}
+
+	return volume.Remove(version)
+}
+
+func (p *volumePlugin) Path(req *volume.PathRequest) (*volume.PathResponse, error) {
+	var mReq = volume.MountRequest{
+		Name: req.Name,
+	}
+	mResp, err := p.Mount(&mReq)
+	if err != nil {
+		return nil, err
+	}
+	return &volume.PathResponse{Mountpoint: mResp.Mountpoint}, nil
+}
+
+func (p *volumePlugin) Mount(req *volume.MountRequest) (*volume.MountResponse, error) {
+	log.Printf("Received mount request for volume '%s'", req.Name)
+	vol, version, err := p.getVolume(req.Name)
+	if err != nil {
+		return nil, err
+	}
+
+	ok, err := vol.Exists(version)
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		return nil, ErrVolumeNotFound
+	}
+
+	var resp = volume.MountResponse{
+		Mountpoint: path.Join(vol.Path, version),
+	}
+	return &resp, nil
+}
+
+func (p *volumePlugin) Unmount(req *volume.UnmountRequest) error {
+	log.Printf("Received unmount request for volume '%s'", req.Name)
+	_, _, err := p.getVolume(req.Name)
+	return err
+}
+
+func (p *volumePlugin) Capabilities() *volume.CapabilitiesResponse {
+	return &volume.CapabilitiesResponse{
+		Capabilities: volume.Capability{Scope: "local"},
+	}
+}
+
+func (p *volumePlugin) getVolume(name string) (*nvidia.Volume, string, error) {
+	m := volVersionRegex.FindStringSubmatch(name)
+	if len(m) != 3 {
+		return nil, "", ErrVolumeBadFormat
+	}
+	volume, version := p.Volumes[m[1]], m[2]
+	if volume == nil {
+		return nil, "", ErrVolumeUnsupported
+	}
+	return volume, version, nil
+}

--- a/insonmnia/miner/gpu/nvidia_docker_tuner.go
+++ b/insonmnia/miner/gpu/nvidia_docker_tuner.go
@@ -1,14 +1,30 @@
-package miner
+// +build linux
+
+package gpu
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 
 	"github.com/docker/docker/api/types/container"
+
+	log "github.com/noxiouz/zapctx/ctxlog"
 )
+
+const openCLVendorDir = "/etc/OpenCL/vendors"
+
+func init() {
+	modes["nvidiadocker"] = newNvidiaDockerTuner
+}
+
+type gpuNvidiaDockerTuner struct {
+	args nvidiaPluginArgs
+}
 
 // related to https://github.com/NVIDIA/nvidia-docker/blob/master/src/nvidia-docker-plugin/remote_v1.go#L180
 type nvidiaPluginArgs struct {
@@ -17,23 +33,14 @@ type nvidiaPluginArgs struct {
 	Devices      []string
 }
 
-type nvidiaGPUTuner interface {
-	Tune(hostconfig *container.HostConfig) error
-}
-
-type nilGPUTuner struct{}
-
-func (nilGPUTuner) Tune(hostconfig *container.HostConfig) error {
-	return nil
-}
-
-type gpuTuner struct {
-	args nvidiaPluginArgs
-}
-
-func newGPUTuner(config *GPUConfig) (nvidiaGPUTuner, error) {
+func newNvidiaDockerTuner(ctx context.Context, args Args) (Tuner, error) {
+	nvidiaDockerDriverEndpoint, ok := args["nvidiadockerdriver"].(string)
+	if !ok {
+		log.G(ctx).Error("missing option pointing to NvidiaDockerEndpoint or it's not a string")
+		return nil, fmt.Errorf("configuration error")
+	}
 	// TODO: construct the URL in a more safe way
-	resp, err := http.Get("http://" + config.NvidiaDockerDriver + "/docker/cli/json")
+	resp, err := http.Get("http://" + nvidiaDockerDriverEndpoint + "/docker/cli/json")
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch GPU configuration from nvidia-docker-plugin: %v", err)
 	}
@@ -45,15 +52,23 @@ func newGPUTuner(config *GPUConfig) (nvidiaGPUTuner, error) {
 		return nil, fmt.Errorf("non OK response from nvidia-docker-plugin: %s %s", resp.Status, b)
 	}
 
-	var args nvidiaPluginArgs
-	if err = json.NewDecoder(resp.Body).Decode(&args); err != nil {
+	var plArgs nvidiaPluginArgs
+	if err = json.NewDecoder(resp.Body).Decode(&plArgs); err != nil {
 		return nil, fmt.Errorf("failed to decode GPU args from nvidia-docker-plugin: %v", err)
 	}
 
-	return &gpuTuner{args: args}, nil
+	// If we have OpenCL vendors dir, bind it into a container too
+	_, err = os.Stat(openCLVendorDir)
+	if err == nil {
+		plArgs.Volumes = append(plArgs.Volumes, openCLVendorDir+":"+openCLVendorDir+":ro")
+	}
+
+	return &gpuNvidiaDockerTuner{args: plArgs}, nil
 }
 
-func (g *gpuTuner) Tune(hostconfig *container.HostConfig) error {
+func (*gpuNvidiaDockerTuner) Close() error { return nil }
+
+func (g *gpuNvidiaDockerTuner) Tune(hostconfig *container.HostConfig) error {
 	// This tunes configs to get the same result as docker run with:
 	// --volume-driver=nvidia-docker --volume=nvidia_driver_375.66:/usr/local/nvidia:ro --device=/dev/nvidiactl --device=/dev/nvidia-uvm --device=/dev/nvidia-uvm-tools --device=/dev/nvidia
 

--- a/insonmnia/miner/gpu/nvidia_init.go
+++ b/insonmnia/miner/gpu/nvidia_init.go
@@ -1,0 +1,141 @@
+// +build linux,embeddednvidia
+
+package gpu
+
+import (
+	"context"
+	"net"
+	"os"
+
+	"go.uber.org/zap"
+
+	"github.com/NVIDIA/nvidia-docker/src/nvidia"
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/go-plugins-helpers/volume"
+	log "github.com/noxiouz/zapctx/ctxlog"
+)
+
+func init() {
+	modes["embedded"] = newEmbeddedTuner
+}
+
+var volPath = "/var/lib/nvidia-docker/volumes"
+
+const (
+	// we pin up driver  version and use patched NvidiaDocekr packages
+	// otherwise it requires for ATI host to have NVIDIA driver installed
+	// This name must be related to VolumeMap in NvidiaDocker itself.
+	// This map contains names of libnraries to look for
+	magicVolumeName = "nvidia_driver_300.0"
+
+	dockerVolumeDriverName = "nvidia-docker"
+
+	// TODO: configurable
+	sockPath = "/run/docker/plugins/" + dockerVolumeDriverName + ".sock"
+)
+
+type embeddedTuner struct {
+	devices         []string
+	OpenCLVendorDir string
+	handler         *volume.Handler
+	pluginListener  net.Listener
+}
+
+func (g *embeddedTuner) Tune(hostconfig *container.HostConfig) error {
+	// NOTE: driver name depends on UNIX socket name which Docker uses to connect to a driver
+	hostconfig.VolumeDriver = dockerVolumeDriverName
+	hostconfig.Binds = append(hostconfig.Binds, magicVolumeName+":"+"/usr/local/nvidia:ro")
+	if g.OpenCLVendorDir != "" {
+		hostconfig.Binds = append(hostconfig.Binds, g.OpenCLVendorDir+":"+g.OpenCLVendorDir+":ro")
+	}
+	for _, device := range g.devices {
+		hostconfig.Devices = append(hostconfig.Devices, container.DeviceMapping{
+			PathOnHost:        device,
+			CgroupPermissions: "rwm",
+		})
+	}
+	return nil
+}
+
+func (g *embeddedTuner) Close() error {
+	if err := g.pluginListener.Close(); err != nil {
+		return err
+	}
+	return os.Remove(sockPath)
+}
+
+func newEmbeddedTuner(ctx context.Context, _ Args) (Tuner, error) {
+	var ovs embeddedTuner
+	// Detect if we support NVIDIA
+	log.G(ctx).Info("Loading NVIDIA unified memory")
+	UVMErr := nvidia.LoadUVM()
+	if UVMErr != nil {
+		log.G(ctx).Warn("failed to load UVM %v. Seems NVIDIA is not installed on the host", zap.Error(UVMErr))
+	}
+
+	log.G(ctx).Info("Loading NVIDIA management library")
+	initErr := nvidia.Init()
+	if initErr == nil {
+		defer func() { nvidia.Shutdown() }()
+	}
+
+	var nvidiaSupported = initErr == nil && UVMErr == nil
+	if nvidiaSupported {
+		log.G(ctx).Info("NVIDIA GPU supported by the host. Discovering GPU devices")
+		devices, err := nvidia.LookupDevices()
+		if err != nil {
+			log.G(ctx).Error("failed to lookup GPU devices", zap.Error(err))
+			return nil, err
+		}
+		cdevices, err := nvidia.GetControlDevicePaths()
+		if err != nil {
+			log.G(ctx).Error("failed to get contorl devices paths", zap.Error(err))
+			return nil, err
+		}
+		ovs.devices = append(ovs.devices, cdevices...)
+		for _, device := range devices {
+			ovs.devices = append(ovs.devices, device.Path)
+		}
+	}
+
+	if _, err := os.Stat("/dev/dri"); err == nil {
+		ovs.devices = append(ovs.devices, "/dev/dri")
+	}
+
+	if _, err := os.Stat(openCLVendorDir); err == nil {
+		ovs.OpenCLVendorDir = openCLVendorDir
+	}
+
+	// NOTE: Add libraries we need to discover
+	nvolumes := nvidia.Volumes[0]
+	components := nvolumes.Components
+	components["libraries"] = append(components["libraries"],
+		"libdrm.so",
+		"libOpenCL.so",
+		"libMesaOpenCL.so",
+		"pipe_vmwgfx.so",
+		"pipe_r600.so",
+		"pipe_r300.so",
+		"pipe_radeonsi.so",
+		"pipe_swrast.so",
+		"pipe_nouveau.so",
+	)
+	log.G(ctx).Info("Provisioning volumes", zap.String("at", volPath))
+	volumes, err := nvidia.LookupVolumes(volPath)
+	if err != nil {
+		return nil, err
+	}
+	ovs.handler = volume.NewHandler(NewPlugin(volumes))
+
+	ovs.pluginListener, err = net.Listen("unix", sockPath)
+	if err != nil {
+		log.G(ctx).Error("failed to create listening socket for to communicate with Docker as plugin", zap.String("path", sockPath), zap.Error(err))
+		return nil, err
+	}
+
+	go func() {
+		ovs.handler.Serve(ovs.pluginListener)
+	}()
+
+	return &ovs, nil
+}

--- a/miner.yaml
+++ b/miner.yaml
@@ -34,5 +34,6 @@ logging:
 #   server: "stun.ekiga.net:3478"
 
 # GPUConfig:
+  # type: "nvidiadocker"
   # by default nvidia-docker-plugin works on that endpoint
-  # nvidiadockerdriver: "localhost:3476"
+  # args: { nvidiadockerdriver: "localhost:3476" }

--- a/vendor/github.com/NVIDIA/nvidia-docker/LICENSE
+++ b/vendor/github.com/NVIDIA/nvidia-docker/LICENSE
@@ -1,0 +1,25 @@
+Copyright (c) 2015-2016, NVIDIA CORPORATION. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+ * Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+ * Neither the name of NVIDIA CORPORATION nor the names of its
+   contributors may be used to endorse or promote products derived
+   from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/github.com/NVIDIA/nvidia-docker/src/cuda/bindings.go
+++ b/vendor/github.com/NVIDIA/nvidia-docker/src/cuda/bindings.go
@@ -1,0 +1,82 @@
+// Copyright (c) 2015-2016, NVIDIA CORPORATION. All rights reserved.
+
+package cuda
+
+// #cgo LDFLAGS: -lcudart_static -ldl -lrt
+// #include <stdlib.h>
+// #include <cuda_runtime_api.h>
+import "C"
+
+import (
+	"fmt"
+	"unsafe"
+)
+
+type handle struct{ dev C.int }
+
+type deviceProp struct {
+	major                      int
+	minor                      int
+	multiProcessorCount        uint
+	ECCEnabled                 bool
+	totalGlobalMem             uint
+	sharedMemPerMultiprocessor uint
+	totalConstMem              uint
+	l2CacheSize                uint
+	memoryClockRate            uint
+	memoryBusWidth             uint
+}
+
+func errorString(ret C.cudaError_t) error {
+	if ret == C.cudaSuccess {
+		return nil
+	}
+	err := C.GoString(C.cudaGetErrorString(ret))
+	return fmt.Errorf("cuda: %v", err)
+}
+
+func driverGetVersion() (int, error) {
+	var driver C.int
+
+	r := C.cudaDriverGetVersion(&driver)
+	return int(driver), errorString(r)
+}
+
+func deviceGetByPCIBusId(busid string) (handle, error) {
+	var dev C.int
+
+	id := C.CString(busid)
+	r := C.cudaDeviceGetByPCIBusId(&dev, id)
+	C.free(unsafe.Pointer(id))
+	return handle{dev}, errorString(r)
+}
+
+func deviceCanAccessPeer(h1, h2 handle) (bool, error) {
+	var ok C.int
+
+	r := C.cudaDeviceCanAccessPeer(&ok, h1.dev, h2.dev)
+	return (ok != 0), errorString(r)
+}
+
+func deviceReset() error {
+	return errorString(C.cudaDeviceReset())
+}
+
+func (h handle) getDeviceProperties() (*deviceProp, error) {
+	var props C.struct_cudaDeviceProp
+
+	r := C.cudaGetDeviceProperties(&props, h.dev)
+	p := &deviceProp{
+		major:                      int(props.major),
+		minor:                      int(props.minor),
+		multiProcessorCount:        uint(props.multiProcessorCount),
+		ECCEnabled:                 bool(props.ECCEnabled != 0),
+		totalGlobalMem:             uint(props.totalGlobalMem),
+		sharedMemPerMultiprocessor: uint(props.sharedMemPerMultiprocessor),
+		totalConstMem:              uint(props.totalConstMem),
+		l2CacheSize:                uint(props.l2CacheSize),
+		memoryClockRate:            uint(props.memoryClockRate),
+		memoryBusWidth:             uint(props.memoryBusWidth),
+	}
+	return p, errorString(r)
+}

--- a/vendor/github.com/NVIDIA/nvidia-docker/src/cuda/cuda.go
+++ b/vendor/github.com/NVIDIA/nvidia-docker/src/cuda/cuda.go
@@ -1,0 +1,120 @@
+// Copyright (c) 2015-2016, NVIDIA CORPORATION. All rights reserved.
+
+package cuda
+
+import (
+	"fmt"
+)
+
+type MemoryInfo struct {
+	ECC       *bool
+	Global    *uint
+	Shared    *uint
+	Constant  *uint
+	L2Cache   *uint
+	Bandwidth *uint
+}
+
+type Device struct {
+	handle
+
+	Family *string
+	Arch   *string
+	Cores  *uint
+	Memory MemoryInfo
+}
+
+func archFamily(arch string) *string {
+	m := map[string]string{
+		"1": "Tesla",
+		"2": "Fermi",
+		"3": "Kepler",
+		"5": "Maxwell",
+		"6": "Pascal",
+	}
+
+	f, ok := m[arch[:1]]
+	if !ok {
+		return nil
+	}
+	return &f
+}
+
+func archSMCores(arch string) *uint {
+	m := map[string]uint{
+		"1.0": 8,   // Tesla Generation (SM 1.0) G80 class
+		"1.1": 8,   // Tesla Generation (SM 1.1) G8x G9x class
+		"1.2": 8,   // Tesla Generation (SM 1.2) GT21x class
+		"1.3": 8,   // Tesla Generation (SM 1.3) GT20x class
+		"2.0": 32,  // Fermi Generation (SM 2.0) GF100 GF110 class
+		"2.1": 48,  // Fermi Generation (SM 2.1) GF10x GF11x class
+		"3.0": 192, // Kepler Generation (SM 3.0) GK10x class
+		"3.2": 192, // Kepler Generation (SM 3.2) TK1 class
+		"3.5": 192, // Kepler Generation (SM 3.5) GK11x GK20x class
+		"3.7": 192, // Kepler Generation (SM 3.7) GK21x class
+		"5.0": 128, // Maxwell Generation (SM 5.0) GM10x class
+		"5.2": 128, // Maxwell Generation (SM 5.2) GM20x class
+		"5.3": 128, // Maxwell Generation (SM 5.3) TX1 class
+		"6.0": 64,  // Pascal Generation (SM 6.0) GP100 class
+		"6.1": 128, // Pascal Generation (SM 6.1) GP10x class
+		"6.2": 128, // Pascal Generation (SM 6.2) GP10x class
+	}
+
+	c, ok := m[arch]
+	if !ok {
+		return nil
+	}
+	return &c
+}
+
+func GetDriverVersion() (string, error) {
+	d, err := driverGetVersion()
+	return fmt.Sprintf("%d.%d", d/1000, d%100/10), err
+}
+
+func NewDevice(busid string) (device *Device, err error) {
+	h, err := deviceGetByPCIBusId(busid)
+	if err != nil {
+		return nil, err
+	}
+	props, err := h.getDeviceProperties()
+	if err != nil {
+		return nil, err
+	}
+	arch := fmt.Sprintf("%d.%d", props.major, props.minor)
+	family := archFamily(arch)
+	cores := archSMCores(arch)
+	bw := 2 * (props.memoryClockRate / 1000) * (props.memoryBusWidth / 8)
+
+	// Destroy the active CUDA context
+	if err := deviceReset(); err != nil {
+		return nil, err
+	}
+
+	device = &Device{
+		handle: h,
+		Family: family,
+		Arch:   &arch,
+		Cores:  cores,
+		Memory: MemoryInfo{
+			ECC:       &props.ECCEnabled,
+			Global:    &props.totalGlobalMem,
+			Shared:    &props.sharedMemPerMultiprocessor,
+			Constant:  &props.totalConstMem,
+			L2Cache:   &props.l2CacheSize,
+			Bandwidth: &bw, // MB/s
+		},
+	}
+	if cores != nil {
+		*device.Cores *= props.multiProcessorCount
+	}
+	*device.Memory.Global /= 1024 * 1024 // MiB
+	*device.Memory.Shared /= 1024        // KiB
+	*device.Memory.Constant /= 1024      // KiB
+	*device.Memory.L2Cache /= 1024       // KiB
+	return
+}
+
+func CanAccessPeer(dev1, dev2 *Device) (bool, error) {
+	return deviceCanAccessPeer(dev1.handle, dev2.handle)
+}

--- a/vendor/github.com/NVIDIA/nvidia-docker/src/ldcache/ldcache.go
+++ b/vendor/github.com/NVIDIA/nvidia-docker/src/ldcache/ldcache.go
@@ -1,0 +1,196 @@
+// Copyright (c) 2015-2016, NVIDIA CORPORATION. All rights reserved.
+
+package ldcache
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"os"
+	"path/filepath"
+	"syscall"
+	"unsafe"
+)
+
+const ldcachePath = "/etc/ld.so.cache"
+
+const (
+	magicString1 = "ld.so-1.7.0"
+	magicString2 = "glibc-ld.so.cache"
+	magicVersion = "1.1"
+)
+
+const (
+	flagTypeMask = 0x00ff
+	flagTypeELF  = 0x0001
+
+	flagArchMask    = 0xff00
+	flagArchI386    = 0x0000
+	flagArchX8664   = 0x0300
+	flagArchX32     = 0x0800
+	flagArchPpc64le = 0x0500
+)
+
+var ErrInvalidCache = errors.New("invalid ld.so.cache file")
+
+type Header1 struct {
+	Magic [len(magicString1) + 1]byte // include null delimiter
+	NLibs uint32
+}
+
+type Entry1 struct {
+	Flags      int32
+	Key, Value uint32
+}
+
+type Header2 struct {
+	Magic     [len(magicString2)]byte
+	Version   [len(magicVersion)]byte
+	NLibs     uint32
+	TableSize uint32
+	_         [3]uint32 // unused
+	_         uint64    // force 8 byte alignment
+}
+
+type Entry2 struct {
+	Flags      int32
+	Key, Value uint32
+	OSVersion  uint32
+	HWCap      uint64
+}
+
+type LDCache struct {
+	*bytes.Reader
+
+	data, libs []byte
+	header     Header2
+	entries    []Entry2
+}
+
+func Open() (*LDCache, error) {
+	f, err := os.Open(ldcachePath)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	fi, err := f.Stat()
+	if err != nil {
+		return nil, err
+	}
+	d, err := syscall.Mmap(int(f.Fd()), 0, int(fi.Size()),
+		syscall.PROT_READ, syscall.MAP_PRIVATE)
+	if err != nil {
+		return nil, err
+	}
+
+	cache := &LDCache{data: d, Reader: bytes.NewReader(d)}
+	return cache, cache.parse()
+}
+
+func (c *LDCache) Close() error {
+	return syscall.Munmap(c.data)
+}
+
+func (c *LDCache) Magic() string {
+	return string(c.header.Magic[:])
+}
+
+func (c *LDCache) Version() string {
+	return string(c.header.Version[:])
+}
+
+func strn(b []byte, n int) string {
+	return string(b[:n])
+}
+
+func (c *LDCache) parse() error {
+	var header Header1
+
+	// Check for the old format (< glibc-2.2)
+	if c.Len() <= int(unsafe.Sizeof(header)) {
+		return ErrInvalidCache
+	}
+	if strn(c.data, len(magicString1)) == magicString1 {
+		if err := binary.Read(c, binary.LittleEndian, &header); err != nil {
+			return err
+		}
+		n := int64(header.NLibs) * int64(unsafe.Sizeof(Entry1{}))
+		offset, err := c.Seek(n, 1) // skip old entries
+		if err != nil {
+			return err
+		}
+		n = (-offset) & int64(unsafe.Alignof(c.header)-1)
+		_, err = c.Seek(n, 1) // skip padding
+		if err != nil {
+			return err
+		}
+	}
+
+	c.libs = c.data[c.Size()-int64(c.Len()):] // kv offsets start here
+	if err := binary.Read(c, binary.LittleEndian, &c.header); err != nil {
+		return err
+	}
+	if c.Magic() != magicString2 || c.Version() != magicVersion {
+		return ErrInvalidCache
+	}
+	c.entries = make([]Entry2, c.header.NLibs)
+	if err := binary.Read(c, binary.LittleEndian, &c.entries); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *LDCache) Lookup(libs ...string) (paths32, paths64 []string) {
+	type void struct{}
+	var paths *[]string
+
+	set := make(map[string]void)
+	prefix := make([][]byte, len(libs))
+
+	for i := range libs {
+		prefix[i] = []byte(libs[i])
+	}
+	for _, e := range c.entries {
+		if ((e.Flags & flagTypeMask) & flagTypeELF) == 0 {
+			continue
+		}
+		switch e.Flags & flagArchMask {
+		case flagArchX8664:
+			fallthrough
+		case flagArchPpc64le:
+			paths = &paths64
+		case flagArchX32:
+			fallthrough
+		case flagArchI386:
+			paths = &paths32
+		default:
+			continue
+		}
+		if e.Key > uint32(len(c.libs)) || e.Value > uint32(len(c.libs)) {
+			continue
+		}
+		lib := c.libs[e.Key:]
+		value := c.libs[e.Value:]
+
+		for _, p := range prefix {
+			if bytes.HasPrefix(lib, p) {
+				n := bytes.IndexByte(value, 0)
+				if n < 0 {
+					break
+				}
+				path, err := filepath.EvalSymlinks(strn(value, n))
+				if err != nil {
+					break
+				}
+				if _, ok := set[path]; ok {
+					break
+				}
+				set[path] = void{}
+				*paths = append(*paths, path)
+				break
+			}
+		}
+	}
+	return
+}

--- a/vendor/github.com/NVIDIA/nvidia-docker/src/nvidia/devices.go
+++ b/vendor/github.com/NVIDIA/nvidia-docker/src/nvidia/devices.go
@@ -1,0 +1,130 @@
+// Copyright (c) 2015-2016, NVIDIA CORPORATION. All rights reserved.
+
+package nvidia
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/NVIDIA/nvidia-docker/src/cuda"
+	"github.com/NVIDIA/nvidia-docker/src/nvml"
+)
+
+type NVMLDevice nvml.Device
+type CUDADevice cuda.Device
+
+type Device struct {
+	*NVMLDevice
+	*CUDADevice
+}
+
+type NVMLDeviceStatus nvml.DeviceStatus
+
+type DeviceStatus struct {
+	*NVMLDeviceStatus
+}
+
+type LookupStrategy uint
+
+const (
+	LookupMinimal LookupStrategy = iota
+)
+
+func (d *Device) Status() (*DeviceStatus, error) {
+	s, err := (*nvml.Device)(d.NVMLDevice).Status()
+	if err != nil {
+		return nil, err
+	}
+	return &DeviceStatus{(*NVMLDeviceStatus)(s)}, nil
+}
+
+func LookupDevices(s ...LookupStrategy) (devs []Device, err error) {
+	var i uint
+
+	n, err := nvml.GetDeviceCount()
+	if err != nil {
+		return nil, err
+	}
+	devs = make([]Device, 0, n)
+	if n == 0 {
+		return
+	}
+
+	if len(s) == 1 && s[0] == LookupMinimal {
+		for i = 0; i < n; i++ {
+			d, err := nvml.NewDeviceLite(i)
+			if err != nil {
+				return nil, err
+			}
+			devs = append(devs, Device{(*NVMLDevice)(d), &CUDADevice{}})
+		}
+		return
+	}
+
+	for i = 0; i < n; i++ {
+		nd, err := nvml.NewDevice(i)
+		if err != nil {
+			return nil, err
+		}
+		cd, err := cuda.NewDevice(nd.PCI.BusID)
+		if err != nil {
+			return nil, err
+		}
+		devs = append(devs, Device{(*NVMLDevice)(nd), (*CUDADevice)(cd)})
+	}
+
+	for i = 0; i < n-1; i++ {
+		for j := i + 1; j < n; j++ {
+			ok, err := cuda.CanAccessPeer(
+				(*cuda.Device)(devs[i].CUDADevice),
+				(*cuda.Device)(devs[j].CUDADevice),
+			)
+			if err != nil {
+				return nil, err
+			}
+			if ok {
+				l, err := nvml.GetP2PLink(
+					(*nvml.Device)(devs[i].NVMLDevice),
+					(*nvml.Device)(devs[j].NVMLDevice),
+				)
+				if err != nil {
+					return nil, err
+				}
+				devs[i].Topology = append(devs[i].Topology, nvml.P2PLink{devs[j].PCI.BusID, l})
+				devs[j].Topology = append(devs[j].Topology, nvml.P2PLink{devs[i].PCI.BusID, l})
+			}
+		}
+	}
+	return
+}
+
+func FilterDevices(devs []Device, ids []string) ([]Device, error) {
+	type void struct{}
+	set := make(map[int]void)
+
+loop:
+	for _, id := range ids {
+		if strings.HasPrefix(id, "GPU-") {
+			for i := range devs {
+				if strings.HasPrefix(devs[i].UUID, id) {
+					set[i] = void{}
+					continue loop
+				}
+			}
+		} else {
+			i, err := strconv.Atoi(id)
+			if err == nil && i >= 0 && i < len(devs) {
+				set[i] = void{}
+				continue loop
+			}
+		}
+		return nil, fmt.Errorf("invalid device: %s", id)
+	}
+
+	d := make([]Device, 0, len(set))
+	for i := range set {
+		d = append(d, devs[i])
+	}
+	return d, nil
+}

--- a/vendor/github.com/NVIDIA/nvidia-docker/src/nvidia/nvidia.go
+++ b/vendor/github.com/NVIDIA/nvidia-docker/src/nvidia/nvidia.go
@@ -1,0 +1,61 @@
+// Copyright (c) 2015-2016, NVIDIA CORPORATION. All rights reserved.
+
+package nvidia
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+
+	"github.com/NVIDIA/nvidia-docker/src/cuda"
+	"github.com/NVIDIA/nvidia-docker/src/nvml"
+)
+
+const (
+	DockerPlugin   = "nvidia-docker"
+	DeviceCtl      = "/dev/nvidiactl"
+	DeviceUVM      = "/dev/nvidia-uvm"
+	DeviceUVMTools = "/dev/nvidia-uvm-tools"
+)
+
+func Init() error {
+	if err := os.Setenv("CUDA_DISABLE_UNIFIED_MEMORY", "1"); err != nil {
+		return err
+	}
+	if err := os.Setenv("CUDA_CACHE_DISABLE", "1"); err != nil {
+		return err
+	}
+	if err := os.Unsetenv("CUDA_VISIBLE_DEVICES"); err != nil {
+		return err
+	}
+	return nvml.Init()
+}
+
+func Shutdown() error {
+	return nvml.Shutdown()
+}
+
+func LoadUVM() error {
+	if exec.Command("nvidia-modprobe", "-u", "-c=0").Run() != nil {
+		return errors.New("Could not load UVM kernel module. Is nvidia-modprobe installed?")
+	}
+	return nil
+}
+
+func GetDriverVersion() (string, error) {
+	return nvml.GetDriverVersion()
+}
+
+func GetCUDAVersion() (string, error) {
+	return cuda.GetDriverVersion()
+}
+
+func GetControlDevicePaths() ([]string, error) {
+	devs := []string{DeviceCtl, DeviceUVM}
+
+	_, err := os.Stat(DeviceUVMTools)
+	if os.IsNotExist(err) {
+		return devs, nil
+	}
+	return append(devs, DeviceUVMTools), err
+}

--- a/vendor/github.com/NVIDIA/nvidia-docker/src/nvidia/volumes.go
+++ b/vendor/github.com/NVIDIA/nvidia-docker/src/nvidia/volumes.go
@@ -1,0 +1,391 @@
+// Copyright (c) 2015-2016, NVIDIA CORPORATION. All rights reserved.
+
+package nvidia
+
+import (
+	"bufio"
+	"bytes"
+	"debug/elf"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/NVIDIA/nvidia-docker/src/ldcache"
+)
+
+const (
+	binDir   = "bin"
+	lib32Dir = "lib"
+	lib64Dir = "lib64"
+)
+
+type components map[string][]string
+
+type volumeDir struct {
+	name  string
+	files []string
+}
+
+type VolumeInfo struct {
+	Name         string
+	Mountpoint   string
+	MountOptions string
+	Components   components
+}
+
+type Volume struct {
+	*VolumeInfo
+
+	Path    string
+	Version string
+	dirs    []volumeDir
+}
+
+type VolumeMap map[string]*Volume
+
+type FileCloneStrategy interface {
+	Clone(src, dst string) error
+}
+
+type LinkStrategy struct{}
+
+func (s LinkStrategy) Clone(src, dst string) error {
+	return os.Link(src, dst)
+}
+
+type LinkOrCopyStrategy struct{}
+
+func (s LinkOrCopyStrategy) Clone(src, dst string) error {
+	// Prefer hard link, fallback to copy
+	err := os.Link(src, dst)
+	if err != nil {
+		err = Copy(src, dst)
+	}
+	return err
+}
+
+func Copy(src, dst string) error {
+	s, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer s.Close()
+
+	fi, err := s.Stat()
+	if err != nil {
+		return err
+	}
+
+	d, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+
+	if _, err := io.Copy(d, s); err != nil {
+		d.Close()
+		return err
+	}
+
+	if err := d.Chmod(fi.Mode()); err != nil {
+		d.Close()
+		return err
+	}
+
+	return d.Close()
+}
+
+var Volumes = []VolumeInfo{
+	{
+		"nvidia_driver",
+		"/usr/local/nvidia",
+		"ro",
+		components{
+			"binaries": {
+				//"nvidia-modprobe",       // Kernel module loader
+				//"nvidia-settings",       // X server settings
+				//"nvidia-xconfig",        // X xorg.conf editor
+				"nvidia-cuda-mps-control", // Multi process service CLI
+				"nvidia-cuda-mps-server",  // Multi process service server
+				"nvidia-debugdump",        // GPU coredump utility
+				"nvidia-persistenced",     // Persistence mode utility
+				"nvidia-smi",              // System management interface
+			},
+			"libraries": {
+				// ------- X11 -------
+
+				//"libnvidia-cfg.so",  // GPU configuration (used by nvidia-xconfig)
+				//"libnvidia-gtk2.so", // GTK2 (used by nvidia-settings)
+				//"libnvidia-gtk3.so", // GTK3 (used by nvidia-settings)
+				//"libnvidia-wfb.so",  // Wrapped software rendering module for X server
+				//"libglx.so",         // GLX extension module for X server
+
+				// ----- Compute -----
+
+				"libnvidia-ml.so",              // Management library
+				"libcuda.so",                   // CUDA driver library
+				"libnvidia-ptxjitcompiler.so",  // PTX-SASS JIT compiler (used by libcuda)
+				"libnvidia-fatbinaryloader.so", // fatbin loader (used by libcuda)
+				"libnvidia-opencl.so",          // NVIDIA OpenCL ICD
+				"libnvidia-compiler.so",        // NVVM-PTX compiler for OpenCL (used by libnvidia-opencl)
+				//"libOpenCL.so",               // OpenCL ICD loader
+
+				// ------ Video ------
+
+				"libvdpau_nvidia.so",  // NVIDIA VDPAU ICD
+				"libnvidia-encode.so", // Video encoder
+				"libnvcuvid.so",       // Video decoder
+				"libnvidia-fbc.so",    // Framebuffer capture
+				"libnvidia-ifr.so",    // OpenGL framebuffer capture
+
+				// ----- Graphic -----
+
+				// XXX In an ideal world we would only mount nvidia_* vendor specific libraries and
+				// install ICD loaders inside the container. However, for backward compatibility reason
+				// we need to mount everything. This will hopefully change once GLVND is well established.
+
+				"libGL.so",         // OpenGL/GLX legacy _or_ compatibility wrapper (GLVND)
+				"libGLX.so",        // GLX ICD loader (GLVND)
+				"libOpenGL.so",     // OpenGL ICD loader (GLVND)
+				"libGLESv1_CM.so",  // OpenGL ES v1 common profile legacy _or_ ICD loader (GLVND)
+				"libGLESv2.so",     // OpenGL ES v2 legacy _or_ ICD loader (GLVND)
+				"libEGL.so",        // EGL ICD loader
+				"libGLdispatch.so", // OpenGL dispatch (GLVND) (used by libOpenGL, libEGL and libGLES*)
+
+				"libGLX_nvidia.so",         // OpenGL/GLX ICD (GLVND)
+				"libEGL_nvidia.so",         // EGL ICD (GLVND)
+				"libGLESv2_nvidia.so",      // OpenGL ES v2 ICD (GLVND)
+				"libGLESv1_CM_nvidia.so",   // OpenGL ES v1 common profile ICD (GLVND)
+				"libnvidia-eglcore.so",     // EGL core (used by libGLES* or libGLES*_nvidia and libEGL_nvidia)
+				"libnvidia-egl-wayland.so", // EGL wayland extensions (used by libEGL_nvidia)
+				"libnvidia-glcore.so",      // OpenGL core (used by libGL or libGLX_nvidia)
+				"libnvidia-tls.so",         // Thread local storage (used by libGL or libGLX_nvidia)
+				"libnvidia-glsi.so",        // OpenGL system interaction (used by libEGL_nvidia)
+			},
+		},
+	},
+}
+
+func blacklisted(file string, obj *elf.File) (bool, error) {
+	lib := regexp.MustCompile(`^.*/lib([\w-]+)\.so[\d.]*$`)
+	glcore := regexp.MustCompile(`libnvidia-e?glcore\.so`)
+	gldispatch := regexp.MustCompile(`libGLdispatch\.so`)
+
+	if m := lib.FindStringSubmatch(file); m != nil {
+		switch m[1] {
+
+		// Blacklist EGL/OpenGL libraries issued by other vendors
+		case "EGL":
+			fallthrough
+		case "GLESv1_CM":
+			fallthrough
+		case "GLESv2":
+			fallthrough
+		case "GL":
+			deps, err := obj.DynString(elf.DT_NEEDED)
+			if err != nil {
+				return false, err
+			}
+			for _, d := range deps {
+				if glcore.MatchString(d) || gldispatch.MatchString(d) {
+					return false, nil
+				}
+			}
+			return true, nil
+
+		// Blacklist TLS libraries using the old ABI (!= 2.3.99)
+		case "nvidia-tls":
+			const abi = 0x6300000003
+			s, err := obj.Section(".note.ABI-tag").Data()
+			if err != nil {
+				return false, err
+			}
+			return binary.LittleEndian.Uint64(s[24:]) != abi, nil
+		}
+	}
+	return false, nil
+}
+
+func (v *Volume) Create(s FileCloneStrategy) (err error) {
+	root := path.Join(v.Path, v.Version)
+	if err = os.MkdirAll(root, 0755); err != nil {
+		return
+	}
+	defer func() {
+		if err != nil {
+			v.Remove()
+		}
+	}()
+
+	for _, d := range v.dirs {
+		vpath := path.Join(root, d.name)
+		if err := os.MkdirAll(vpath, 0755); err != nil {
+			return err
+		}
+
+		// For each file matching the volume components (blacklist excluded), create a hardlink/copy
+		// of it inside the volume directory. We also need to create soname symlinks similar to what
+		// ldconfig does since our volume will only show up at runtime.
+		for _, f := range d.files {
+			obj, err := elf.Open(f)
+			if err != nil {
+				return fmt.Errorf("%s: %v", f, err)
+			}
+			defer obj.Close()
+
+			ok, err := blacklisted(f, obj)
+			if err != nil {
+				return fmt.Errorf("%s: %v", f, err)
+			}
+			if ok {
+				continue
+			}
+
+			l := path.Join(vpath, path.Base(f))
+			if err := s.Clone(f, l); err != nil {
+				return err
+			}
+			soname, err := obj.DynString(elf.DT_SONAME)
+			if err != nil {
+				return fmt.Errorf("%s: %v", f, err)
+			}
+			if len(soname) > 0 {
+				l = path.Join(vpath, soname[0])
+				if err := os.Symlink(path.Base(f), l); err != nil && !os.IsExist(err) {
+					return err
+				}
+				// XXX Many applications (wrongly) assume that libcuda.so exists (e.g. with dlopen)
+				// Hardcode the libcuda symlink for the time being.
+				if strings.HasPrefix(soname[0], "libcuda") {
+					l = strings.TrimRight(l, ".0123456789")
+					if err := os.Symlink(path.Base(f), l); err != nil && !os.IsExist(err) {
+						return err
+					}
+				}
+				// XXX GLVND requires this symlink for indirect GLX support
+				// It won't be needed once we have an indirect GLX vendor neutral library.
+				if strings.HasPrefix(soname[0], "libGLX_nvidia") {
+					l = strings.Replace(l, "GLX_nvidia", "GLX_indirect", 1)
+					if err := os.Symlink(path.Base(f), l); err != nil && !os.IsExist(err) {
+						return err
+					}
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func (v *Volume) Remove(version ...string) error {
+	vv := v.Version
+	if len(version) == 1 {
+		vv = version[0]
+	}
+	return os.RemoveAll(path.Join(v.Path, vv))
+}
+
+func (v *Volume) Exists(version ...string) (bool, error) {
+	vv := v.Version
+	if len(version) == 1 {
+		vv = version[0]
+	}
+	_, err := os.Stat(path.Join(v.Path, vv))
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	return true, err
+}
+
+func (v *Volume) ListVersions() ([]string, error) {
+	dirs, err := ioutil.ReadDir(v.Path)
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	versions := make([]string, len(dirs))
+	for i := range dirs {
+		versions[i] = dirs[i].Name()
+	}
+	return versions, nil
+}
+
+func which(bins ...string) ([]string, error) {
+	paths := make([]string, 0, len(bins))
+
+	out, _ := exec.Command("which", bins...).Output()
+	r := bufio.NewReader(bytes.NewBuffer(out))
+	for {
+		p, err := r.ReadString('\n')
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+		if p = strings.TrimSpace(p); !path.IsAbs(p) {
+			continue
+		}
+		path, err := filepath.EvalSymlinks(p)
+		if err != nil {
+			return nil, err
+		}
+		paths = append(paths, path)
+	}
+	return paths, nil
+}
+
+func LookupVolumes(prefix string) (vols VolumeMap, err error) {
+	// NOTE: freeze it
+	// Otherwise it requires to rewrite everything almost from scratch
+	// drv, err := GetDriverVersion()
+	// if err != nil {
+	// 	return nil, err
+	// }
+	const drv = "300.0"
+	cache, err := ldcache.Open()
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if e := cache.Close(); err == nil {
+			err = e
+		}
+	}()
+
+	vols = make(VolumeMap, len(Volumes))
+
+	for i := range Volumes {
+		vol := &Volume{
+			VolumeInfo: &Volumes[i],
+			Path:       path.Join(prefix, Volumes[i].Name),
+			Version:    drv,
+		}
+
+		for t, c := range vol.Components {
+			switch t {
+			case "binaries":
+				bins, err := which(c...)
+				if err != nil {
+					return nil, err
+				}
+				vol.dirs = append(vol.dirs, volumeDir{binDir, bins})
+			case "libraries":
+				libs32, libs64 := cache.Lookup(c...)
+				vol.dirs = append(vol.dirs,
+					volumeDir{lib32Dir, libs32},
+					volumeDir{lib64Dir, libs64},
+				)
+			}
+		}
+		vols[vol.Name] = vol
+	}
+	return
+}

--- a/vendor/github.com/NVIDIA/nvidia-docker/src/nvml/bindings.go
+++ b/vendor/github.com/NVIDIA/nvidia-docker/src/nvml/bindings.go
@@ -1,0 +1,311 @@
+// Copyright (c) 2015-2016, NVIDIA CORPORATION. All rights reserved.
+
+package nvml
+
+// #cgo LDFLAGS: -ldl -Wl,--unresolved-symbols=ignore-in-object-files
+// #include "nvml_dl.h"
+import "C"
+
+import (
+	"errors"
+	"fmt"
+)
+
+const (
+	szDriver   = C.NVML_SYSTEM_DRIVER_VERSION_BUFFER_SIZE
+	szName     = C.NVML_DEVICE_NAME_BUFFER_SIZE
+	szUUID     = C.NVML_DEVICE_UUID_BUFFER_SIZE
+	szProcs    = 32
+	szProcName = 64
+)
+
+type handle struct{ dev C.nvmlDevice_t }
+
+func uintPtr(c C.uint) *uint {
+	i := uint(c)
+	return &i
+}
+
+func uint64Ptr(c C.ulonglong) *uint64 {
+	i := uint64(c)
+	return &i
+}
+
+func stringPtr(c *C.char) *string {
+	s := C.GoString(c)
+	return &s
+}
+
+func errorString(ret C.nvmlReturn_t) error {
+	if ret == C.NVML_SUCCESS {
+		return nil
+	}
+	err := C.GoString(C.nvmlErrorString(ret))
+	return fmt.Errorf("nvml: %v", err)
+}
+
+func init_() error {
+	r := C.nvmlInit_dl()
+	if r == C.NVML_ERROR_LIBRARY_NOT_FOUND {
+		return errors.New("could not load NVML library")
+	}
+	return errorString(r)
+}
+
+func shutdown() error {
+	return errorString(C.nvmlShutdown_dl())
+}
+
+func systemGetDriverVersion() (string, error) {
+	var driver [szDriver]C.char
+
+	r := C.nvmlSystemGetDriverVersion(&driver[0], szDriver)
+	return C.GoString(&driver[0]), errorString(r)
+}
+
+func systemGetProcessName(pid uint) (string, error) {
+	var proc [szProcName]C.char
+
+	r := C.nvmlSystemGetProcessName(C.uint(pid), &proc[0], szProcName)
+	return C.GoString(&proc[0]), errorString(r)
+}
+
+func deviceGetCount() (uint, error) {
+	var n C.uint
+
+	r := C.nvmlDeviceGetCount(&n)
+	return uint(n), errorString(r)
+}
+
+func deviceGetHandleByIndex(idx uint) (handle, error) {
+	var dev C.nvmlDevice_t
+
+	r := C.nvmlDeviceGetHandleByIndex(C.uint(idx), &dev)
+	return handle{dev}, errorString(r)
+}
+
+func deviceGetTopologyCommonAncestor(h1, h2 handle) (*uint, error) {
+	var level C.nvmlGpuTopologyLevel_t
+
+	r := C.nvmlDeviceGetTopologyCommonAncestor_dl(h1.dev, h2.dev, &level)
+	if r == C.NVML_ERROR_FUNCTION_NOT_FOUND || r == C.NVML_ERROR_NOT_SUPPORTED {
+		return nil, nil
+	}
+	return uintPtr(C.uint(level)), errorString(r)
+}
+
+func (h handle) deviceGetName() (*string, error) {
+	var name [szName]C.char
+
+	r := C.nvmlDeviceGetName(h.dev, &name[0], szName)
+	if r == C.NVML_ERROR_NOT_SUPPORTED {
+		return nil, nil
+	}
+	return stringPtr(&name[0]), errorString(r)
+}
+
+func (h handle) deviceGetUUID() (*string, error) {
+	var uuid [szUUID]C.char
+
+	r := C.nvmlDeviceGetUUID(h.dev, &uuid[0], szUUID)
+	if r == C.NVML_ERROR_NOT_SUPPORTED {
+		return nil, nil
+	}
+	return stringPtr(&uuid[0]), errorString(r)
+}
+
+func (h handle) deviceGetPciInfo() (*string, error) {
+	var pci C.nvmlPciInfo_t
+
+	r := C.nvmlDeviceGetPciInfo(h.dev, &pci)
+	if r == C.NVML_ERROR_NOT_SUPPORTED {
+		return nil, nil
+	}
+	return stringPtr(&pci.busId[0]), errorString(r)
+}
+
+func (h handle) deviceGetMinorNumber() (*uint, error) {
+	var minor C.uint
+
+	r := C.nvmlDeviceGetMinorNumber(h.dev, &minor)
+	if r == C.NVML_ERROR_NOT_SUPPORTED {
+		return nil, nil
+	}
+	return uintPtr(minor), errorString(r)
+}
+
+func (h handle) deviceGetBAR1MemoryInfo() (*uint64, *uint64, error) {
+	var bar1 C.nvmlBAR1Memory_t
+
+	r := C.nvmlDeviceGetBAR1MemoryInfo(h.dev, &bar1)
+	if r == C.NVML_ERROR_NOT_SUPPORTED {
+		return nil, nil, nil
+	}
+	return uint64Ptr(bar1.bar1Total), uint64Ptr(bar1.bar1Used), errorString(r)
+}
+
+func (h handle) deviceGetPowerManagementLimit() (*uint, error) {
+	var power C.uint
+
+	r := C.nvmlDeviceGetPowerManagementLimit(h.dev, &power)
+	if r == C.NVML_ERROR_NOT_SUPPORTED {
+		return nil, nil
+	}
+	return uintPtr(power), errorString(r)
+}
+
+func (h handle) deviceGetMaxClockInfo() (*uint, *uint, error) {
+	var sm, mem C.uint
+
+	r := C.nvmlDeviceGetMaxClockInfo(h.dev, C.NVML_CLOCK_SM, &sm)
+	if r == C.NVML_ERROR_NOT_SUPPORTED {
+		return nil, nil, nil
+	}
+	if r == C.NVML_SUCCESS {
+		r = C.nvmlDeviceGetMaxClockInfo(h.dev, C.NVML_CLOCK_MEM, &mem)
+	}
+	return uintPtr(sm), uintPtr(mem), errorString(r)
+}
+
+func (h handle) deviceGetMaxPcieLinkGeneration() (*uint, error) {
+	var link C.uint
+
+	r := C.nvmlDeviceGetMaxPcieLinkGeneration(h.dev, &link)
+	if r == C.NVML_ERROR_NOT_SUPPORTED {
+		return nil, nil
+	}
+	return uintPtr(link), errorString(r)
+}
+
+func (h handle) deviceGetMaxPcieLinkWidth() (*uint, error) {
+	var width C.uint
+
+	r := C.nvmlDeviceGetMaxPcieLinkWidth(h.dev, &width)
+	if r == C.NVML_ERROR_NOT_SUPPORTED {
+		return nil, nil
+	}
+	return uintPtr(width), errorString(r)
+}
+
+func (h handle) deviceGetPowerUsage() (*uint, error) {
+	var power C.uint
+
+	r := C.nvmlDeviceGetPowerUsage(h.dev, &power)
+	if r == C.NVML_ERROR_NOT_SUPPORTED {
+		return nil, nil
+	}
+	return uintPtr(power), errorString(r)
+}
+
+func (h handle) deviceGetTemperature() (*uint, error) {
+	var temp C.uint
+
+	r := C.nvmlDeviceGetTemperature(h.dev, C.NVML_TEMPERATURE_GPU, &temp)
+	if r == C.NVML_ERROR_NOT_SUPPORTED {
+		return nil, nil
+	}
+	return uintPtr(temp), errorString(r)
+}
+
+func (h handle) deviceGetUtilizationRates() (*uint, *uint, error) {
+	var usage C.nvmlUtilization_t
+
+	r := C.nvmlDeviceGetUtilizationRates(h.dev, &usage)
+	if r == C.NVML_ERROR_NOT_SUPPORTED {
+		return nil, nil, nil
+	}
+	return uintPtr(usage.gpu), uintPtr(usage.memory), errorString(r)
+}
+
+func (h handle) deviceGetEncoderUtilization() (*uint, error) {
+	var usage, sampling C.uint
+
+	r := C.nvmlDeviceGetEncoderUtilization(h.dev, &usage, &sampling)
+	if r == C.NVML_ERROR_NOT_SUPPORTED {
+		return nil, nil
+	}
+	return uintPtr(usage), errorString(r)
+}
+
+func (h handle) deviceGetDecoderUtilization() (*uint, error) {
+	var usage, sampling C.uint
+
+	r := C.nvmlDeviceGetDecoderUtilization(h.dev, &usage, &sampling)
+	if r == C.NVML_ERROR_NOT_SUPPORTED {
+		return nil, nil
+	}
+	return uintPtr(usage), errorString(r)
+}
+
+func (h handle) deviceGetMemoryInfo() (*uint64, error) {
+	var mem C.nvmlMemory_t
+
+	r := C.nvmlDeviceGetMemoryInfo(h.dev, &mem)
+	if r == C.NVML_ERROR_NOT_SUPPORTED {
+		return nil, nil
+	}
+	return uint64Ptr(mem.used), errorString(r)
+}
+
+func (h handle) deviceGetClockInfo() (*uint, *uint, error) {
+	var sm, mem C.uint
+
+	r := C.nvmlDeviceGetClockInfo(h.dev, C.NVML_CLOCK_SM, &sm)
+	if r == C.NVML_ERROR_NOT_SUPPORTED {
+		return nil, nil, nil
+	}
+	if r == C.NVML_SUCCESS {
+		r = C.nvmlDeviceGetClockInfo(h.dev, C.NVML_CLOCK_MEM, &mem)
+	}
+	return uintPtr(sm), uintPtr(mem), errorString(r)
+}
+
+func (h handle) deviceGetMemoryErrorCounter() (*uint64, *uint64, *uint64, error) {
+	var l1, l2, mem C.ulonglong
+
+	r := C.nvmlDeviceGetMemoryErrorCounter(h.dev, C.NVML_MEMORY_ERROR_TYPE_UNCORRECTED,
+		C.NVML_VOLATILE_ECC, C.NVML_MEMORY_LOCATION_L1_CACHE, &l1)
+	if r == C.NVML_ERROR_NOT_SUPPORTED {
+		return nil, nil, nil, nil
+	}
+	if r == C.NVML_SUCCESS {
+		r = C.nvmlDeviceGetMemoryErrorCounter(h.dev, C.NVML_MEMORY_ERROR_TYPE_UNCORRECTED,
+			C.NVML_VOLATILE_ECC, C.NVML_MEMORY_LOCATION_L2_CACHE, &l2)
+	}
+	if r == C.NVML_SUCCESS {
+		r = C.nvmlDeviceGetMemoryErrorCounter(h.dev, C.NVML_MEMORY_ERROR_TYPE_UNCORRECTED,
+			C.NVML_VOLATILE_ECC, C.NVML_MEMORY_LOCATION_DEVICE_MEMORY, &mem)
+	}
+	return uint64Ptr(l1), uint64Ptr(l2), uint64Ptr(mem), errorString(r)
+}
+
+func (h handle) deviceGetPcieThroughput() (*uint, *uint, error) {
+	var rx, tx C.uint
+
+	r := C.nvmlDeviceGetPcieThroughput(h.dev, C.NVML_PCIE_UTIL_RX_BYTES, &rx)
+	if r == C.NVML_ERROR_NOT_SUPPORTED {
+		return nil, nil, nil
+	}
+	if r == C.NVML_SUCCESS {
+		r = C.nvmlDeviceGetPcieThroughput(h.dev, C.NVML_PCIE_UTIL_TX_BYTES, &tx)
+	}
+	return uintPtr(rx), uintPtr(tx), errorString(r)
+}
+
+func (h handle) deviceGetComputeRunningProcesses() ([]uint, []uint64, error) {
+	var procs [szProcs]C.nvmlProcessInfo_t
+	var count = C.uint(szProcs)
+
+	r := C.nvmlDeviceGetComputeRunningProcesses(h.dev, &count, &procs[0])
+	if r == C.NVML_ERROR_NOT_SUPPORTED {
+		return nil, nil, nil
+	}
+	n := int(count)
+	pids := make([]uint, n)
+	mems := make([]uint64, n)
+	for i := 0; i < n; i++ {
+		pids[i] = uint(procs[i].pid)
+		mems[i] = uint64(procs[i].usedGpuMemory)
+	}
+	return pids, mems, errorString(r)
+}

--- a/vendor/github.com/NVIDIA/nvidia-docker/src/nvml/nvml.go
+++ b/vendor/github.com/NVIDIA/nvidia-docker/src/nvml/nvml.go
@@ -1,0 +1,381 @@
+// Copyright (c) 2015-2016, NVIDIA CORPORATION. All rights reserved.
+
+package nvml
+
+// #include "nvml_dl.h"
+import "C"
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"strconv"
+	"strings"
+)
+
+var (
+	ErrCPUAffinity        = errors.New("failed to retrieve CPU affinity")
+	ErrUnsupportedP2PLink = errors.New("unsupported P2P link type")
+	ErrUnsupportedGPU     = errors.New("unsupported GPU device")
+)
+
+type P2PLinkType uint
+
+const (
+	P2PLinkUnknown P2PLinkType = iota
+	P2PLinkCrossCPU
+	P2PLinkSameCPU
+	P2PLinkHostBridge
+	P2PLinkMultiSwitch
+	P2PLinkSingleSwitch
+	P2PLinkSameBoard
+)
+
+type P2PLink struct {
+	BusID string
+	Link  P2PLinkType
+}
+
+func (t P2PLinkType) String() string {
+	switch t {
+	case P2PLinkCrossCPU:
+		return "Cross CPU socket"
+	case P2PLinkSameCPU:
+		return "Same CPU socket"
+	case P2PLinkHostBridge:
+		return "Host PCI bridge"
+	case P2PLinkMultiSwitch:
+		return "Multiple PCI switches"
+	case P2PLinkSingleSwitch:
+		return "Single PCI switch"
+	case P2PLinkSameBoard:
+		return "Same board"
+	case P2PLinkUnknown:
+	}
+	return "N/A"
+}
+
+type ClockInfo struct {
+	Cores  *uint
+	Memory *uint
+}
+
+type PCIInfo struct {
+	BusID     string
+	BAR1      *uint64
+	Bandwidth *uint
+}
+
+type Device struct {
+	handle
+
+	UUID        string
+	Path        string
+	Model       *string
+	Power       *uint
+	CPUAffinity *uint
+	PCI         PCIInfo
+	Clocks      ClockInfo
+	Topology    []P2PLink
+}
+
+type UtilizationInfo struct {
+	GPU     *uint
+	Memory  *uint
+	Encoder *uint
+	Decoder *uint
+}
+
+type PCIThroughputInfo struct {
+	RX *uint
+	TX *uint
+}
+
+type PCIStatusInfo struct {
+	BAR1Used   *uint64
+	Throughput PCIThroughputInfo
+}
+
+type ECCErrorsInfo struct {
+	L1Cache *uint64
+	L2Cache *uint64
+	Global  *uint64
+}
+
+type MemoryInfo struct {
+	GlobalUsed *uint64
+	ECCErrors  ECCErrorsInfo
+}
+
+type ProcessInfo struct {
+	PID        uint
+	Name       string
+	MemoryUsed uint64
+}
+
+type DeviceStatus struct {
+	Power       *uint
+	Temperature *uint
+	Utilization UtilizationInfo
+	Memory      MemoryInfo
+	Clocks      ClockInfo
+	PCI         PCIStatusInfo
+	Processes   []ProcessInfo
+}
+
+func assert(err error) {
+	if err != nil {
+		panic(err)
+	}
+}
+
+func Init() error {
+	return init_()
+}
+
+func Shutdown() error {
+	return shutdown()
+}
+
+func GetDeviceCount() (uint, error) {
+	return deviceGetCount()
+}
+
+func GetDriverVersion() (string, error) {
+	return systemGetDriverVersion()
+}
+
+func numaNode(busid string) (uint, error) {
+	b, err := ioutil.ReadFile(fmt.Sprintf("/sys/bus/pci/devices/%s/numa_node", strings.ToLower(busid)))
+	if err != nil {
+		// XXX report node 0 if NUMA support isn't enabled
+		return 0, nil
+	}
+	node, err := strconv.ParseInt(string(bytes.TrimSpace(b)), 10, 8)
+	if err != nil {
+		return 0, fmt.Errorf("%v: %v", ErrCPUAffinity, err)
+	}
+	if node < 0 {
+		node = 0 // XXX report node 0 instead of NUMA_NO_NODE
+	}
+	return uint(node), nil
+}
+
+func pciBandwidth(gen, width *uint) *uint {
+	m := map[uint]uint{
+		1: 250, // MB/s
+		2: 500,
+		3: 985,
+		4: 1969,
+	}
+	if gen == nil || width == nil {
+		return nil
+	}
+	bw := m[*gen] * *width
+	return &bw
+}
+
+func NewDevice(idx uint) (device *Device, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = r.(error)
+		}
+	}()
+
+	h, err := deviceGetHandleByIndex(idx)
+	assert(err)
+	model, err := h.deviceGetName()
+	assert(err)
+	uuid, err := h.deviceGetUUID()
+	assert(err)
+	minor, err := h.deviceGetMinorNumber()
+	assert(err)
+	power, err := h.deviceGetPowerManagementLimit()
+	assert(err)
+	busid, err := h.deviceGetPciInfo()
+	assert(err)
+	bar1, _, err := h.deviceGetBAR1MemoryInfo()
+	assert(err)
+	pcig, err := h.deviceGetMaxPcieLinkGeneration()
+	assert(err)
+	pciw, err := h.deviceGetMaxPcieLinkWidth()
+	assert(err)
+	ccore, cmem, err := h.deviceGetMaxClockInfo()
+	assert(err)
+
+	if minor == nil || busid == nil || uuid == nil {
+		return nil, ErrUnsupportedGPU
+	}
+	path := fmt.Sprintf("/dev/nvidia%d", *minor)
+	node, err := numaNode(*busid)
+	assert(err)
+
+	device = &Device{
+		handle:      h,
+		UUID:        *uuid,
+		Path:        path,
+		Model:       model,
+		Power:       power,
+		CPUAffinity: &node,
+		PCI: PCIInfo{
+			BusID:     *busid,
+			BAR1:      bar1,
+			Bandwidth: pciBandwidth(pcig, pciw), // MB/s
+		},
+		Clocks: ClockInfo{
+			Cores:  ccore, // MHz
+			Memory: cmem,  // MHz
+		},
+	}
+	if power != nil {
+		*device.Power /= 1000 // W
+	}
+	if bar1 != nil {
+		*device.PCI.BAR1 /= 1024 * 1024 // MiB
+	}
+	return
+}
+
+func NewDeviceLite(idx uint) (device *Device, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = r.(error)
+		}
+	}()
+
+	h, err := deviceGetHandleByIndex(idx)
+	assert(err)
+	uuid, err := h.deviceGetUUID()
+	assert(err)
+	minor, err := h.deviceGetMinorNumber()
+	assert(err)
+	busid, err := h.deviceGetPciInfo()
+	assert(err)
+
+	if minor == nil || busid == nil || uuid == nil {
+		return nil, ErrUnsupportedGPU
+	}
+	path := fmt.Sprintf("/dev/nvidia%d", *minor)
+
+	device = &Device{
+		handle: h,
+		UUID:   *uuid,
+		Path:   path,
+		PCI: PCIInfo{
+			BusID: *busid,
+		},
+	}
+	return
+}
+
+func (d *Device) Status() (status *DeviceStatus, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = r.(error)
+		}
+	}()
+
+	power, err := d.deviceGetPowerUsage()
+	assert(err)
+	temp, err := d.deviceGetTemperature()
+	assert(err)
+	ugpu, umem, err := d.deviceGetUtilizationRates()
+	assert(err)
+	uenc, err := d.deviceGetEncoderUtilization()
+	assert(err)
+	udec, err := d.deviceGetDecoderUtilization()
+	assert(err)
+	mem, err := d.deviceGetMemoryInfo()
+	assert(err)
+	ccore, cmem, err := d.deviceGetClockInfo()
+	assert(err)
+	_, bar1, err := d.deviceGetBAR1MemoryInfo()
+	assert(err)
+	pids, pmems, err := d.deviceGetComputeRunningProcesses()
+	assert(err)
+	el1, el2, emem, err := d.deviceGetMemoryErrorCounter()
+	assert(err)
+	pcirx, pcitx, err := d.deviceGetPcieThroughput()
+	assert(err)
+
+	status = &DeviceStatus{
+		Power:       power,
+		Temperature: temp, // °C
+		Utilization: UtilizationInfo{
+			GPU:     ugpu, // %
+			Memory:  umem, // %
+			Encoder: uenc, // %
+			Decoder: udec, // %
+		},
+		Memory: MemoryInfo{
+			GlobalUsed: mem,
+			ECCErrors: ECCErrorsInfo{
+				L1Cache: el1,
+				L2Cache: el2,
+				Global:  emem,
+			},
+		},
+		Clocks: ClockInfo{
+			Cores:  ccore, // MHz
+			Memory: cmem,  // MHz
+		},
+		PCI: PCIStatusInfo{
+			BAR1Used: bar1,
+			Throughput: PCIThroughputInfo{
+				RX: pcirx,
+				TX: pcitx,
+			},
+		},
+	}
+	if power != nil {
+		*status.Power /= 1000 // W
+	}
+	if mem != nil {
+		*status.Memory.GlobalUsed /= 1024 * 1024 // MiB
+	}
+	if bar1 != nil {
+		*status.PCI.BAR1Used /= 1024 * 1024 // MiB
+	}
+	if pcirx != nil {
+		*status.PCI.Throughput.RX /= 1000 // MB/s
+	}
+	if pcitx != nil {
+		*status.PCI.Throughput.TX /= 1000 // MB/s
+	}
+	for i := range pids {
+		name, err := systemGetProcessName(pids[i])
+		assert(err)
+		status.Processes = append(status.Processes, ProcessInfo{
+			PID:        pids[i],
+			Name:       name,
+			MemoryUsed: pmems[i] / (1024 * 1024), // MiB
+		})
+	}
+	return
+}
+
+func GetP2PLink(dev1, dev2 *Device) (link P2PLinkType, err error) {
+	level, err := deviceGetTopologyCommonAncestor(dev1.handle, dev2.handle)
+	if err != nil || level == nil {
+		return P2PLinkUnknown, err
+	}
+
+	switch *level {
+	case C.NVML_TOPOLOGY_INTERNAL:
+		link = P2PLinkSameBoard
+	case C.NVML_TOPOLOGY_SINGLE:
+		link = P2PLinkSingleSwitch
+	case C.NVML_TOPOLOGY_MULTIPLE:
+		link = P2PLinkMultiSwitch
+	case C.NVML_TOPOLOGY_HOSTBRIDGE:
+		link = P2PLinkHostBridge
+	case C.NVML_TOPOLOGY_CPU:
+		link = P2PLinkSameCPU
+	case C.NVML_TOPOLOGY_SYSTEM:
+		link = P2PLinkCrossCPU
+	default:
+		err = ErrUnsupportedP2PLink
+	}
+	return
+}

--- a/vendor/github.com/NVIDIA/nvidia-docker/src/nvml/nvml_dl.c
+++ b/vendor/github.com/NVIDIA/nvidia-docker/src/nvml/nvml_dl.c
@@ -1,0 +1,46 @@
+// Copyright (c) 2015-2016, NVIDIA CORPORATION. All rights reserved.
+
+#include <stddef.h>
+#include <dlfcn.h>
+
+#include "nvml_dl.h"
+
+#define DLSYM(x, sym)                           \
+do {                                            \
+    dlerror();				        \
+    x = dlsym(handle, #sym);                    \
+    if (dlerror() != NULL) {                    \
+        return (NVML_ERROR_FUNCTION_NOT_FOUND); \
+    }                                           \
+} while (0)
+
+typedef nvmlReturn_t (*nvmlSym_t)();
+
+static void *handle;
+
+nvmlReturn_t NVML_DL(nvmlInit)(void)
+{
+    handle = dlopen("libnvidia-ml.so.1", RTLD_LAZY | RTLD_GLOBAL);
+    if (handle == NULL) {
+	return (NVML_ERROR_LIBRARY_NOT_FOUND);
+    }
+    return (nvmlInit());
+}
+
+nvmlReturn_t NVML_DL(nvmlShutdown)(void)
+{
+    nvmlReturn_t r = nvmlShutdown();
+    if (r != NVML_SUCCESS) {
+	return (r);
+    }
+    return (dlclose(handle) ? NVML_ERROR_UNKNOWN : NVML_SUCCESS);
+}
+
+nvmlReturn_t NVML_DL(nvmlDeviceGetTopologyCommonAncestor)(
+  nvmlDevice_t dev1, nvmlDevice_t dev2, nvmlGpuTopologyLevel_t *info)
+{
+    nvmlSym_t sym;
+
+    DLSYM(sym, nvmlDeviceGetTopologyCommonAncestor);
+    return ((*sym)(dev1, dev2, info));
+}

--- a/vendor/github.com/NVIDIA/nvidia-docker/src/nvml/nvml_dl.h
+++ b/vendor/github.com/NVIDIA/nvidia-docker/src/nvml/nvml_dl.h
@@ -1,0 +1,15 @@
+// Copyright (c) 2015-2016, NVIDIA CORPORATION. All rights reserved.
+
+#ifndef _NVML_DL_H_
+#define _NVML_DL_H_
+
+#include <nvml.h>
+
+#define NVML_DL(x) x##_dl
+
+extern nvmlReturn_t NVML_DL(nvmlInit)(void);
+extern nvmlReturn_t NVML_DL(nvmlShutdown)(void);
+extern nvmlReturn_t NVML_DL(nvmlDeviceGetTopologyCommonAncestor)(
+  nvmlDevice_t, nvmlDevice_t, nvmlGpuTopologyLevel_t *);
+
+#endif // _NVML_DL_H_

--- a/vendor/github.com/coreos/go-systemd/activation/files.go
+++ b/vendor/github.com/coreos/go-systemd/activation/files.go
@@ -1,0 +1,52 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package activation implements primitives for systemd socket activation.
+package activation
+
+import (
+	"os"
+	"strconv"
+	"syscall"
+)
+
+// based on: https://gist.github.com/alberts/4640792
+const (
+	listenFdsStart = 3
+)
+
+func Files(unsetEnv bool) []*os.File {
+	if unsetEnv {
+		defer os.Unsetenv("LISTEN_PID")
+		defer os.Unsetenv("LISTEN_FDS")
+	}
+
+	pid, err := strconv.Atoi(os.Getenv("LISTEN_PID"))
+	if err != nil || pid != os.Getpid() {
+		return nil
+	}
+
+	nfds, err := strconv.Atoi(os.Getenv("LISTEN_FDS"))
+	if err != nil || nfds == 0 {
+		return nil
+	}
+
+	files := make([]*os.File, 0, nfds)
+	for fd := listenFdsStart; fd < listenFdsStart+nfds; fd++ {
+		syscall.CloseOnExec(fd)
+		files = append(files, os.NewFile(uintptr(fd), "LISTEN_FD_"+strconv.Itoa(fd)))
+	}
+
+	return files
+}

--- a/vendor/github.com/coreos/go-systemd/activation/listeners.go
+++ b/vendor/github.com/coreos/go-systemd/activation/listeners.go
@@ -1,0 +1,60 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package activation
+
+import (
+	"crypto/tls"
+	"net"
+)
+
+// Listeners returns a slice containing a net.Listener for each matching socket type
+// passed to this process.
+//
+// The order of the file descriptors is preserved in the returned slice.
+// Nil values are used to fill any gaps. For example if systemd were to return file descriptors
+// corresponding with "udp, tcp, tcp", then the slice would contain {nil, net.Listener, net.Listener}
+func Listeners(unsetEnv bool) ([]net.Listener, error) {
+	files := Files(unsetEnv)
+	listeners := make([]net.Listener, len(files))
+
+	for i, f := range files {
+		if pc, err := net.FileListener(f); err == nil {
+			listeners[i] = pc
+		}
+	}
+	return listeners, nil
+}
+
+// TLSListeners returns a slice containing a net.listener for each matching TCP socket type
+// passed to this process.
+// It uses default Listeners func and forces TCP sockets handlers to use TLS based on tlsConfig.
+func TLSListeners(unsetEnv bool, tlsConfig *tls.Config) ([]net.Listener, error) {
+	listeners, err := Listeners(unsetEnv)
+
+	if listeners == nil || err != nil {
+		return nil, err
+	}
+
+	if tlsConfig != nil && err == nil {
+		for i, l := range listeners {
+			// Activate TLS only for TCP sockets
+			if l.Addr().Network() == "tcp" {
+				listeners[i] = tls.NewListener(l, tlsConfig)
+			}
+		}
+	}
+
+	return listeners, err
+}

--- a/vendor/github.com/coreos/go-systemd/activation/packetconns.go
+++ b/vendor/github.com/coreos/go-systemd/activation/packetconns.go
@@ -1,0 +1,37 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package activation
+
+import (
+	"net"
+)
+
+// PacketConns returns a slice containing a net.PacketConn for each matching socket type
+// passed to this process.
+//
+// The order of the file descriptors is preserved in the returned slice.
+// Nil values are used to fill any gaps. For example if systemd were to return file descriptors
+// corresponding with "udp, tcp, udp", then the slice would contain {net.PacketConn, nil, net.PacketConn}
+func PacketConns(unsetEnv bool) ([]net.PacketConn, error) {
+	files := Files(unsetEnv)
+	conns := make([]net.PacketConn, len(files))
+
+	for i, f := range files {
+		if pc, err := net.FilePacketConn(f); err == nil {
+			conns[i] = pc
+		}
+	}
+	return conns, nil
+}

--- a/vendor/github.com/docker/go-plugins-helpers/LICENSE
+++ b/vendor/github.com/docker/go-plugins-helpers/LICENSE
@@ -1,0 +1,202 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+

--- a/vendor/github.com/docker/go-plugins-helpers/NOTICE
+++ b/vendor/github.com/docker/go-plugins-helpers/NOTICE
@@ -1,0 +1,19 @@
+Docker
+Copyright 2012-2015 Docker, Inc.
+
+This product includes software developed at Docker, Inc. (https://www.docker.com).
+
+This product contains software (https://github.com/kr/pty) developed
+by Keith Rarick, licensed under the MIT License.
+
+The following is courtesy of our legal counsel:
+
+
+Use and transfer of Docker may be subject to certain restrictions by the
+United States and other governments.
+It is your responsibility to ensure that your use and/or transfer does not
+violate applicable laws.
+
+For more information, please see https://www.bis.doc.gov
+
+See also https://www.apache.org/dev/crypto.html and/or seek legal counsel.

--- a/vendor/github.com/docker/go-plugins-helpers/sdk/encoder.go
+++ b/vendor/github.com/docker/go-plugins-helpers/sdk/encoder.go
@@ -1,0 +1,37 @@
+package sdk
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+// DefaultContentTypeV1_1 is the default content type accepted and sent by the plugins.
+const DefaultContentTypeV1_1 = "application/vnd.docker.plugins.v1.1+json"
+
+// DecodeRequest decodes an http request into a given structure.
+func DecodeRequest(w http.ResponseWriter, r *http.Request, req interface{}) (err error) {
+	if err = json.NewDecoder(r.Body).Decode(req); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+	}
+	return
+}
+
+// EncodeResponse encodes the given structure into an http response.
+func EncodeResponse(w http.ResponseWriter, res interface{}, err bool) {
+	w.Header().Set("Content-Type", DefaultContentTypeV1_1)
+	if err {
+		w.WriteHeader(http.StatusInternalServerError)
+	}
+	json.NewEncoder(w).Encode(res)
+}
+
+// StreamResponse streams a response object to the client
+func StreamResponse(w http.ResponseWriter, data io.ReadCloser) {
+	w.Header().Set("Content-Type", DefaultContentTypeV1_1)
+	if _, err := copyBuf(w, data); err != nil {
+		fmt.Printf("ERROR in stream: %v\n", err)
+	}
+	data.Close()
+}

--- a/vendor/github.com/docker/go-plugins-helpers/sdk/handler.go
+++ b/vendor/github.com/docker/go-plugins-helpers/sdk/handler.go
@@ -1,0 +1,88 @@
+package sdk
+
+import (
+	"crypto/tls"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+)
+
+const activatePath = "/Plugin.Activate"
+
+// Handler is the base to create plugin handlers.
+// It initializes connections and sockets to listen to.
+type Handler struct {
+	mux *http.ServeMux
+}
+
+// NewHandler creates a new Handler with an http mux.
+func NewHandler(manifest string) Handler {
+	mux := http.NewServeMux()
+
+	mux.HandleFunc(activatePath, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", DefaultContentTypeV1_1)
+		fmt.Fprintln(w, manifest)
+	})
+
+	return Handler{mux: mux}
+}
+
+// Serve sets up the handler to serve requests on the passed in listener
+func (h Handler) Serve(l net.Listener) error {
+	server := http.Server{
+		Addr:    l.Addr().String(),
+		Handler: h.mux,
+	}
+	return server.Serve(l)
+}
+
+// ServeTCP makes the handler to listen for request in a given TCP address.
+// It also writes the spec file in the right directory for docker to read.
+// Due to constrains for running Docker in Docker on Windows, data-root directory
+// of docker daemon must be provided. To get default directory, use
+// WindowsDefaultDaemonRootDir() function. On Unix, this parameter is ignored.
+func (h Handler) ServeTCP(pluginName, addr, daemonDir string, tlsConfig *tls.Config) error {
+	l, spec, err := newTCPListener(addr, pluginName, daemonDir, tlsConfig)
+	if err != nil {
+		return err
+	}
+	if spec != "" {
+		defer os.Remove(spec)
+	}
+	return h.Serve(l)
+}
+
+// ServeUnix makes the handler to listen for requests in a unix socket.
+// It also creates the socket file in the right directory for docker to read.
+func (h Handler) ServeUnix(addr string, gid int) error {
+	l, spec, err := newUnixListener(addr, gid)
+	if err != nil {
+		return err
+	}
+	if spec != "" {
+		defer os.Remove(spec)
+	}
+	return h.Serve(l)
+}
+
+// ServeWindows makes the handler to listen for request in a Windows named pipe.
+// It also creates the spec file in the right directory for docker to read.
+// Due to constrains for running Docker in Docker on Windows, data-root directory
+// of docker daemon must be provided. To get default directory, use
+// WindowsDefaultDaemonRootDir() function. On Unix, this parameter is ignored.
+func (h Handler) ServeWindows(addr, pluginName, daemonDir string, pipeConfig *WindowsPipeConfig) error {
+	l, spec, err := newWindowsListener(addr, pluginName, daemonDir, pipeConfig)
+	if err != nil {
+		return err
+	}
+	if spec != "" {
+		defer os.Remove(spec)
+	}
+	return h.Serve(l)
+}
+
+// HandleFunc registers a function to handle a request path with.
+func (h Handler) HandleFunc(path string, fn func(w http.ResponseWriter, r *http.Request)) {
+	h.mux.HandleFunc(path, fn)
+}

--- a/vendor/github.com/docker/go-plugins-helpers/sdk/pool.go
+++ b/vendor/github.com/docker/go-plugins-helpers/sdk/pool.go
@@ -1,0 +1,18 @@
+package sdk
+
+import (
+	"io"
+	"sync"
+)
+
+const buffer32K = 32 * 1024
+
+var buffer32KPool = &sync.Pool{New: func() interface{} { return make([]byte, buffer32K) }}
+
+// copyBuf uses a shared buffer pool with io.CopyBuffer
+func copyBuf(w io.Writer, r io.Reader) (int64, error) {
+	buf := buffer32KPool.Get().([]byte)
+	written, err := io.CopyBuffer(w, r, buf)
+	buffer32KPool.Put(buf)
+	return written, err
+}

--- a/vendor/github.com/docker/go-plugins-helpers/sdk/spec_file_generator.go
+++ b/vendor/github.com/docker/go-plugins-helpers/sdk/spec_file_generator.go
@@ -1,0 +1,58 @@
+package sdk
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+)
+
+type protocol string
+
+const (
+	protoTCP       protocol = "tcp"
+	protoNamedPipe protocol = "npipe"
+)
+
+// PluginSpecDir returns plugin spec dir in relation to daemon root directory.
+func PluginSpecDir(daemonRoot string) string {
+	return ([]string{filepath.Join(daemonRoot, "plugins")})[0]
+}
+
+// WindowsDefaultDaemonRootDir returns default data directory of docker daemon on Windows.
+func WindowsDefaultDaemonRootDir() string {
+	return filepath.Join(os.Getenv("programdata"), "docker")
+}
+
+func createPluginSpecDirWindows(name, address, daemonRoot string) (string, error) {
+	_, err := os.Stat(daemonRoot)
+	if os.IsNotExist(err) {
+		return "", fmt.Errorf("Deamon root directory must already exist: %s", err)
+	}
+
+	pluginSpecDir := PluginSpecDir(daemonRoot)
+
+	if err := windowsCreateDirectoryWithACL(pluginSpecDir); err != nil {
+		return "", err
+	}
+	return pluginSpecDir, nil
+}
+
+func createPluginSpecDirUnix(name, address string) (string, error) {
+	pluginSpecDir := PluginSpecDir("/etc/docker")
+	if err := os.MkdirAll(pluginSpecDir, 0755); err != nil {
+		return "", err
+	}
+	return pluginSpecDir, nil
+}
+
+func writeSpecFile(name, address, pluginSpecDir string, proto protocol) (string, error) {
+	specFileDir := filepath.Join(pluginSpecDir, name+".spec")
+
+	url := string(proto) + "://" + address
+	if err := ioutil.WriteFile(specFileDir, []byte(url), 0644); err != nil {
+		return "", err
+	}
+
+	return specFileDir, nil
+}

--- a/vendor/github.com/docker/go-plugins-helpers/sdk/tcp_listener.go
+++ b/vendor/github.com/docker/go-plugins-helpers/sdk/tcp_listener.go
@@ -1,0 +1,34 @@
+package sdk
+
+import (
+	"crypto/tls"
+	"net"
+	"runtime"
+
+	"github.com/docker/go-connections/sockets"
+)
+
+func newTCPListener(address, pluginName, daemonDir string, tlsConfig *tls.Config) (net.Listener, string, error) {
+	listener, err := sockets.NewTCPSocket(address, tlsConfig)
+	if err != nil {
+		return nil, "", err
+	}
+
+	addr := listener.Addr().String()
+
+	var specDir string
+	if runtime.GOOS == "windows" {
+		specDir, err = createPluginSpecDirWindows(pluginName, addr, daemonDir)
+	} else {
+		specDir, err = createPluginSpecDirUnix(pluginName, addr)
+	}
+	if err != nil {
+		return nil, "", err
+	}
+
+	specFile, err := writeSpecFile(pluginName, addr, specDir, protoTCP)
+	if err != nil {
+		return nil, "", err
+	}
+	return listener, specFile, nil
+}

--- a/vendor/github.com/docker/go-plugins-helpers/sdk/unix_listener.go
+++ b/vendor/github.com/docker/go-plugins-helpers/sdk/unix_listener.go
@@ -1,0 +1,35 @@
+// +build linux freebsd
+
+package sdk
+
+import (
+	"net"
+	"os"
+	"path/filepath"
+
+	"github.com/docker/go-connections/sockets"
+)
+
+const pluginSockDir = "/run/docker/plugins"
+
+func newUnixListener(pluginName string, gid int) (net.Listener, string, error) {
+	path, err := fullSocketAddress(pluginName)
+	if err != nil {
+		return nil, "", err
+	}
+	listener, err := sockets.NewUnixSocket(path, gid)
+	if err != nil {
+		return nil, "", err
+	}
+	return listener, path, nil
+}
+
+func fullSocketAddress(address string) (string, error) {
+	if err := os.MkdirAll(pluginSockDir, 0755); err != nil {
+		return "", err
+	}
+	if filepath.IsAbs(address) {
+		return address, nil
+	}
+	return filepath.Join(pluginSockDir, address+".sock"), nil
+}

--- a/vendor/github.com/docker/go-plugins-helpers/sdk/unix_listener_nosystemd.go
+++ b/vendor/github.com/docker/go-plugins-helpers/sdk/unix_listener_nosystemd.go
@@ -1,0 +1,10 @@
+// +build linux freebsd
+// +build nosystemd
+
+package sdk
+
+import "net"
+
+func setupSocketActivation() (net.Listener, error) {
+	return nil, nil
+}

--- a/vendor/github.com/docker/go-plugins-helpers/sdk/unix_listener_systemd.go
+++ b/vendor/github.com/docker/go-plugins-helpers/sdk/unix_listener_systemd.go
@@ -1,0 +1,45 @@
+// +build linux freebsd
+// +build !nosystemd
+
+package sdk
+
+import (
+	"fmt"
+	"net"
+	"os"
+
+	"github.com/coreos/go-systemd/activation"
+)
+
+// isRunningSystemd checks whether the host was booted with systemd as its init
+// system. This functions similarly to systemd's `sd_booted(3)`: internally, it
+// checks whether /run/systemd/system/ exists and is a directory.
+// http://www.freedesktop.org/software/systemd/man/sd_booted.html
+//
+// Copied from github.com/coreos/go-systemd/util.IsRunningSystemd
+func isRunningSystemd() bool {
+	fi, err := os.Lstat("/run/systemd/system")
+	if err != nil {
+		return false
+	}
+	return fi.IsDir()
+}
+
+func setupSocketActivation() (net.Listener, error) {
+	if !isRunningSystemd() {
+		return nil, nil
+	}
+	listenFds := activation.Files(false)
+	if len(listenFds) > 1 {
+		return nil, fmt.Errorf("expected only one socket from systemd, got %d", len(listenFds))
+	}
+	var listener net.Listener
+	if len(listenFds) == 1 {
+		l, err := net.FileListener(listenFds[0])
+		if err != nil {
+			return nil, err
+		}
+		listener = l
+	}
+	return listener, nil
+}

--- a/vendor/github.com/docker/go-plugins-helpers/sdk/unix_listener_unsupported.go
+++ b/vendor/github.com/docker/go-plugins-helpers/sdk/unix_listener_unsupported.go
@@ -1,0 +1,16 @@
+// +build !linux,!freebsd
+
+package sdk
+
+import (
+	"errors"
+	"net"
+)
+
+var (
+	errOnlySupportedOnLinuxAndFreeBSD = errors.New("unix socket creation is only supported on Linux and FreeBSD")
+)
+
+func newUnixListener(pluginName string, gid int) (net.Listener, string, error) {
+	return nil, "", errOnlySupportedOnLinuxAndFreeBSD
+}

--- a/vendor/github.com/docker/go-plugins-helpers/sdk/windows_listener.go
+++ b/vendor/github.com/docker/go-plugins-helpers/sdk/windows_listener.go
@@ -1,0 +1,70 @@
+// +build windows
+
+package sdk
+
+import (
+	"net"
+	"os"
+	"syscall"
+	"unsafe"
+
+	"github.com/Microsoft/go-winio"
+)
+
+// Named pipes use Windows Security Descriptor Definition Language to define ACL. Following are
+// some useful definitions.
+const (
+	// This will set permissions for everyone to have full access
+	AllowEveryone = "S:(ML;;NW;;;LW)D:(A;;0x12019f;;;WD)"
+
+	// This will set permissions for Service, System, Adminstrator group and account to have full access
+	AllowServiceSystemAdmin = "D:(A;ID;FA;;;SY)(A;ID;FA;;;BA)(A;ID;FA;;;LA)(A;ID;FA;;;LS)"
+)
+
+func newWindowsListener(address, pluginName, daemonRoot string, pipeConfig *WindowsPipeConfig) (net.Listener, string, error) {
+	winioPipeConfig := winio.PipeConfig{
+		SecurityDescriptor: pipeConfig.SecurityDescriptor,
+		InputBufferSize:    pipeConfig.InBufferSize,
+		OutputBufferSize:   pipeConfig.OutBufferSize,
+	}
+	listener, err := winio.ListenPipe(address, &winioPipeConfig)
+	if err != nil {
+		return nil, "", err
+	}
+
+	addr := listener.Addr().String()
+
+	specDir, err := createPluginSpecDirWindows(pluginName, addr, daemonRoot)
+	if err != nil {
+		return nil, "", err
+	}
+
+	spec, err := writeSpecFile(pluginName, addr, specDir, protoNamedPipe)
+	if err != nil {
+		return nil, "", err
+	}
+	return listener, spec, nil
+}
+
+func windowsCreateDirectoryWithACL(name string) error {
+	sa := syscall.SecurityAttributes{Length: 0}
+	sddl := "D:P(A;OICI;GA;;;BA)(A;OICI;GA;;;SY)"
+	sd, err := winio.SddlToSecurityDescriptor(sddl)
+	if err != nil {
+		return &os.PathError{Op: "mkdir", Path: name, Err: err}
+	}
+	sa.Length = uint32(unsafe.Sizeof(sa))
+	sa.InheritHandle = 1
+	sa.SecurityDescriptor = uintptr(unsafe.Pointer(&sd[0]))
+
+	namep, err := syscall.UTF16PtrFromString(name)
+	if err != nil {
+		return &os.PathError{Op: "mkdir", Path: name, Err: err}
+	}
+
+	e := syscall.CreateDirectory(namep, &sa)
+	if e != nil {
+		return &os.PathError{Op: "mkdir", Path: name, Err: e}
+	}
+	return nil
+}

--- a/vendor/github.com/docker/go-plugins-helpers/sdk/windows_listener_unsupported.go
+++ b/vendor/github.com/docker/go-plugins-helpers/sdk/windows_listener_unsupported.go
@@ -1,0 +1,20 @@
+// +build !windows
+
+package sdk
+
+import (
+	"errors"
+	"net"
+)
+
+var (
+	errOnlySupportedOnWindows = errors.New("named pipe creation is only supported on Windows")
+)
+
+func newWindowsListener(address, pluginName, daemonRoot string, pipeConfig *WindowsPipeConfig) (net.Listener, string, error) {
+	return nil, "", errOnlySupportedOnWindows
+}
+
+func windowsCreateDirectoryWithACL(name string) error {
+	return nil
+}

--- a/vendor/github.com/docker/go-plugins-helpers/sdk/windows_pipe_config.go
+++ b/vendor/github.com/docker/go-plugins-helpers/sdk/windows_pipe_config.go
@@ -1,0 +1,13 @@
+package sdk
+
+// WindowsPipeConfig is a helper structure for configuring named pipe parameters on Windows.
+type WindowsPipeConfig struct {
+	// SecurityDescriptor contains a Windows security descriptor in SDDL format.
+	SecurityDescriptor string
+
+	// InBufferSize in bytes.
+	InBufferSize int32
+
+	// OutBufferSize in bytes.
+	OutBufferSize int32
+}

--- a/vendor/github.com/docker/go-plugins-helpers/volume/README.md
+++ b/vendor/github.com/docker/go-plugins-helpers/volume/README.md
@@ -1,0 +1,35 @@
+# Docker volume extension api.
+
+Go handler to create external volume extensions for Docker.
+
+## Usage
+
+This library is designed to be integrated in your program.
+
+1. Implement the `volume.Driver` interface.
+2. Initialize a `volume.Handler` with your implementation.
+3. Call either `ServeTCP` or `ServeUnix` from the `volume.Handler`.
+
+### Example using TCP sockets:
+
+```go
+  d := MyVolumeDriver{}
+  h := volume.NewHandler(d)
+  h.ServeTCP("test_volume", ":8080")
+```
+
+### Example using Unix sockets:
+
+```go
+  d := MyVolumeDriver{}
+  h := volume.NewHandler(d)
+  u, _ := user.Lookup("root")
+  gid, _ := strconv.Atoi(u.Gid)
+  h.ServeUnix("test_volume", gid)
+```
+
+## Full example plugins
+
+- https://github.com/calavera/docker-volume-glusterfs
+- https://github.com/calavera/docker-volume-keywhiz
+- https://github.com/quobyte/docker-volume

--- a/vendor/github.com/docker/go-plugins-helpers/volume/api.go
+++ b/vendor/github.com/docker/go-plugins-helpers/volume/api.go
@@ -1,0 +1,229 @@
+package volume
+
+import (
+	"log"
+	"net/http"
+
+	"github.com/docker/go-plugins-helpers/sdk"
+)
+
+const (
+	// DefaultDockerRootDirectory is the default directory where volumes will be created.
+	DefaultDockerRootDirectory = "/var/lib/docker-volumes"
+
+	manifest         = `{"Implements": ["VolumeDriver"]}`
+	createPath       = "/VolumeDriver.Create"
+	getPath          = "/VolumeDriver.Get"
+	listPath         = "/VolumeDriver.List"
+	removePath       = "/VolumeDriver.Remove"
+	hostVirtualPath  = "/VolumeDriver.Path"
+	mountPath        = "/VolumeDriver.Mount"
+	unmountPath      = "/VolumeDriver.Unmount"
+	capabilitiesPath = "/VolumeDriver.Capabilities"
+)
+
+// CreateRequest is the structure that docker's requests are deserialized to.
+type CreateRequest struct {
+	Name    string
+	Options map[string]string `json:"Opts,omitempty"`
+}
+
+// RemoveRequest structure for a volume remove request
+type RemoveRequest struct {
+	Name string
+}
+
+// MountRequest structure for a volume mount request
+type MountRequest struct {
+	Name string
+	ID   string
+}
+
+// MountResponse structure for a volume mount response
+type MountResponse struct {
+	Mountpoint string
+}
+
+// UnmountRequest structure for a volume unmount request
+type UnmountRequest struct {
+	Name string
+	ID   string
+}
+
+// PathRequest structure for a volume path request
+type PathRequest struct {
+	Name string
+}
+
+// PathResponse structure for a volume path response
+type PathResponse struct {
+	Mountpoint string
+}
+
+// GetRequest structure for a volume get request
+type GetRequest struct {
+	Name string
+}
+
+// GetResponse structure for a volume get response
+type GetResponse struct {
+	Volume *Volume
+}
+
+// ListResponse structure for a volume list response
+type ListResponse struct {
+	Volumes []*Volume
+}
+
+// CapabilitiesResponse structure for a volume capability response
+type CapabilitiesResponse struct {
+	Capabilities Capability
+}
+
+// Volume represents a volume object for use with `Get` and `List` requests
+type Volume struct {
+	Name       string
+	Mountpoint string
+	Status     map[string]interface{}
+}
+
+// Capability represents the list of capabilities a volume driver can return
+type Capability struct {
+	Scope string
+}
+
+// ErrorResponse is a formatted error message that docker can understand
+type ErrorResponse struct {
+	Err string
+}
+
+// NewErrorResponse creates an ErrorResponse with the provided message
+func NewErrorResponse(msg string) *ErrorResponse {
+	return &ErrorResponse{Err: msg}
+}
+
+// Driver represent the interface a driver must fulfill.
+type Driver interface {
+	Create(*CreateRequest) error
+	List() (*ListResponse, error)
+	Get(*GetRequest) (*GetResponse, error)
+	Remove(*RemoveRequest) error
+	Path(*PathRequest) (*PathResponse, error)
+	Mount(*MountRequest) (*MountResponse, error)
+	Unmount(*UnmountRequest) error
+	Capabilities() *CapabilitiesResponse
+}
+
+// Handler forwards requests and responses between the docker daemon and the plugin.
+type Handler struct {
+	driver Driver
+	sdk.Handler
+}
+
+// NewHandler initializes the request handler with a driver implementation.
+func NewHandler(driver Driver) *Handler {
+	h := &Handler{driver, sdk.NewHandler(manifest)}
+	h.initMux()
+	return h
+}
+
+func (h *Handler) initMux() {
+	h.HandleFunc(createPath, func(w http.ResponseWriter, r *http.Request) {
+		log.Println("Entering go-plugins-helpers createPath")
+		req := &CreateRequest{}
+		err := sdk.DecodeRequest(w, r, req)
+		if err != nil {
+			return
+		}
+		err = h.driver.Create(req)
+		if err != nil {
+			sdk.EncodeResponse(w, NewErrorResponse(err.Error()), true)
+			return
+		}
+		sdk.EncodeResponse(w, struct{}{}, false)
+	})
+	h.HandleFunc(removePath, func(w http.ResponseWriter, r *http.Request) {
+		log.Println("Entering go-plugins-helpers removePath")
+		req := &RemoveRequest{}
+		err := sdk.DecodeRequest(w, r, req)
+		if err != nil {
+			return
+		}
+		err = h.driver.Remove(req)
+		if err != nil {
+			sdk.EncodeResponse(w, NewErrorResponse(err.Error()), true)
+			return
+		}
+		sdk.EncodeResponse(w, struct{}{}, false)
+	})
+	h.HandleFunc(mountPath, func(w http.ResponseWriter, r *http.Request) {
+		log.Println("Entering go-plugins-helpers mountPath")
+		req := &MountRequest{}
+		err := sdk.DecodeRequest(w, r, req)
+		if err != nil {
+			return
+		}
+		res, err := h.driver.Mount(req)
+		if err != nil {
+			sdk.EncodeResponse(w, NewErrorResponse(err.Error()), true)
+			return
+		}
+		sdk.EncodeResponse(w, res, false)
+	})
+	h.HandleFunc(hostVirtualPath, func(w http.ResponseWriter, r *http.Request) {
+		log.Println("Entering go-plugins-helpers hostVirtualPath")
+		req := &PathRequest{}
+		err := sdk.DecodeRequest(w, r, req)
+		if err != nil {
+			return
+		}
+		res, err := h.driver.Path(req)
+		if err != nil {
+			sdk.EncodeResponse(w, NewErrorResponse(err.Error()), true)
+			return
+		}
+		sdk.EncodeResponse(w, res, false)
+	})
+	h.HandleFunc(getPath, func(w http.ResponseWriter, r *http.Request) {
+		log.Println("Entering go-plugins-helpers getPath")
+		req := &GetRequest{}
+		err := sdk.DecodeRequest(w, r, req)
+		if err != nil {
+			return
+		}
+		res, err := h.driver.Get(req)
+		if err != nil {
+			sdk.EncodeResponse(w, NewErrorResponse(err.Error()), true)
+			return
+		}
+		sdk.EncodeResponse(w, res, false)
+	})
+	h.HandleFunc(unmountPath, func(w http.ResponseWriter, r *http.Request) {
+		log.Println("Entering go-plugins-helpers unmountPath")
+		req := &UnmountRequest{}
+		err := sdk.DecodeRequest(w, r, req)
+		if err != nil {
+			return
+		}
+		err = h.driver.Unmount(req)
+		if err != nil {
+			sdk.EncodeResponse(w, NewErrorResponse(err.Error()), true)
+			return
+		}
+		sdk.EncodeResponse(w, struct{}{}, false)
+	})
+	h.HandleFunc(listPath, func(w http.ResponseWriter, r *http.Request) {
+		log.Println("Entering go-plugins-helpers listPath")
+		res, err := h.driver.List()
+		if err != nil {
+			sdk.EncodeResponse(w, NewErrorResponse(err.Error()), true)
+			return
+		}
+		sdk.EncodeResponse(w, res, false)
+	})
+
+	h.HandleFunc(capabilitiesPath, func(w http.ResponseWriter, r *http.Request) {
+		log.Println("Entering go-plugins-helpers capabilitiesPath")
+		sdk.EncodeResponse(w, h.driver.Capabilities(), false)
+	})
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -64,6 +64,30 @@
 			"revisionTime": "2017-06-08T04:50:38Z"
 		},
 		{
+			"checksumSHA1": "ObIo600Bu1u+28ARcRFZ256s0ZU=",
+			"path": "github.com/NVIDIA/nvidia-docker/src/cuda",
+			"revision": "d8e8727788aaf0012a4bcfab4d55b7bc5eb718b6",
+			"revisionTime": "2017-07-22T19:54:03Z"
+		},
+		{
+			"checksumSHA1": "SAnjtQ1GwCYZN46A+ZN7HUPrahI=",
+			"path": "github.com/NVIDIA/nvidia-docker/src/ldcache",
+			"revision": "d8e8727788aaf0012a4bcfab4d55b7bc5eb718b6",
+			"revisionTime": "2017-07-22T19:54:03Z"
+		},
+		{
+			"checksumSHA1": "vfc+9YhThSZODTrctqBjBdCEHQg=",
+			"path": "github.com/NVIDIA/nvidia-docker/src/nvidia",
+			"revision": "d8e8727788aaf0012a4bcfab4d55b7bc5eb718b6",
+			"revisionTime": "2017-07-22T19:54:03Z"
+		},
+		{
+			"checksumSHA1": "w1z6hmlgJp64kMot66VBsQFeKcY=",
+			"path": "github.com/NVIDIA/nvidia-docker/src/nvml",
+			"revision": "d8e8727788aaf0012a4bcfab4d55b7bc5eb718b6",
+			"revisionTime": "2017-07-22T19:54:03Z"
+		},
+		{
 			"checksumSHA1": "QvibMZwbRw2ltwyNCza/0fXUbF0=",
 			"origin": "github.com/docker/docker/vendor/github.com/Sirupsen/logrus",
 			"path": "github.com/Sirupsen/logrus",
@@ -144,6 +168,12 @@
 			"path": "github.com/containerd/cgroups",
 			"revision": "6d5c608c203dab9f154fdb40c22c043cebd4d699",
 			"revisionTime": "2017-07-14T21:03:33Z"
+		},
+		{
+			"checksumSHA1": "RBwpnMpfQt7Jo7YWrRph0Vwe+f0=",
+			"path": "github.com/coreos/go-systemd/activation",
+			"revision": "24036eb3df68550d24a2736c5d013f4e83366866",
+			"revisionTime": "2017-06-09T14:46:27Z"
 		},
 		{
 			"checksumSHA1": "/zxxFPYjUB7Wowz33r5AhTDvoz0=",
@@ -335,6 +365,18 @@
 			"path": "github.com/docker/go-connections/tlsconfig",
 			"revision": "cd35e4beee13a7c193e2a89008cd87d38fcd0161",
 			"revisionTime": "2017-06-08T04:50:38Z"
+		},
+		{
+			"checksumSHA1": "e/cSY11dRBYpw1MpxpKLDG0NO28=",
+			"path": "github.com/docker/go-plugins-helpers/sdk",
+			"revision": "bd8c600f0cdd76c7a57ff6aa86bd2b423868c688",
+			"revisionTime": "2017-09-19T09:29:28Z"
+		},
+		{
+			"checksumSHA1": "Q7aTLIDZPbH1XrFlbSWvM/aqG5E=",
+			"path": "github.com/docker/go-plugins-helpers/volume",
+			"revision": "bd8c600f0cdd76c7a57ff6aa86bd2b423868c688",
+			"revisionTime": "2017-09-19T09:29:28Z"
 		},
 		{
 			"checksumSHA1": "Pv1NbtDY4wETwwSD2DsI+s8de/I=",


### PR DESCRIPTION
There are 3 modes now: *nil*, *nvidiadocker*, *embedded*:

+ *nil*: just a placeholder for unsupported platforms or if the feature disabled
+ *nvidiadocker*: old-style way to provide GPU support with an extra fix to enable OpenCL for Nvidia.  Works via NvidiaDocker plugin
+ *embedded*: supports both nvidia (GPU/OpenCL) and ATI OpenCL. Parts of NvidiaDocker are embedded into a miner with some improvements (i.e volume API is rewritten). Miner acts as docker volume driver to bind the libraries inside a container. 

**clinfo**  util was used as testing utility

**NOTE**: a container should have LD_LIBRARY_PATH pointing to /usr/local/nvidia/lib{64} and PATH /usr/local/nvidia/bin. Base images for nvidia-docker contain such env fixes.
Although we can set LD_LIBRARY_PATH from outside the container, it's impossible to append into PATH variable