### PR TITLE
feat: worker-side Hub authorization

### DIFF
--- a/insonmnia/miner/cgroup_test.go
+++ b/insonmnia/miner/cgroup_test.go
@@ -11,6 +11,7 @@ func TestParseResources(t *testing.T) {
 	defer deleteTestConfigFile()
 	raw := `
 hub:
+  endpoint: 0@0.0.0.0:0
   resources:
     cgroup: insonmnia
     resources:

--- a/insonmnia/miner/config.go
+++ b/insonmnia/miner/config.go
@@ -8,7 +8,7 @@ import (
 
 // HubConfig describes Hub configuration.
 type HubConfig struct {
-	Endpoint string           `required:"false" yaml:"endpoint"`
+	Endpoint string           `required:"true" yaml:"endpoint"`
 	CGroups  *ResourcesConfig `required:"false" yaml:"resources"`
 }
 
@@ -42,7 +42,7 @@ type ResourcesConfig struct {
 }
 
 type config struct {
-	HubConfig      *HubConfig      `required:"false" yaml:"hub"`
+	HubConfig      *HubConfig      `required:"true" yaml:"hub"`
 	FirewallConfig *FirewallConfig `required:"false" yaml:"firewall"`
 	Eth            *EthConfig      `yaml:"ethereum"`
 	GPUConfig      *gpu.Config     `required:"false" yaml:"GPUConfig"`

--- a/insonmnia/miner/config_test.go
+++ b/insonmnia/miner/config_test.go
@@ -34,20 +34,6 @@ hub:
 	assert.Equal(t, "127.0.0.1", conf.HubEndpoint())
 }
 
-func TestLoadEmptyConfig(t *testing.T) {
-	defer deleteTestConfigFile()
-	raw := `
-hub:
-  endpoint: ""`
-
-	err := createTestConfigFile(raw)
-	assert.Nil(t, err)
-
-	conf, err := NewConfig(testMinerConfigPath)
-	assert.Nil(t, err)
-	assert.Equal(t, conf.HubEndpoint(), "")
-}
-
 func TestGPUConfig(t *testing.T) {
 	err := createTestConfigFile(`
 hub:
@@ -66,15 +52,4 @@ GPUConfig:
 	assert.Equal(t, "nvidiadocker", conf.GPU().Type)
 	assert.NotEmpty(t, conf.GPU().Args)
 	assert.Equal(t, "localhost:3476", conf.GPU().Args["nvidiadockerdriver"])
-}
-
-func TestLoadConfigWithoutEndpoint(t *testing.T) {
-	defer deleteTestConfigFile()
-	err := createTestConfigFile("")
-	assert.Nil(t, err)
-
-	conf, err := NewConfig(testMinerConfigPath)
-	assert.NoError(t, err)
-	assert.Nil(t, conf.HubResources())
-	assert.Empty(t, conf.HubEndpoint())
 }

--- a/insonmnia/miner/crypto.go
+++ b/insonmnia/miner/crypto.go
@@ -1,0 +1,55 @@
+package miner
+
+import (
+	"fmt"
+	"net"
+	"strings"
+
+	"github.com/sonm-io/core/util"
+	"google.golang.org/grpc/credentials"
+)
+
+type walletAuthenticator struct {
+	credentials.TransportCredentials
+	Wallet string
+}
+
+func (w *walletAuthenticator) ServerHandshake(conn net.Conn) (net.Conn, credentials.AuthInfo, error) {
+	conn, authInfo, err := w.TransportCredentials.ServerHandshake(conn)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	switch authInfo := authInfo.(type) {
+	case util.EthAuthInfo:
+		if authInfo.Wallet[2:] != w.Wallet {
+			return nil, nil, fmt.Errorf("authorization failed: expected %s, actual %s", w.Wallet, authInfo.Wallet[2:])
+		}
+	default:
+		return nil, nil, fmt.Errorf("unsupported AuthInfo %s %T", authInfo.AuthType(), authInfo)
+	}
+
+	return conn, authInfo, nil
+}
+
+func newWalletAuthenticator(c credentials.TransportCredentials, wallet string) credentials.TransportCredentials {
+	return &walletAuthenticator{c, wallet}
+}
+
+func parseHubEndpoint(endpoint string) (string, string, error) {
+	parsed := strings.SplitN(endpoint, "@", 2)
+	if len(parsed) != 2 {
+		return "", "", errInvalidEndpointFormat
+	}
+
+	ethAddr := parsed[0]
+	socketAddr := parsed[1]
+
+	if len(ethAddr) <= 2 {
+		return "", "", errInvalidEthAddrFormat
+	}
+	if ethAddr[:2] == "0x" {
+		ethAddr = ethAddr[2:]
+	}
+	return socketAddr, ethAddr, nil
+}

--- a/insonmnia/miner/server_test.go
+++ b/insonmnia/miner/server_test.go
@@ -18,7 +18,7 @@ import (
 
 func defaultMockCfg(mock *gomock.Controller) *MockConfig {
 	cfg := NewMockConfig(mock)
-	cfg.EXPECT().HubEndpoint().AnyTimes().Return("::1")
+	cfg.EXPECT().HubEndpoint().AnyTimes().Return("0x0@::1")
 	cfg.EXPECT().HubResources().AnyTimes()
 	cfg.EXPECT().Firewall().AnyTimes()
 	cfg.EXPECT().GPU().AnyTimes()

--- a/miner.yaml
+++ b/miner.yaml
@@ -1,9 +1,8 @@
-# Hub settings. Optional.
+# Hub settings.
 hub:
-  # Endpoint for hub communication, optional param
-  # Can be omitted, in this case a discovery mechanism is activated.
-  # format is "ip:port"
-   endpoint: "127.0.0.1:10002"
+  # Endpoint for hub communication
+  # Format is "ethAddr@ip:port".
+   endpoint: c54f43a8ec76C15162CC80f31Cf02aE4cd31727@127.0.0.1:10002
 
   # Resources section is available only on Linux
   # If configured, all tasks will share this pool of resources.


### PR DESCRIPTION
This commit activates worker-side Hub authorization using specified wallet key as a Hub endpoint. This wallet is compared with signed-one provided by a Hub during TLS handshake, verifying that we've connected to the proper Hub.

It is also planned to be used for discovery through the Locator, but for now a Hub address must also be specified. The result hub endpoint format is <ethAddr>@<socketAddr>.

This commit also makes hub settings required. I have no idea what to do with whisper at worker's side, but it seems that it can be safely removed.