### PR TITLE
feat: worker ACL

### DIFF
--- a/cmd/cli/commands/hub.go
+++ b/cmd/cli/commands/hub.go
@@ -16,6 +16,17 @@ import (
 func init() {
 	hubRootCmd.AddCommand(hubPingCmd, hubStatusCmd, hubSlotCmd)
 	hubSlotCmd.AddCommand(minerShowSlotsCmd, hubAddSlotCmd)
+	hubWorkerACLCmd.AddCommand(registerWorkerCmd, deregisterWorkerCmd)
+}
+
+func wrapHubCommand(use, short string, command *cobra.Command) *cobra.Command {
+	command.Use = use
+	command.Short = short
+
+	if command.PreRunE == nil {
+		command.PreRunE = checkHubAddressIsSet
+	}
+	return command
 }
 
 // --- hub commands
@@ -142,6 +153,58 @@ var hubAddSlotCmd = &cobra.Command{
 		return nil
 	},
 }
+
+var hubWorkerACLCmd = wrapHubCommand("acl", "Worker ACL management", &cobra.Command{})
+
+var registerWorkerCmd = wrapHubCommand("register", "Registers a worker credentials", &cobra.Command{
+	Args: cobra.MinimumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		id := args[0]
+		hub, err := NewHubInteractor(nodeAddress, timeout)
+		if err != nil {
+			return err
+		}
+
+		reply, err := hub.RegisterWorker(id)
+		if err != nil {
+			return err
+		}
+
+		dump, err := json.Marshal(reply)
+		if err != nil {
+			return err
+		}
+
+		cmd.Println(string(dump))
+
+		return nil
+	},
+})
+
+var deregisterWorkerCmd = wrapHubCommand("deregister", "Deregisters a worker credentials", &cobra.Command{
+	Args: cobra.MinimumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		id := args[0]
+		hub, err := NewHubInteractor(nodeAddress, timeout)
+		if err != nil {
+			return err
+		}
+
+		reply, err := hub.DeregisterWorker(id)
+		if err != nil {
+			return err
+		}
+
+		dump, err := json.Marshal(reply)
+		if err != nil {
+			return err
+		}
+
+		cmd.Println(string(dump))
+
+		return nil
+	},
+})
 
 func printHubStatus(cmd *cobra.Command, stat *pb.HubStatusReply) {
 	if isSimpleFormat() {

--- a/insonmnia/hub/acl.go
+++ b/insonmnia/hub/acl.go
@@ -1,6 +1,8 @@
 package hub
 
 import (
+	"sync"
+
 	"gopkg.in/fatih/set.v0"
 )
 
@@ -12,30 +14,42 @@ type ACLStorage interface {
 	// Insert inserts the given worker credentials to the storage.
 	Insert(credentials string)
 	// Remove removes the given worker credentials from the storage.
-	Remove(credentials string)
+	// Returns true if it was actually removed.
+	Remove(credentials string) bool
 	// Has checks whether the given worker credentials contains in the
 	// storage.
 	Has(credentials string) bool
 }
 
 type workerACLStorage struct {
-	storage *set.Set
+	storage *set.SetNonTS
+	mu      sync.RWMutex
 }
 
 func NewACLStorage() ACLStorage {
 	return &workerACLStorage{
-		storage: set.New(),
+		storage: set.NewNonTS(),
 	}
 }
 
 func (s *workerACLStorage) Insert(credentials string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	s.storage.Add(credentials)
 }
 
-func (s *workerACLStorage) Remove(credentials string) {
-	s.storage.Remove(credentials)
+func (s *workerACLStorage) Remove(credentials string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	exists := s.storage.Has(credentials)
+	if exists {
+		s.storage.Remove(credentials)
+	}
+	return exists
 }
 
 func (s *workerACLStorage) Has(credentials string) bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 	return s.storage.Has(credentials)
 }

--- a/insonmnia/hub/acl.go
+++ b/insonmnia/hub/acl.go
@@ -1,0 +1,41 @@
+package hub
+
+import (
+	"gopkg.in/fatih/set.v0"
+)
+
+// ACLStorage describes an ACL storage for workers.
+//
+// A worker connection can be accepted only and the only if its credentials
+// provided with the certificate contains in this storage.
+type ACLStorage interface {
+	// Insert inserts the given worker credentials to the storage.
+	Insert(credentials string)
+	// Remove removes the given worker credentials from the storage.
+	Remove(credentials string)
+	// Has checks whether the given worker credentials contains in the
+	// storage.
+	Has(credentials string) bool
+}
+
+type workerACLStorage struct {
+	storage *set.Set
+}
+
+func NewACLStorage() ACLStorage {
+	return &workerACLStorage{
+		storage: set.New(),
+	}
+}
+
+func (s *workerACLStorage) Insert(credentials string) {
+	s.storage.Add(credentials)
+}
+
+func (s *workerACLStorage) Remove(credentials string) {
+	s.storage.Remove(credentials)
+}
+
+func (s *workerACLStorage) Has(credentials string) bool {
+	return s.storage.Has(credentials)
+}

--- a/insonmnia/hub/server.go
+++ b/insonmnia/hub/server.go
@@ -2,6 +2,7 @@ package hub
 
 import (
 	"crypto/ecdsa"
+	"crypto/x509"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -839,6 +840,13 @@ func New(ctx context.Context, cfg *HubConfig, version string) (*Hub, error) {
 		return nil, err
 	}
 
+	acl := NewACLStorage()
+	privateKey, err := x509.MarshalECPrivateKey(ethKey)
+	if err != nil {
+		return nil, err
+	}
+	acl.Insert(hex.EncodeToString(privateKey))
+
 	h := &Hub{
 		ctx:          ctx,
 		cancel:       cancel,
@@ -868,7 +876,7 @@ func New(ctx context.Context, cfg *HubConfig, version string) (*Hub, error) {
 
 		deviceProperties: make(map[string]DeviceProperties),
 		slots:            make([]*structs.Slot, 0),
-		acl:              NewACLStorage(),
+		acl:              acl,
 	}
 
 	interceptor := h.onRequest

--- a/insonmnia/hub/server.go
+++ b/insonmnia/hub/server.go
@@ -785,7 +785,9 @@ func (h *Hub) RegisterWorker(ctx context.Context, request *pb.ID) (*pb.Empty, er
 func (h *Hub) DeregisterWorker(ctx context.Context, request *pb.ID) (*pb.Empty, error) {
 	log.G(h.ctx).Info("handling DeregisterWorker request", zap.String("id", request.GetId()))
 
-	h.acl.Remove(request.Id)
+	if existed := h.acl.Remove(request.Id); !existed {
+		log.G(h.ctx).Warn("attempt to deregister unregistered worker", zap.String("id", request.GetId()))
+	}
 	return &pb.Empty{}, nil
 }
 

--- a/insonmnia/hub/server.go
+++ b/insonmnia/hub/server.go
@@ -79,7 +79,7 @@ type Hub struct {
 	startTime time.Time
 	version   string
 
-	// Scheduling.
+	// Scheduling (obsolete).
 	filters []minerFilter
 	consul  Consul
 
@@ -94,11 +94,17 @@ type Hub struct {
 	eth    ETH
 	market Market
 
+	// Device properties.
+	// Must be synchronized with out Hub cluster.
 	deviceProperties map[string]DeviceProperties
 
 	// Scheduling.
-
+	// Must be synchronized with out Hub cluster.
 	slots []*structs.Slot
+
+	// Worker ACL.
+	// Must be synchronized with out Hub cluster.
+	acl ACLStorage
 }
 
 type DeviceProperties map[string]float64
@@ -768,16 +774,18 @@ func (h *Hub) GetRegisteredWorkers(ctx context.Context, empty *pb.Empty) (*pb.Ge
 
 // RegisterWorker allows Worker with given ID to connect to the Hub
 func (h *Hub) RegisterWorker(ctx context.Context, request *pb.ID) (*pb.Empty, error) {
-	// todo: implement me
 	log.G(h.ctx).Info("handling RegisterWorker request", zap.String("id", request.GetId()))
-	return nil, ErrUnimplemented
+
+	h.acl.Insert(request.Id)
+	return &pb.Empty{}, nil
 }
 
 // DeregisterWorkers deny Worker with given ID to connect to the Hub
 func (h *Hub) DeregisterWorker(ctx context.Context, request *pb.ID) (*pb.Empty, error) {
-	// todo: implement me
 	log.G(h.ctx).Info("handling DeregisterWorker request", zap.String("id", request.GetId()))
-	return nil, ErrUnimplemented
+
+	h.acl.Remove(request.Id)
+	return &pb.Empty{}, nil
 }
 
 // New returns new Hub
@@ -859,6 +867,8 @@ func New(ctx context.Context, cfg *HubConfig, version string) (*Hub, error) {
 		market: market,
 
 		deviceProperties: make(map[string]DeviceProperties),
+		slots:            make([]*structs.Slot, 0),
+		acl:              NewACLStorage(),
 	}
 
 	interceptor := h.onRequest

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -1727,8 +1727,8 @@
 			"checksumSHA1": "NGg7/qIJVUfXi7xnEyyDLocdi6Y=",
 			"origin": "github.com/ethereum/go-ethereum/vendor/gopkg.in/fatih/set.v0",
 			"path": "gopkg.in/fatih/set.v0",
-			"revision": "a602ee90f2c28eadbca8cdc2e143825a4c24ab23",
-			"revisionTime": "2017-07-26T07:40:41Z"
+			"revision": "9f7cd7568275e2db45a3d90429f7c92bf7dfbf19",
+			"revisionTime": "2017-11-03T20:29:49Z"
 		},
 		{
 			"checksumSHA1": "DQXNV0EivoHm4q+bkdahYXrjjfE=",


### PR DESCRIPTION
This PR implements worker ACL registration/deregistration.

Added:
- ACL storage on the Hub.
- New CLI commands: `acl register CREDENTIALS` and `acl deregister CREDENTIALS`.

Changed:
- Implemented above methods on the Hub.

Things to be done:
- Waiting for #154, since from there we can extract worker credentials from the certificate and to perform validation while establishing a worker connection.