### PR TITLE
Feature: node load keys

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -122,10 +122,11 @@ mock:
 	mockgen -package miner -destination insonmnia/miner/overseer_mock.go -source insonmnia/miner/overseer.go
 	mockgen -package miner -destination insonmnia/miner/config_mock.go -source insonmnia/miner/config.go
 	mockgen -package hardware -destination insonmnia/hardware/hardware_mock.go -source insonmnia/hardware/hardware.go
-	mockgen -package config -destination cmd/cli/config/config_mock.go  -source cmd/cli/config/config.go
 	mockgen -package commands -destination cmd/cli/commands/interactor_mock.go  -source cmd/cli/commands/interactor.go
 	mockgen -package task_config -destination cmd/cli/task_config/config_mock.go  -source cmd/cli/task_config/config.go
 	mockgen -package accounts -destination accounts/keys_mock.go  -source accounts/keys.go
+	mockgen -package config -destination cmd/cli/config/config_mock.go  -source cmd/cli/config/config.go \
+		-aux_files accounts=accounts/keys.go
 
 clean:
 	rm -f ${MINER} ${HUB} ${CLI} ${BOOTNODE} ${MARKET}

--- a/accounts/keys.go
+++ b/accounts/keys.go
@@ -154,3 +154,12 @@ func (pf *staticPassPhraser) GetPassPhrase() (string, error) { return pf.p, nil 
 func NewStaticPassPhraser(p string) PassPhraser {
 	return &staticPassPhraser{p: p}
 }
+
+// KeyStorager interface describe an item that must know something about
+// a path to the keystore and a passphrase
+type KeyStorager interface {
+	// KeyStore returns path to key store
+	KeyStore() string
+	// PassPhrase returns passphrase for keystore
+	PassPhrase() string
+}

--- a/cmd/cli/commands/common.go
+++ b/cmd/cli/commands/common.go
@@ -1,13 +1,13 @@
 package commands
 
 import (
+	"crypto/ecdsa"
 	"encoding/json"
 	"errors"
 	"os"
 	"time"
 
-	"crypto/ecdsa"
-
+	"github.com/sonm-io/core/accounts"
 	"github.com/sonm-io/core/cmd/cli/config"
 	"github.com/spf13/cobra"
 )
@@ -157,23 +157,12 @@ func isSimpleFormat() bool {
 	return true
 }
 
-// printer interface describe anything that can print
-// something somehow on a something.
-type printer interface {
-	Printf(format string, i ...interface{})
-}
-
-// silentPrinter implements printer interface but prints nothing.
-type silentPrinter struct{}
-
-func (sp *silentPrinter) Printf(format string, i ...interface{}) {}
-
 // loadKeyStoreWrapper implemented to match cobra.Command.PreRun signature.
 //
 // Function loads and opens keystore. Also, storing opened key in "sessionKey" var
 // to be able to reuse it into cli during one session.
 func loadKeyStoreWrapper(cmd *cobra.Command, _ []string) {
-	ko, err := cliKeyOpener(&silentPrinter{}, cfg.KeyStore(), cfg.PassPhrase())
+	ko, err := accounts.DefaultKeyOpener(accounts.NewSilentPrinter(), cfg.KeyStore(), cfg.PassPhrase())
 	if err != nil {
 		showError(cmd, err.Error(), nil)
 		os.Exit(1)

--- a/cmd/cli/commands/login.go
+++ b/cmd/cli/commands/login.go
@@ -2,20 +2,16 @@ package commands
 
 import (
 	"os"
-	"path"
 
 	"github.com/sonm-io/core/accounts"
-	"github.com/sonm-io/core/util"
 	"github.com/spf13/cobra"
 )
-
-var defaultKeystorePath = ".sonm/keystore/"
 
 var loginCmd = &cobra.Command{
 	Use:   "login",
 	Short: "Open or generate Etherum keys",
 	Run: func(cmd *cobra.Command, _ []string) {
-		ko, err := cliKeyOpener(cmd, cfg.KeyStore(), cfg.PassPhrase())
+		ko, err := accounts.DefaultKeyOpener(cmd, cfg.KeyStore(), cfg.PassPhrase())
 		if err != nil {
 			showError(cmd, "Cannot init KeyOpener", err)
 			os.Exit(1)
@@ -33,47 +29,4 @@ var loginCmd = &cobra.Command{
 			cmd.Printf("Keystore successfully opened\r\n")
 		}
 	},
-}
-
-// cliKeyOpener return KeyOpener configured for using with cli
-func cliKeyOpener(p printer, keyDir, passPhrase string) (accounts.KeyOpener, error) {
-	var err error
-	// use default key store dir if not specified in config
-	if keyDir == "" {
-		keyDir, err = getDefaultKeyStorePath()
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	p.Printf("Using %s as KeyStore directory\r\n", keyDir)
-
-	if !util.DirectoryExists(keyDir) {
-		p.Printf("KeyStore directory does not exists, try to create it...\r\n")
-		err = os.MkdirAll(keyDir, 0700)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	// ask for pass-phrase if not specified in config
-	var pf accounts.PassPhraser
-	if passPhrase == "" {
-		pf = accounts.NewInteractivePassPhraser()
-	} else {
-		pf = accounts.NewStaticPassPhraser(passPhrase)
-	}
-
-	ko := accounts.NewKeyOpener(keyDir, pf)
-	return ko, nil
-}
-
-func getDefaultKeyStorePath() (string, error) {
-	home, err := util.GetUserHomeDir()
-	if err != nil {
-		return "", err
-	}
-
-	keyDir := path.Join(home, defaultKeystorePath)
-	return keyDir, nil
 }

--- a/cmd/cli/config/config.go
+++ b/cmd/cli/config/config.go
@@ -6,6 +6,7 @@ import (
 	"path"
 
 	"github.com/jinzhu/configor"
+	"github.com/sonm-io/core/accounts"
 )
 
 const (
@@ -17,8 +18,9 @@ const (
 type Config interface {
 	OutputFormat() string
 	HubAddress() string
-	KeyStore() string
-	PassPhrase() string
+	// KeyStorager included into config because of
+	// cli instance must know how to open the keystore
+	accounts.KeyStorager
 }
 
 // cliConfig implements Config interface

--- a/cmd/cli/config/config_test.go
+++ b/cmd/cli/config/config_test.go
@@ -35,7 +35,9 @@ func deleteTestConfigFile() {
 func TestConfigLoad(t *testing.T) {
 	err := createTestConfigFile(`
 hub_address: 127.0.0.1:10005
-output_format: json`)
+output_format: json
+key_store: "/home/user/.sonm/keys/"
+pass_phrase: "qwerty123"`)
 	defer deleteTestConfigFile()
 	assert.NoError(t, err)
 
@@ -43,6 +45,8 @@ output_format: json`)
 	assert.NoError(t, err)
 	assert.Equal(t, "json", cfg.OutputFormat())
 	assert.Equal(t, "127.0.0.1:10005", cfg.HubAddress())
+	assert.Equal(t, "/home/user/.sonm/keys/", cfg.KeyStore())
+	assert.Equal(t, "qwerty123", cfg.PassPhrase())
 }
 
 func TestConfigDefaults(t *testing.T) {

--- a/insonmnia/node/market.go
+++ b/insonmnia/node/market.go
@@ -4,6 +4,8 @@ import (
 	"sync"
 	"time"
 
+	"crypto/ecdsa"
+
 	log "github.com/noxiouz/zapctx/ctxlog"
 	"github.com/pkg/errors"
 	"github.com/sonm-io/core/insonmnia/structs"
@@ -187,6 +189,7 @@ func (h *orderHandler) createDeal(askOrder *pb.Order) error {
 
 type marketAPI struct {
 	conf   Config
+	key    *ecdsa.PrivateKey
 	market pb.MarketClient
 	ctx    context.Context
 
@@ -233,7 +236,7 @@ func (m *marketAPI) CreateOrder(ctx context.Context, req *pb.Order) (*pb.Order, 
 		return nil, errNotAnBidOrder
 	}
 
-	req.ByuerID = m.conf.ClientID()
+	req.ByuerID = util.PubKeyToAddr(m.key.PublicKey)
 	created, err := m.market.CreateOrder(ctx, req)
 	if err != nil {
 		return nil, err

--- a/insonmnia/node/server.go
+++ b/insonmnia/node/server.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/jinzhu/configor"
 	log "github.com/noxiouz/zapctx/ctxlog"
+	"github.com/sonm-io/core/accounts"
 	pb "github.com/sonm-io/core/proto"
 	"github.com/sonm-io/core/util"
 	"go.uber.org/zap"
@@ -26,6 +27,9 @@ type Config interface {
 	LogLevel() int
 	// ClientID returns EtherumID of Node Owner
 	ClientID() string
+	// KeyStorager included into config because of
+	// Node instance must know how to open the keystore
+	accounts.KeyStorager
 }
 
 type nodeConfig struct {
@@ -48,11 +52,17 @@ type locatorConfig struct {
 	Endpoint string `required:"true" default:"" yaml:"endpoint"`
 }
 
+type keysConfig struct {
+	Keystore   string `required:"false" default:"" yaml:"key_store"`
+	Passphrase string `required:"false" default:"" yaml:"pass_phrase"`
+}
+
 type yamlConfig struct {
 	Node    nodeConfig    `required:"true" yaml:"node"`
 	Market  marketConfig  `required:"true" yaml:"market"`
 	Log     logConfig     `required:"true" yaml:"log"`
 	Locator locatorConfig `required:"true" yaml:"locator"`
+	Keys    keysConfig    `required:"false" yaml:"keys"`
 	Hub     *hubConfig    `required:"false" yaml:"hub"`
 }
 
@@ -78,12 +88,21 @@ func (y *yamlConfig) HubEndpoint() string {
 func (y *yamlConfig) ClientID() string {
 	// NOTE: just for testing on current iteration
 	// key exchange will be implemented soon
+	// TODO(sshaman1101): extract clientID from etherum key loaded from keystore
 
 	return "my-uniq-id"
 }
 
 func (y *yamlConfig) LogLevel() int {
 	return y.Log.Level
+}
+
+func (y *yamlConfig) KeyStore() string {
+	return y.Keys.Keystore
+}
+
+func (y *yamlConfig) PassPhrase() string {
+	return y.Keys.Passphrase
 }
 
 // NewConfig loads localNode config from given .yaml file

--- a/insonmnia/node/server.go
+++ b/insonmnia/node/server.go
@@ -27,8 +27,6 @@ type Config interface {
 	LocatorEndpoint() string
 	// LogLevel return log verbosity
 	LogLevel() int
-	// ClientID returns EtherumID of Node Owner
-	ClientID() string
 	// KeyStorager included into config because of
 	// Node instance must know how to open the keystore
 	accounts.KeyStorager
@@ -85,14 +83,6 @@ func (y *yamlConfig) HubEndpoint() string {
 		return y.Hub.Endpoint
 	}
 	return ""
-}
-
-func (y *yamlConfig) ClientID() string {
-	// NOTE: just for testing on current iteration
-	// key exchange will be implemented soon
-	// TODO(sshaman1101): extract clientID from etherum key loaded from keystore
-
-	return "my-uniq-id"
 }
 
 func (y *yamlConfig) LogLevel() int {

--- a/insonmnia/node/server.go
+++ b/insonmnia/node/server.go
@@ -3,6 +3,8 @@ package node
 import (
 	"net"
 
+	"crypto/ecdsa"
+
 	"github.com/jinzhu/configor"
 	log "github.com/noxiouz/zapctx/ctxlog"
 	"github.com/sonm-io/core/accounts"
@@ -119,16 +121,17 @@ func NewConfig(path string) (Config, error) {
 
 // Node is LocalNode instance
 type Node struct {
-	ctx  context.Context
-	conf Config
-	lis  net.Listener
-	srv  *grpc.Server
+	ctx     context.Context
+	conf    Config
+	lis     net.Listener
+	srv     *grpc.Server
+	privKey *ecdsa.PrivateKey
 }
 
 // New creates new Local Node instance
 // also method starts internal gRPC client connections
 // to the external services like Market and Hub
-func New(ctx context.Context, c Config) (*Node, error) {
+func New(ctx context.Context, c Config, key *ecdsa.PrivateKey) (*Node, error) {
 	lis, err := net.Listen("tcp", c.ListenAddress())
 	if err != nil {
 		return nil, err
@@ -160,10 +163,11 @@ func New(ctx context.Context, c Config) (*Node, error) {
 	pb.RegisterTaskManagementServer(srv, tasks)
 
 	return &Node{
-		lis:  lis,
-		conf: c,
-		ctx:  ctx,
-		srv:  srv,
+		lis:     lis,
+		conf:    c,
+		ctx:     ctx,
+		srv:     srv,
+		privKey: key,
 	}, nil
 }
 

--- a/node.yaml
+++ b/node.yaml
@@ -21,6 +21,13 @@ locator:
   # Locator's gRPC endpoint for Eth to IP addr resolution
   endpoint: 127.0.0.1:9090
 
+# Settings for Etherum keys
+keys:
+  # path to keystore
+  key_store: ""
+  # passphrase for keystore
+  pass_phrase: ""
+
 # Hub management settings
 # set this if you have your own hub and want to manage it
 # hub:


### PR DESCRIPTION
This PR allows a user to load Etherum keys for Node. Key loading implemented in the same way as it was done for cli (#170).

Also, a lot of code from #170 was refactored and reused. And may be reused for Hub's key loading.