### PR TITLE
fix: better makefile install rule

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,11 @@ GOCMD=./cmd
 ifeq ($(GO), )
     GO=go
 endif
+
+ifeq ($(GOPATH), )
+    GOPATH=$(shell ls -d ~/go)
+endif
+
 INSTALLDIR=${GOPATH}/bin/
 
 MINER=sonmminer
@@ -75,27 +80,10 @@ build/aux: build/locator build/marketplace
 
 build: build/insomnia build/aux
 
-install/miner: build/miner
+install: all
 	@echo "+ $@"
 	mkdir -p ${INSTALLDIR}
-	cp ${MINER} ${INSTALLDIR}
-
-install/hub: build/hub
-	@echo "+ $@"
-	mkdir -p ${INSTALLDIR}
-	cp ${HUB} ${INSTALLDIR}
-
-install/cli: build/cli
-	@echo "+ $@"
-	mkdir -p ${INSTALLDIR}
-	cp ${CLI} ${INSTALLDIR}
-
-install/node: build/node
-	@echo "+ $@"
-	mkdir -p ${INSTALLDIR}
-	cp ${LOCAL_NODE} ${INSTALLDIR}
-
-install: install/miner install/hub install/cli
+	cp ${MINER} ${HUB} ${CLI} ${LOCATOR} ${MARKET} ${LOCAL_NODE} ${INSTALLDIR}
 
 vet:
 	@echo "+ $@"

--- a/fusrodah/examples/hub/main.go
+++ b/fusrodah/examples/hub/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/sonm-io/core/fusrodah/hub"
 )

--- a/fusrodah/hub/server_test.go
+++ b/fusrodah/hub/server_test.go
@@ -2,9 +2,10 @@ package hub
 
 import (
 	"encoding/json"
+	"testing"
+
 	"github.com/sonm-io/core/fusrodah"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 // marshalDiscoveryMessage

--- a/fusrodah/miner/server_test.go
+++ b/fusrodah/miner/server_test.go
@@ -2,9 +2,10 @@ package miner
 
 import (
 	"encoding/json"
+	"testing"
+
 	"github.com/sonm-io/core/fusrodah"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func marshalTestData(wrk, cli string) []byte {

--- a/insonmnia/gateway/pool.go
+++ b/insonmnia/gateway/pool.go
@@ -3,9 +3,10 @@ package gateway
 import (
 	"errors"
 
-	"gopkg.in/oleiade/lane.v1"
 	"math/rand"
 	"sync"
+
+	"gopkg.in/oleiade/lane.v1"
 )
 
 type PortPool struct {

--- a/insonmnia/gateway/pool_test.go
+++ b/insonmnia/gateway/pool_test.go
@@ -1,8 +1,9 @@
 package gateway
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestPool(t *testing.T) {

--- a/insonmnia/hub/router_nonlinux.go
+++ b/insonmnia/hub/router_nonlinux.go
@@ -4,6 +4,7 @@ package hub
 
 import (
 	"context"
+
 	"github.com/sonm-io/core/insonmnia/gateway"
 )
 

--- a/insonmnia/resource/pool.go
+++ b/insonmnia/resource/pool.go
@@ -2,8 +2,9 @@ package resource
 
 import (
 	"errors"
-	"github.com/sonm-io/core/insonmnia/hardware"
 	"sync"
+
+	"github.com/sonm-io/core/insonmnia/hardware"
 )
 
 var (

--- a/insonmnia/structs/common.go
+++ b/insonmnia/structs/common.go
@@ -2,6 +2,7 @@ package structs
 
 import (
 	"errors"
+
 	pb "github.com/sonm-io/core/proto"
 )
 


### PR DESCRIPTION
it's rather strange that make install builds insomnia, but do not build marketplace and locator.
This PR fixes this and failure in case of missing GOPATH var