### PR TITLE
refactor: remove accidentally duplicated code

### DIFF
--- a/cmd/cli/commands/hub.go
+++ b/cmd/cli/commands/hub.go
@@ -16,7 +16,6 @@ import (
 func init() {
 	hubRootCmd.AddCommand(hubPingCmd, hubStatusCmd, hubSlotCmd)
 	hubSlotCmd.AddCommand(minerShowSlotsCmd, hubAddSlotCmd)
-	hubWorkerACLCmd.AddCommand(registerWorkerCmd, deregisterWorkerCmd)
 }
 
 func wrapHubCommand(use, short string, command *cobra.Command) *cobra.Command {
@@ -153,58 +152,6 @@ var hubAddSlotCmd = &cobra.Command{
 		return nil
 	},
 }
-
-var hubWorkerACLCmd = wrapHubCommand("acl", "Worker ACL management", &cobra.Command{})
-
-var registerWorkerCmd = wrapHubCommand("register", "Registers a worker credentials", &cobra.Command{
-	Args: cobra.MinimumNArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		id := args[0]
-		hub, err := NewHubInteractor(nodeAddress, timeout)
-		if err != nil {
-			return err
-		}
-
-		reply, err := hub.RegisterWorker(id)
-		if err != nil {
-			return err
-		}
-
-		dump, err := json.Marshal(reply)
-		if err != nil {
-			return err
-		}
-
-		cmd.Println(string(dump))
-
-		return nil
-	},
-})
-
-var deregisterWorkerCmd = wrapHubCommand("deregister", "Deregisters a worker credentials", &cobra.Command{
-	Args: cobra.MinimumNArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		id := args[0]
-		hub, err := NewHubInteractor(nodeAddress, timeout)
-		if err != nil {
-			return err
-		}
-
-		reply, err := hub.DeregisterWorker(id)
-		if err != nil {
-			return err
-		}
-
-		dump, err := json.Marshal(reply)
-		if err != nil {
-			return err
-		}
-
-		cmd.Println(string(dump))
-
-		return nil
-	},
-})
 
 func printHubStatus(cmd *cobra.Command, stat *pb.HubStatusReply) {
 	if isSimpleFormat() {

--- a/cmd/cli/commands/login.go
+++ b/cmd/cli/commands/login.go
@@ -1,0 +1,1 @@
+package commands

--- a/cmd/cli/commands/node_acl.go
+++ b/cmd/cli/commands/node_acl.go
@@ -18,7 +18,7 @@ func init() {
 
 var nodeACLRootCmd = &cobra.Command{
 	Use:   "acl",
-	Short: "Operations with Access Control Lists",
+	Short: "Worker ACL management",
 }
 
 func printWorkerAclList(cmd *cobra.Command, list *pb.GetRegisteredWorkersReply) {
@@ -55,7 +55,7 @@ var nodeACLListCmd = &cobra.Command{
 
 var nodeACLRegisterCmd = &cobra.Command{
 	Use:   "register <worker_id>",
-	Short: "Register new Worker",
+	Short: "Deregisters a worker credentials",
 	Args:  cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		hub, err := NewHubInteractor(nodeAddress, timeout)
@@ -76,7 +76,7 @@ var nodeACLRegisterCmd = &cobra.Command{
 
 var nodeACLDeregisterCmd = &cobra.Command{
 	Use:   "deregister <worker_id>",
-	Short: "Deregister known worker",
+	Short: "Deregisters a worker credentials",
 	Args:  cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		hub, err := NewHubInteractor(nodeAddress, timeout)


### PR DESCRIPTION
This PR removes duplicate implementation of ACL section into the CLI.

`wrapHubCommand` func left untouched, need to improve and reuse it. 