### PR TITLE
Feature/cli load keys

### DIFF
--- a/accounts/keys.go
+++ b/accounts/keys.go
@@ -71,17 +71,17 @@ func (o *defaultKeyOpener) OpenKeystore() (bool, error) {
 	err = idt.Open(passPhrase)
 	if err == nil {
 		return false, nil
-	}
-
-	if err == ErrWalletIsEmpty {
-		_, err = o.createNewKey(idt)
-		if err != nil {
-			return false, err
+	} else {
+		if err == ErrWalletIsEmpty {
+			// pass passPhrase to createKey method to prevent double pass phrase reading
+			_, err = o.createNewKey(idt, passPhrase)
+			if err == nil {
+				return true, nil
+			}
 		}
-		return true, nil
-	}
 
-	return false, nil
+		return false, err
+	}
 }
 
 func (o *defaultKeyOpener) GetKey() (*ecdsa.PrivateKey, error) {
@@ -92,13 +92,8 @@ func (o *defaultKeyOpener) GetKey() (*ecdsa.PrivateKey, error) {
 	return o.idt.GetPrivateKey()
 }
 
-func (o *defaultKeyOpener) createNewKey(idt Identity) (*ecdsa.PrivateKey, error) {
-	passPhrease, err := o.pf.GetPassPhrase()
-	if err != nil {
-		return nil, err
-	}
-
-	err = idt.New(passPhrease)
+func (o *defaultKeyOpener) createNewKey(idt Identity, passPhrease string) (*ecdsa.PrivateKey, error) {
+	err := idt.New(passPhrease)
 	if err != nil {
 		return nil, err
 	}

--- a/accounts/keys.go
+++ b/accounts/keys.go
@@ -7,6 +7,7 @@ import (
 	"os"
 
 	"github.com/howeyc/gopass"
+	"github.com/sonm-io/core/util"
 )
 
 var (
@@ -57,7 +58,7 @@ func (o *defaultKeyOpener) OpenKeystore() (bool, error) {
 		}
 	}()
 
-	if !hasDir(o.keyDirPath) {
+	if !util.DirectoryExists(o.keyDirPath) {
 		return false, errNoKeystoreDir
 	}
 
@@ -108,13 +109,6 @@ func (o *defaultKeyOpener) createNewKey(idt Identity) (*ecdsa.PrivateKey, error)
 	}
 
 	return idt.GetPrivateKey()
-}
-
-func hasDir(p string) bool {
-	if _, err := os.Stat(p); err != nil {
-		return !os.IsNotExist(err)
-	}
-	return true
 }
 
 // NewKeyOpener returns KeyOpener that able to open keys

--- a/accounts/keys.go
+++ b/accounts/keys.go
@@ -141,3 +141,16 @@ func NewInteractivePassPhraser() PassPhraser {
 		writer: os.Stdout,
 	}
 }
+
+// staticPassPhraser implements PassPhraser interface
+// by holding already-known pass phrase received from any
+// external source.
+type staticPassPhraser struct {
+	p string
+}
+
+func (pf *staticPassPhraser) GetPassPhrase() (string, error) { return pf.p, nil }
+
+func NewStaticPassPhraser(p string) PassPhraser {
+	return &staticPassPhraser{p: p}
+}

--- a/cmd/cli/commands/common.go
+++ b/cmd/cli/commands/common.go
@@ -59,6 +59,8 @@ func init() {
 
 	nodeRootCmd.AddCommand(nodeHubRootCmd, nodeMarketRootCmd)
 	rootCmd.AddCommand(hubRootCmd, minerRootCmd, tasksRootCmd, versionCmd, nodeRootCmd)
+
+	rootCmd.AddCommand(loginCmd)
 }
 
 var nodeRootCmd = &cobra.Command{

--- a/cmd/cli/commands/hub.go
+++ b/cmd/cli/commands/hub.go
@@ -18,16 +18,6 @@ func init() {
 	hubSlotCmd.AddCommand(minerShowSlotsCmd, hubAddSlotCmd)
 }
 
-func wrapHubCommand(use, short string, command *cobra.Command) *cobra.Command {
-	command.Use = use
-	command.Short = short
-
-	if command.PreRunE == nil {
-		command.PreRunE = checkHubAddressIsSet
-	}
-	return command
-}
-
 // --- hub commands
 var hubRootCmd = &cobra.Command{
 	Use:     "hub",

--- a/cmd/cli/commands/hub.go
+++ b/cmd/cli/commands/hub.go
@@ -16,7 +16,6 @@ import (
 func init() {
 	hubRootCmd.AddCommand(hubPingCmd, hubStatusCmd, hubSlotCmd)
 	hubSlotCmd.AddCommand(minerShowSlotsCmd, hubAddSlotCmd)
-	hubWorkerACLCmd.AddCommand(registerWorkerCmd, deregisterWorkerCmd)
 }
 
 func wrapHubCommand(use, short string, command *cobra.Command) *cobra.Command {
@@ -153,58 +152,6 @@ var hubAddSlotCmd = &cobra.Command{
 		return nil
 	},
 }
-
-var hubWorkerACLCmd = wrapHubCommand("acl", "Worker ACL management", &cobra.Command{})
-
-var registerWorkerCmd = wrapHubCommand("register", "Registers a worker credentials", &cobra.Command{
-	Args: cobra.MinimumNArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		id := args[0]
-		hub, err := NewHubInteractor(nodeAddress, timeout)
-		if err != nil {
-			return err
-		}
-
-		reply, err := hub.RegisterWorker(id)
-		if err != nil {
-			return err
-		}
-
-		dump, err := json.Marshal(reply)
-		if err != nil {
-			return err
-		}
-
-		cmd.Println(string(dump))
-
-		return nil
-	},
-})
-
-var deregisterWorkerCmd = wrapHubCommand("deregister", "Deregisters a worker credentials", &cobra.Command{
-	Args: cobra.MinimumNArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		id := args[0]
-		hub, err := NewHubInteractor(nodeAddress, timeout)
-		if err != nil {
-			return err
-		}
-
-		reply, err := hub.DeregisterWorker(id)
-		if err != nil {
-			return err
-		}
-
-		dump, err := json.Marshal(reply)
-		if err != nil {
-			return err
-		}
-
-		cmd.Println(string(dump))
-
-		return nil
-	},
-})
 
 func printHubStatus(cmd *cobra.Command, stat *pb.HubStatusReply) {
 	if isSimpleFormat() {

--- a/cmd/cli/commands/login.go
+++ b/cmd/cli/commands/login.go
@@ -1,0 +1,1 @@
+package commands

--- a/cmd/cli/commands/login.go
+++ b/cmd/cli/commands/login.go
@@ -1,1 +1,72 @@
 package commands
+
+import (
+	"os"
+	"path"
+
+	"github.com/sonm-io/core/accounts"
+	"github.com/sonm-io/core/util"
+	"github.com/spf13/cobra"
+)
+
+var defaultKeystorePath = ".sonm/keystore/"
+
+var loginCmd = &cobra.Command{
+	Use:   "login",
+	Short: "Open or generate Etherum keys",
+	Run: func(cmd *cobra.Command, _ []string) {
+		var err error
+		keyStorageDir := cfg.KeyStore()
+
+		// use default key store dir if not specified in config
+		if keyStorageDir == "" {
+			keyStorageDir, err = getDefaultKeyStorePath()
+			if err != nil {
+				showError(cmd, "Cannot get default keystore", err)
+				os.Exit(1)
+			}
+		}
+
+		cmd.Printf("Using %s as KeyStore directory\r\n", keyStorageDir)
+
+		if !util.DirectoryExists(keyStorageDir) {
+			cmd.Printf("KeyStore directory does not exists, try to create it...\r\n")
+			err = os.MkdirAll(keyStorageDir, 0700)
+			if err != nil {
+				showError(cmd, "Cannot create KeyStore directory", err)
+				os.Exit(1)
+			}
+		}
+
+		// ask for pass-phrase if not specified in config
+		var pf accounts.PassPhraser
+		if cfg.PassPhrase() == "" {
+			pf = accounts.NewInteractivePassPhraser()
+		} else {
+			pf = accounts.NewStaticPassPhraser(cfg.PassPhrase())
+		}
+
+		ko := accounts.NewKeyOpener(keyStorageDir, pf)
+		created, err := ko.OpenKeystore()
+		if err != nil {
+			showError(cmd, "Cannot open KeyStore", err)
+			os.Exit(1)
+		}
+
+		if created {
+			cmd.Printf("Keystore successfully created\r\n")
+		} else {
+			cmd.Printf("Keystore successfully opened\r\n")
+		}
+	},
+}
+
+func getDefaultKeyStorePath() (string, error) {
+	home, err := util.GetUserHomeDir()
+	if err != nil {
+		return "", err
+	}
+
+	keyDir := path.Join(home, defaultKeystorePath)
+	return keyDir, nil
+}

--- a/cmd/cli/commands/login.go
+++ b/cmd/cli/commands/login.go
@@ -15,38 +15,12 @@ var loginCmd = &cobra.Command{
 	Use:   "login",
 	Short: "Open or generate Etherum keys",
 	Run: func(cmd *cobra.Command, _ []string) {
-		var err error
-		keyStorageDir := cfg.KeyStore()
-
-		// use default key store dir if not specified in config
-		if keyStorageDir == "" {
-			keyStorageDir, err = getDefaultKeyStorePath()
-			if err != nil {
-				showError(cmd, "Cannot get default keystore", err)
-				os.Exit(1)
-			}
+		ko, err := cliKeyOpener(cmd, cfg.KeyStore(), cfg.PassPhrase())
+		if err != nil {
+			showError(cmd, "Cannot init KeyOpener", err)
+			os.Exit(1)
 		}
 
-		cmd.Printf("Using %s as KeyStore directory\r\n", keyStorageDir)
-
-		if !util.DirectoryExists(keyStorageDir) {
-			cmd.Printf("KeyStore directory does not exists, try to create it...\r\n")
-			err = os.MkdirAll(keyStorageDir, 0700)
-			if err != nil {
-				showError(cmd, "Cannot create KeyStore directory", err)
-				os.Exit(1)
-			}
-		}
-
-		// ask for pass-phrase if not specified in config
-		var pf accounts.PassPhraser
-		if cfg.PassPhrase() == "" {
-			pf = accounts.NewInteractivePassPhraser()
-		} else {
-			pf = accounts.NewStaticPassPhraser(cfg.PassPhrase())
-		}
-
-		ko := accounts.NewKeyOpener(keyStorageDir, pf)
 		created, err := ko.OpenKeystore()
 		if err != nil {
 			showError(cmd, "Cannot open KeyStore", err)
@@ -59,6 +33,39 @@ var loginCmd = &cobra.Command{
 			cmd.Printf("Keystore successfully opened\r\n")
 		}
 	},
+}
+
+// cliKeyOpener return KeyOpener configured for using with cli
+func cliKeyOpener(p printer, keyDir, passPhrase string) (accounts.KeyOpener, error) {
+	var err error
+	// use default key store dir if not specified in config
+	if keyDir == "" {
+		keyDir, err = getDefaultKeyStorePath()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	p.Printf("Using %s as KeyStore directory\r\n", keyDir)
+
+	if !util.DirectoryExists(keyDir) {
+		p.Printf("KeyStore directory does not exists, try to create it...\r\n")
+		err = os.MkdirAll(keyDir, 0700)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// ask for pass-phrase if not specified in config
+	var pf accounts.PassPhraser
+	if passPhrase == "" {
+		pf = accounts.NewInteractivePassPhraser()
+	} else {
+		pf = accounts.NewStaticPassPhraser(passPhrase)
+	}
+
+	ko := accounts.NewKeyOpener(keyDir, pf)
+	return ko, nil
 }
 
 func getDefaultKeyStorePath() (string, error) {

--- a/cmd/cli/commands/node_acl.go
+++ b/cmd/cli/commands/node_acl.go
@@ -18,7 +18,7 @@ func init() {
 
 var nodeACLRootCmd = &cobra.Command{
 	Use:   "acl",
-	Short: "Operations with Access Control Lists",
+	Short: "Worker ACL management",
 }
 
 func printWorkerAclList(cmd *cobra.Command, list *pb.GetRegisteredWorkersReply) {
@@ -55,7 +55,7 @@ var nodeACLListCmd = &cobra.Command{
 
 var nodeACLRegisterCmd = &cobra.Command{
 	Use:   "register <worker_id>",
-	Short: "Register new Worker",
+	Short: "Deregisters a worker credentials",
 	Args:  cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		hub, err := NewHubInteractor(nodeAddress, timeout)
@@ -76,7 +76,7 @@ var nodeACLRegisterCmd = &cobra.Command{
 
 var nodeACLDeregisterCmd = &cobra.Command{
 	Use:   "deregister <worker_id>",
-	Short: "Deregister known worker",
+	Short: "Deregisters a worker credentials",
 	Args:  cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		hub, err := NewHubInteractor(nodeAddress, timeout)

--- a/cmd/cli/commands/node_acl.go
+++ b/cmd/cli/commands/node_acl.go
@@ -34,8 +34,9 @@ func printWorkerAclList(cmd *cobra.Command, list *pb.GetRegisteredWorkersReply) 
 }
 
 var nodeACLListCmd = &cobra.Command{
-	Use:   "list",
-	Short: "Show current ACLs",
+	Use:    "list",
+	Short:  "Show current ACLs",
+	PreRun: loadKeyStoreWrapper,
 	Run: func(cmd *cobra.Command, args []string) {
 		hub, err := NewHubInteractor(nodeAddress, timeout)
 		if err != nil {
@@ -54,9 +55,10 @@ var nodeACLListCmd = &cobra.Command{
 }
 
 var nodeACLRegisterCmd = &cobra.Command{
-	Use:   "register <worker_id>",
-	Short: "Deregisters a worker credentials",
-	Args:  cobra.MinimumNArgs(1),
+	Use:    "register <worker_id>",
+	Short:  "Deregisters a worker credentials",
+	Args:   cobra.MinimumNArgs(1),
+	PreRun: loadKeyStoreWrapper,
 	Run: func(cmd *cobra.Command, args []string) {
 		hub, err := NewHubInteractor(nodeAddress, timeout)
 		if err != nil {
@@ -75,9 +77,10 @@ var nodeACLRegisterCmd = &cobra.Command{
 }
 
 var nodeACLDeregisterCmd = &cobra.Command{
-	Use:   "deregister <worker_id>",
-	Short: "Deregisters a worker credentials",
-	Args:  cobra.MinimumNArgs(1),
+	Use:    "deregister <worker_id>",
+	Short:  "Deregisters a worker credentials",
+	Args:   cobra.MinimumNArgs(1),
+	PreRun: loadKeyStoreWrapper,
 	Run: func(cmd *cobra.Command, args []string) {
 		hub, err := NewHubInteractor(nodeAddress, timeout)
 		if err != nil {

--- a/cmd/cli/commands/node_devices.go
+++ b/cmd/cli/commands/node_devices.go
@@ -66,8 +66,9 @@ var nodeDeviceRootCmd = &cobra.Command{
 }
 
 var nodeDeviceListCmd = &cobra.Command{
-	Use:   "list",
-	Short: "Show Hub's aggregated hardware",
+	Use:    "list",
+	Short:  "Show Hub's aggregated hardware",
+	PreRun: loadKeyStoreWrapper,
 	Run: func(cmd *cobra.Command, args []string) {
 		hub, err := NewHubInteractor(nodeAddress, timeout)
 		if err != nil {
@@ -86,9 +87,10 @@ var nodeDeviceListCmd = &cobra.Command{
 }
 
 var nodeGetDevPropsCmd = &cobra.Command{
-	Use:   "get <dev_id>",
-	Short: "Get Device properties",
-	Args:  cobra.MinimumNArgs(1),
+	Use:    "get <dev_id>",
+	Short:  "Get Device properties",
+	Args:   cobra.MinimumNArgs(1),
+	PreRun: loadKeyStoreWrapper,
 	Run: func(cmd *cobra.Command, args []string) {
 		hub, err := NewHubInteractor(nodeAddress, timeout)
 		if err != nil {
@@ -108,9 +110,10 @@ var nodeGetDevPropsCmd = &cobra.Command{
 }
 
 var nodeSetDevPropsCmd = &cobra.Command{
-	Use:   "set <dev_id> <props.yaml>",
-	Short: "Set Device properties",
-	Args:  cobra.MinimumNArgs(2),
+	Use:    "set <dev_id> <props.yaml>",
+	Short:  "Set Device properties",
+	Args:   cobra.MinimumNArgs(2),
+	PreRun: loadKeyStoreWrapper,
 	Run: func(cmd *cobra.Command, args []string) {
 
 		hub, err := NewHubInteractor(nodeAddress, timeout)

--- a/cmd/cli/commands/node_hub.go
+++ b/cmd/cli/commands/node_hub.go
@@ -23,8 +23,9 @@ var nodeHubRootCmd = &cobra.Command{
 }
 
 var nodeHubStatusCmd = &cobra.Command{
-	Use:   "status",
-	Short: "Show hub status",
+	Use:    "status",
+	Short:  "Show hub status",
+	PreRun: loadKeyStoreWrapper,
 	Run: func(cmd *cobra.Command, _ []string) {
 		hub, err := NewHubInteractor(nodeAddress, timeout)
 		if err != nil {

--- a/cmd/cli/commands/node_market.go
+++ b/cmd/cli/commands/node_market.go
@@ -169,9 +169,10 @@ var nodeMarketProcessingCmd = &cobra.Command{
 }
 
 var nodeMarketCreteCmd = &cobra.Command{
-	Use:   "create <order.yaml>",
-	Short: "Place new Bid order on Marketplace",
-	Args:  cobra.MinimumNArgs(1),
+	Use:    "create <order.yaml>",
+	Short:  "Place new Bid order on Marketplace",
+	PreRun: loadKeyStoreWrapper,
+	Args:   cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		market, err := NewMarketInteractor(nodeAddress, timeout)
 		if err != nil {
@@ -197,9 +198,10 @@ var nodeMarketCreteCmd = &cobra.Command{
 }
 
 var nodeMarketCancelCmd = &cobra.Command{
-	Use:   "cancel <order_id>",
-	Short: "Cancel order on Marketplace",
-	Args:  cobra.MinimumNArgs(1),
+	Use:    "cancel <order_id>",
+	Short:  "Cancel order on Marketplace",
+	PreRun: loadKeyStoreWrapper,
+	Args:   cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		market, err := NewMarketInteractor(nodeAddress, timeout)
 		if err != nil {

--- a/cmd/cli/commands/node_order.go
+++ b/cmd/cli/commands/node_order.go
@@ -85,8 +85,7 @@ var nodeOrderCreateCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		planPath := args[1]
-
+		planPath := args[0]
 		slot, err := loadSlotFile(planPath)
 		if err != nil {
 			showError(cmd, "Cannot load AskOrder definition", err)
@@ -104,26 +103,29 @@ var nodeOrderCreateCmd = &cobra.Command{
 }
 
 var nodeOrderRemoveCmd = &cobra.Command{
-	Use:    "remove <plan_id>",
+	Use:    "remove <plan.yaml>",
 	Short:  "Remove plan",
 	Args:   cobra.MinimumNArgs(1),
 	PreRun: loadKeyStoreWrapper,
 	Run: func(cmd *cobra.Command, args []string) {
-		_, err := NewHubInteractor(nodeAddress, timeout)
+		hub, err := NewHubInteractor(nodeAddress, timeout)
 		if err != nil {
 			showError(cmd, "Cannot connect to Node", err)
 			os.Exit(1)
 		}
 
-		// TODO(sshaman1101): implement  this
+		planPath := args[0]
+		slot, err := loadSlotFile(planPath)
+		if err != nil {
+			showError(cmd, "Cannot load AskOrder definition", err)
+			os.Exit(1)
+		}
 
-		// NOTE: method is not implemented in Hub yet
-		//planID := args[0]
-		//_, err = hub.RemoveAskPlan(planID)
-		//if err != nil {
-		//	showError(cmd, "Cannot remove AskOrder", err)
-		//	os.Exit(1)
-		//}
+		_, err = hub.RemoveAskPlan(slot)
+		if err != nil {
+			showError(cmd, "Cannot remove AskOrder", err)
+			os.Exit(1)
+		}
 
 		showOk(cmd)
 	},

--- a/cmd/cli/commands/node_order.go
+++ b/cmd/cli/commands/node_order.go
@@ -53,8 +53,9 @@ func printAskList(cmd *cobra.Command, slots *pb.SlotsReply) {
 }
 
 var nodeOrderListCmd = &cobra.Command{
-	Use:   "list",
-	Short: "Show current ask plans",
+	Use:    "list",
+	Short:  "Show current ask plans",
+	PreRun: loadKeyStoreWrapper,
 	Run: func(cmd *cobra.Command, args []string) {
 		hub, err := NewHubInteractor(nodeAddress, timeout)
 		if err != nil {
@@ -73,9 +74,10 @@ var nodeOrderListCmd = &cobra.Command{
 }
 
 var nodeOrderCreateCmd = &cobra.Command{
-	Use:   "create <plan.yaml>",
-	Short: "Create new plan",
-	Args:  cobra.MinimumNArgs(1),
+	Use:    "create <plan.yaml>",
+	Short:  "Create new plan",
+	Args:   cobra.MinimumNArgs(1),
+	PreRun: loadKeyStoreWrapper,
 	Run: func(cmd *cobra.Command, args []string) {
 		hub, err := NewHubInteractor(nodeAddress, timeout)
 		if err != nil {
@@ -102,9 +104,10 @@ var nodeOrderCreateCmd = &cobra.Command{
 }
 
 var nodeOrderRemoveCmd = &cobra.Command{
-	Use:   "remove <plan_id>",
-	Short: "Remove plan",
-	Args:  cobra.MinimumNArgs(1),
+	Use:    "remove <plan_id>",
+	Short:  "Remove plan",
+	Args:   cobra.MinimumNArgs(1),
+	PreRun: loadKeyStoreWrapper,
 	Run: func(cmd *cobra.Command, args []string) {
 		_, err := NewHubInteractor(nodeAddress, timeout)
 		if err != nil {
@@ -112,7 +115,7 @@ var nodeOrderRemoveCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		// TODO(sshaman1101): implement this
+		// TODO(sshaman1101): implement  this
 
 		// NOTE: method is not implemented in Hub yet
 		//planID := args[0]

--- a/cmd/cli/commands/node_tasks.go
+++ b/cmd/cli/commands/node_tasks.go
@@ -43,8 +43,9 @@ func printNodeTaskStatus(cmd *cobra.Command, tasksMap map[string]*pb.TaskListRep
 }
 
 var nodeTaskListCmd = &cobra.Command{
-	Use:   "list",
-	Short: "Show task list",
+	Use:    "list",
+	Short:  "Show task list",
+	PreRun: loadKeyStoreWrapper,
 	Run: func(cmd *cobra.Command, args []string) {
 		hub, err := NewHubInteractor(nodeAddress, timeout)
 		if err != nil {
@@ -63,9 +64,10 @@ var nodeTaskListCmd = &cobra.Command{
 }
 
 var nodeTaskStatusCmd = &cobra.Command{
-	Use:   "status <task_id>",
-	Short: "Show task status",
-	Args:  cobra.MinimumNArgs(1),
+	Use:    "status <task_id>",
+	Short:  "Show task status",
+	Args:   cobra.MinimumNArgs(1),
+	PreRun: loadKeyStoreWrapper,
 	Run: func(cmd *cobra.Command, args []string) {
 		taskID := args[0]
 		hub, err := NewHubInteractor(nodeAddress, timeout)

--- a/cmd/cli/commands/node_worker.go
+++ b/cmd/cli/commands/node_worker.go
@@ -19,8 +19,9 @@ var nodeWorkerRootCmd = &cobra.Command{
 }
 
 var nodeWorkerListCmd = &cobra.Command{
-	Use:   "list",
-	Short: "Show connected workers list",
+	Use:    "list",
+	Short:  "Show connected workers list",
+	PreRun: loadKeyStoreWrapper,
 	Run: func(cmd *cobra.Command, _ []string) {
 		hub, err := NewHubInteractor(nodeAddress, timeout)
 		if err != nil {
@@ -39,9 +40,10 @@ var nodeWorkerListCmd = &cobra.Command{
 }
 
 var nodeWorkerStatusCmd = &cobra.Command{
-	Use:   "status <worker_id>",
-	Short: "Show worker status",
-	Args:  cobra.MinimumNArgs(1),
+	Use:    "status <worker_id>",
+	Short:  "Show worker status",
+	Args:   cobra.MinimumNArgs(1),
+	PreRun: loadKeyStoreWrapper,
 	Run: func(cmd *cobra.Command, args []string) {
 		hub, err := NewHubInteractor(nodeAddress, timeout)
 		if err != nil {

--- a/cmd/cli/config/config.go
+++ b/cmd/cli/config/config.go
@@ -17,12 +17,16 @@ const (
 type Config interface {
 	OutputFormat() string
 	HubAddress() string
+	KeyStore() string
+	PassPhrase() string
 }
 
 // cliConfig implements Config interface
 type cliConfig struct {
-	HubAddr   string `required:"false" default:"" yaml:"hub_address"`
-	OutFormat string `required:"false" default:"" yaml:"output_format"`
+	HubAddr    string `required:"false" default:"" yaml:"hub_address"`
+	OutFormat  string `required:"false" default:"" yaml:"output_format"`
+	Passphrase string `required:"false" default:"" yaml:"pass_phrase"`
+	Keystore   string `required:"false" default:"" yaml:"key_store"`
 }
 
 func (cc *cliConfig) OutputFormat() string {
@@ -31,6 +35,14 @@ func (cc *cliConfig) OutputFormat() string {
 
 func (cc *cliConfig) HubAddress() string {
 	return cc.HubAddr
+}
+
+func (cc *cliConfig) PassPhrase() string {
+	return cc.Passphrase
+}
+
+func (cc *cliConfig) KeyStore() string {
+	return cc.Keystore
 }
 
 func (cc *cliConfig) getConfigPath() (string, error) {

--- a/util/util.go
+++ b/util/util.go
@@ -8,13 +8,13 @@ import (
 	"io/ioutil"
 	"net"
 	"net/http"
+	"os"
 	"os/user"
 	"runtime"
 	"strconv"
 
 	"github.com/ethereum/go-ethereum/crypto"
 	"gopkg.in/yaml.v2"
-	"os"
 )
 
 // GetLocalIP find local non-loopback ip addr
@@ -118,7 +118,7 @@ func LoadYamlFile(from string, to interface{}) error {
 	return nil
 }
 
-// DirectoryExists returns true if given directory exists
+// DirectoryExists returns true if the given directory exists
 func DirectoryExists(p string) bool {
 	if _, err := os.Stat(p); err != nil {
 		return !os.IsNotExist(err)

--- a/util/util.go
+++ b/util/util.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/crypto"
 	"gopkg.in/yaml.v2"
+	"os"
 )
 
 // GetLocalIP find local non-loopback ip addr
@@ -115,4 +116,12 @@ func LoadYamlFile(from string, to interface{}) error {
 	}
 
 	return nil
+}
+
+// DirectoryExists returns true if given directory exists
+func DirectoryExists(p string) bool {
+	if _, err := os.Stat(p); err != nil {
+		return !os.IsNotExist(err)
+	}
+	return true
 }


### PR DESCRIPTION
This PR adds the `login` method for CLI. The method allows creating or opening an Etherum keystore.

TBD:
- [x] extract key loading logic implemented in loginCmd command;
- [x] Add a "middleware" (using _cobra.Command.PreRunE_) to load the storage on each action that must be signed;