### PR TITLE
fix: blocking grpc leader connection for straight error detection

### DIFF
--- a/insonmnia/hub/cluster.go
+++ b/insonmnia/hub/cluster.go
@@ -602,7 +602,7 @@ func (c *cluster) registerMember(id string, endpoints []string) error {
 	}
 
 	for _, ep := range endpoints {
-		conn, err := util.MakeGrpcClient(c.ctx, ep, c.creds)
+		conn, err := util.MakeGrpcClient(c.ctx, ep, c.creds, grpc.WithBlock(), grpc.WithTimeout(time.Second*5))
 		if err != nil {
 			log.G(c.ctx).Warn("could not connect to hub", zap.String("endpoint", ep), zap.Error(err))
 			continue


### PR DESCRIPTION
Small PRs as @3Hren requested  :)

this PR discards all broken endpoints due to blocking connections. Previous behaviour did not return error resulting in malfunctioning client