### PR TITLE
feat: worker authorization

### DIFF
--- a/miner.yaml
+++ b/miner.yaml
@@ -37,3 +37,8 @@ logging:
   # type: "nvidiadocker"
   # by default nvidia-docker-plugin works on that endpoint
   # args: { nvidiadockerdriver: "localhost:3476" }
+
+ethereum:
+  # Private key for Hub Wallet ethereum account.
+  # (32 bytes in hex format without '0x' prefix.)
+  private_key: d07fff36ef2c3d15144974c25d3f5c061ae830a81eefd44292588b3cea2c701c


### PR DESCRIPTION
At last workers ACL are used.

It's also possible to run hub/miner in insecure mode as before by setting GRPC_INSECURE enrironment variable.

There are four possible cases:
- Hub insecure, miner insecure -> everything as it was before.
- Hub secure, miner insecure -> hub rejects connection.
- Hub insecure, miner secure -> framing error while connecting.
- Hub secure, miner secure -> wallet check.