### PR TITLE
fix: create store prefix if necessary

### DIFF
--- a/insonmnia/hub/cluster.go
+++ b/insonmnia/hub/cluster.go
@@ -83,7 +83,7 @@ func NewCluster(ctx context.Context, cfg *ClusterConfig, creds credentials.Trans
 		return nil, nil, err
 	}
 
-	err = store.Put(cfg.SynchronizableEntitiesPrefix, []byte{}, nil)
+	err = store.Put(cfg.SynchronizableEntitiesPrefix, []byte{}, &store.WriteOptions{IsDir: true})
 	if err != nil {
 		return nil, nil, err
 	}

--- a/insonmnia/hub/cluster.go
+++ b/insonmnia/hub/cluster.go
@@ -83,16 +83,9 @@ func NewCluster(ctx context.Context, cfg *ClusterConfig, creds credentials.Trans
 		return nil, nil, err
 	}
 
-	exists, err := store.Exists(cfg.SynchronizableEntitiesPrefix)
+	err = store.Put(cfg.SynchronizableEntitiesPrefix, []byte{}, nil)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to check if SynchronizableEntitiesPrefix exists: %s", err)
-	}
-
-	if !exists {
-		err = store.Put(cfg.SynchronizableEntitiesPrefix, []byte{}, nil)
-		if err != nil {
-			return nil, nil, err
-		}
+		return nil, nil, err
 	}
 
 	endpoints, err := parseEndpoints(cfg)

--- a/insonmnia/hub/cluster.go
+++ b/insonmnia/hub/cluster.go
@@ -82,6 +82,19 @@ func NewCluster(ctx context.Context, cfg *ClusterConfig, creds credentials.Trans
 	if err != nil {
 		return nil, nil, err
 	}
+
+	exists, err := store.Exists(cfg.SynchronizableEntitiesPrefix)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to check if SynchronizableEntitiesPrefix exists: %s", err)
+	}
+
+	if !exists {
+		err = store.Put(cfg.SynchronizableEntitiesPrefix, []byte{}, nil)
+		if err != nil {
+			return nil, nil, err
+		}
+	}
+
 	endpoints, err := parseEndpoints(cfg)
 	if err != nil {
 		return nil, nil, err

--- a/insonmnia/hub/cluster.go
+++ b/insonmnia/hub/cluster.go
@@ -78,12 +78,12 @@ type Cluster interface {
 // Should be recalled when a cluster's master/slave state changes.
 // The channel is closed when the specified context is canceled.
 func NewCluster(ctx context.Context, cfg *ClusterConfig, creds credentials.TransportCredentials) (Cluster, <-chan ClusterEvent, error) {
-	store, err := makeStore(ctx, cfg)
+	clusterStore, err := makeStore(ctx, cfg)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	err = store.Put(cfg.SynchronizableEntitiesPrefix, []byte{}, &store.WriteOptions{IsDir: true})
+	err = clusterStore.Put(cfg.SynchronizableEntitiesPrefix, []byte{}, &store.WriteOptions{IsDir: true})
 	if err != nil {
 		return nil, nil, err
 	}
@@ -99,7 +99,7 @@ func NewCluster(ctx context.Context, cfg *ClusterConfig, creds credentials.Trans
 		registeredEntities: make(map[string]reflect.Type),
 		entityNames:        make(map[reflect.Type]string),
 
-		store: store,
+		store: clusterStore,
 
 		isLeader:  true,
 		id:        uuid.NewV1().String(),


### PR DESCRIPTION
Initialises store with appropriate SynchronizableEntitiesPrefix. Compound prefixes (e.g., "/a/b/c" are allowed). Tested with boltdb and consul store backends.