### PR TITLE
feat: preload entities from cluster

### DIFF
--- a/insonmnia/hub/cluster.go
+++ b/insonmnia/hub/cluster.go
@@ -65,7 +65,7 @@ type Cluster interface {
 
 	LeaderClient() (pb.HubClient, error)
 
-	RegisterAndLoadEntity(name string, prototype interface{})
+	RegisterAndLoadEntity(name string, prototype interface{}) error
 
 	Synchronize(entity interface{}) error
 }
@@ -191,24 +191,24 @@ func (c *cluster) LeaderClient() (pb.HubClient, error) {
 func (c *cluster) RegisterAndLoadEntity(name string, prototype interface{}) error {
 	c.registeredEntitiesMu.Lock()
 	defer c.registeredEntitiesMu.Unlock()
-	t := reflect.TypeOf(prototype)
+	t := reflect.Indirect(reflect.ValueOf(prototype)).Type()
 	c.registeredEntities[name] = t
 	c.entityNames[t] = name
 	keyName := c.cfg.SynchronizableEntitiesPrefix + "/" + name
 	exists, err := c.store.Exists(keyName)
 	if err != nil {
-		return errors.Wrap(err, fmt.Sprintf("could not check entity {} for existance in storage", name))
+		return errors.Wrap(err, fmt.Sprintf("could not check entity %s for existance in storage", name))
 	}
 	if !exists {
 		return nil
 	}
 	kvPair, err := c.store.Get(keyName)
 	if err != nil {
-		return errors.Wrap(err, fmt.Sprintf("could not fetch entity {} initial value from storage", name))
+		return errors.Wrap(err, fmt.Sprintf("could not fetch entity %s initial value from storage", name))
 	}
 	err = json.Unmarshal(kvPair.Value, prototype)
 	if err != nil {
-		return errors.Wrap(err, fmt.Sprintf("could not unmarshal entity {} from storage data", name))
+		return errors.Wrap(err, fmt.Sprintf("could not unmarshal entity %s from storage data", name))
 	}
 	return nil
 }

--- a/insonmnia/hub/cluster.go
+++ b/insonmnia/hub/cluster.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/tls"
 	"encoding/json"
+	"fmt"
 	"net"
 	"reflect"
 	"strings"
@@ -64,7 +65,7 @@ type Cluster interface {
 
 	LeaderClient() (pb.HubClient, error)
 
-	RegisterEntity(name string, prototype interface{})
+	RegisterAndLoadEntity(name string, prototype interface{})
 
 	Synchronize(entity interface{}) error
 }
@@ -187,12 +188,29 @@ func (c *cluster) LeaderClient() (pb.HubClient, error) {
 	return client.client, nil
 }
 
-func (c *cluster) RegisterEntity(name string, prototype interface{}) {
+func (c *cluster) RegisterAndLoadEntity(name string, prototype interface{}) error {
 	c.registeredEntitiesMu.Lock()
 	defer c.registeredEntitiesMu.Unlock()
 	t := reflect.TypeOf(prototype)
 	c.registeredEntities[name] = t
 	c.entityNames[t] = name
+	keyName := c.cfg.SynchronizableEntitiesPrefix + "/" + name
+	exists, err := c.store.Exists(keyName)
+	if err != nil {
+		return errors.Wrap(err, fmt.Sprintf("could not check entity {} for existance in storage", name))
+	}
+	if !exists {
+		return nil
+	}
+	kvPair, err := c.store.Get(keyName)
+	if err != nil {
+		return errors.Wrap(err, fmt.Sprintf("could not fetch entity {} initial value from storage", name))
+	}
+	err = json.Unmarshal(kvPair.Value, prototype)
+	if err != nil {
+		return errors.Wrap(err, fmt.Sprintf("could not unmarshal entity {} from storage data", name))
+	}
+	return nil
 }
 
 func (c *cluster) Synchronize(entity interface{}) error {

--- a/insonmnia/hub/server.go
+++ b/insonmnia/hub/server.go
@@ -900,10 +900,10 @@ func (h *Hub) Serve() error {
 		h.waiter.Go(h.startLocatorAnnouncer)
 	}
 
-	h.cluster.RegisterEntity("tasks", h.tasks)
-	h.cluster.RegisterEntity("device_properties", h.deviceProperties)
-	h.cluster.RegisterEntity("acl", h.acl)
-	h.cluster.RegisterEntity("slots", h.slots)
+	h.cluster.RegisterAndLoadEntity("tasks", h.tasks)
+	h.cluster.RegisterAndLoadEntity("device_properties", h.deviceProperties)
+	h.cluster.RegisterAndLoadEntity("acl", h.acl)
+	h.cluster.RegisterAndLoadEntity("slots", h.slots)
 
 	h.waiter.Go(h.runCluster)
 	h.waiter.Go(h.listenClusterEvents)

--- a/insonmnia/hub/server.go
+++ b/insonmnia/hub/server.go
@@ -900,10 +900,23 @@ func (h *Hub) Serve() error {
 		h.waiter.Go(h.startLocatorAnnouncer)
 	}
 
-	h.cluster.RegisterAndLoadEntity("tasks", h.tasks)
-	h.cluster.RegisterAndLoadEntity("device_properties", h.deviceProperties)
-	h.cluster.RegisterAndLoadEntity("acl", h.acl)
-	h.cluster.RegisterAndLoadEntity("slots", h.slots)
+	if err := h.cluster.RegisterAndLoadEntity("tasks", &h.tasks); err != nil {
+		return err
+	}
+	if err := h.cluster.RegisterAndLoadEntity("device_properties", &h.deviceProperties); err != nil {
+		return err
+	}
+	if err := h.cluster.RegisterAndLoadEntity("acl", &h.acl); err != nil {
+		return err
+	}
+	if err := h.cluster.RegisterAndLoadEntity("slots", &h.slots); err != nil {
+		return err
+	}
+	log.G(h.ctx).Info("fetched entities",
+		zap.Any("tasks", h.tasks),
+		zap.Any("device_properties", h.deviceProperties),
+		zap.Any("acl", h.acl),
+		zap.Any("slots", h.slots))
 
 	h.waiter.Go(h.runCluster)
 	h.waiter.Go(h.listenClusterEvents)


### PR DESCRIPTION
This PR loads all synchronizable entities before hub startup to prevent races.
@noxiouz PTAL