### PR TITLE
chore: change util's log-level to Debug

### DIFF
--- a/util/certs.go
+++ b/util/certs.go
@@ -87,13 +87,13 @@ func (r *hitlessCertRotator) rotateOnce() (*tls.Certificate, error) {
 
 func (r *hitlessCertRotator) rotation() {
 	rotationPeriod := validPeriod / 3
-	log.G(r.ctx).Info("start certificate rotation loop", zap.Duration("every", rotationPeriod))
+	log.G(r.ctx).Debug("start certificate rotation loop", zap.Duration("every", rotationPeriod))
 	t := time.NewTicker(rotationPeriod)
 	defer t.Stop()
 	for {
 		select {
 		case <-t.C:
-			log.G(r.ctx).Info("rotate certificate")
+			log.G(r.ctx).Debug("rotate certificate")
 			cert, err := r.rotateOnce()
 			if err == nil {
 				r.mu.Lock()


### PR DESCRIPTION
This PR disable logs from the `util` package shown when using this package into CLI.

Each debugging line with `start certificate rotation loop...` is breaking valid JSON output for CLI.