### PR TITLE
feat: miner resolves hub addr via locator

### DIFF
--- a/cmd/miner/main.go
+++ b/cmd/miner/main.go
@@ -56,7 +56,12 @@ func main() {
 	logger := logging.BuildLogger(cfg.Logging().Level, true)
 	ctx = log.WithLogger(ctx, logger)
 
-	builder := miner.NewMinerBuilder(cfg, key)
+	builder, err := miner.NewMinerBuilder(cfg, key)
+	if err != nil {
+		log.GetLogger(ctx).Error("failed to init miner builder:", zap.Error(err))
+		os.Exit(1)
+	}
+
 	builder.Context(ctx)
 	builder.UUID(uuid)
 	m, err := builder.Build()

--- a/insonmnia/miner/builder.go
+++ b/insonmnia/miner/builder.go
@@ -272,6 +272,10 @@ func (b *MinerBuilder) getHubConnectionInfo() (string, common.Address, error) {
 		return "", common.Address{}, fmt.Errorf("all hub endpoints are unreachable: %+v", encounteredErrors)
 	}
 
+	if _, _, err := net.SplitHostPort(hubSockAddr); err != nil {
+		return "", common.Address{}, err
+	}
+
 	return hubSockAddr, hubEthAddr, err
 }
 

--- a/insonmnia/miner/builder.go
+++ b/insonmnia/miner/builder.go
@@ -3,10 +3,9 @@ package miner
 import (
 	"crypto/ecdsa"
 	"fmt"
+	"net"
 	"strings"
 	"time"
-
-	"net"
 
 	"github.com/ccding/go-stun/stun"
 	"github.com/ethereum/go-ethereum/common"
@@ -136,6 +135,7 @@ func (b *MinerBuilder) Build() (miner *Miner, err error) {
 
 	hubSockaddr, hubEthAddr, err := b.getHubConnectionInfo()
 	if err != nil {
+		cancel()
 		return nil, err
 	}
 

--- a/insonmnia/miner/cgroup_test.go
+++ b/insonmnia/miner/cgroup_test.go
@@ -21,6 +21,8 @@ hub:
       cpu:
         quota: 1024
         cpus: "ddd"
+locator:
+  endpoint: "8125721C2413d99a33E351e1F6Bb4e56b6b633FD@127.0.0.1:9090"
 `
 	err := createTestConfigFile(raw)
 	assertions.NoError(err)

--- a/insonmnia/miner/config.go
+++ b/insonmnia/miner/config.go
@@ -38,6 +38,10 @@ type ResourcesConfig struct {
 	Resources *specs.LinuxResources `required:"false" yaml:"resources"`
 }
 
+type LocatorConfig struct {
+	Endpoint string `required:"true" yaml:"endpoint"`
+}
+
 type config struct {
 	HubConfig       HubConfig           `required:"true" yaml:"hub"`
 	FirewallConfig  *FirewallConfig     `required:"false" yaml:"firewall"`
@@ -45,6 +49,7 @@ type config struct {
 	GPUConfig       *gpu.Config         `required:"false" yaml:"GPUConfig"`
 	SSHConfig       *SSHConfig          `required:"false" yaml:"ssh"`
 	LoggingConfig   LoggingConfig       `yaml:"logging"`
+	LocatorConfig   *LocatorConfig      `required:"true" yaml:"locator"`
 	UUIDPathConfig  string              `required:"false" yaml:"uuid_path"`
 	PublicIPsConfig []string            `required:"false" yaml:"public_ip_addrs"`
 }
@@ -85,6 +90,10 @@ func (c *config) ETH() *accounts.EthConfig {
 	return c.Eth
 }
 
+func (c *config) LocatorEndpoint() string {
+	return c.LocatorConfig.Endpoint
+}
+
 // NewConfig creates a new Miner config from the specified YAML file.
 func NewConfig(path string) (Config, error) {
 	cfg := &config{}
@@ -119,4 +128,6 @@ type Config interface {
 	UUIDPath() string
 	// ETH returns ethereum configuration
 	ETH() *accounts.EthConfig
+	// LocatorEndpoint returns locator endpoint.
+	LocatorEndpoint() string
 }

--- a/insonmnia/miner/config_test.go
+++ b/insonmnia/miner/config_test.go
@@ -24,7 +24,9 @@ func TestLoadConfig(t *testing.T) {
 	defer deleteTestConfigFile()
 	raw := `
 hub:
-  endpoint: 127.0.0.1`
+  endpoint: 127.0.0.1
+locator:
+  endpoint: "8125721C2413d99a33E351e1F6Bb4e56b6b633FD@127.0.0.1:9090"`
 	err := createTestConfigFile(raw)
 	assert.Nil(t, err)
 
@@ -43,6 +45,8 @@ logging:
 GPUConfig:
   type: nvidiadocker
   args: { nvidiadockerdriver: "localhost:3476" }
+locator:
+  endpoint: "8125721C2413d99a33E351e1F6Bb4e56b6b633FD@127.0.0.1:9090"
 `)
 	assert.NoError(t, err)
 	defer deleteTestConfigFile()

--- a/insonmnia/miner/server.go
+++ b/insonmnia/miner/server.go
@@ -626,7 +626,7 @@ func (m *Miner) connectToHub(address string) {
 		return
 	}
 
-	// NOTE: it's not the best soluction
+	// NOTE: it's not the best solution.
 	// It's needed to detect connection failure.
 	// Refactor: to detect reconnection from Accept
 	// Look at LimitListener

--- a/insonmnia/miner/server_test.go
+++ b/insonmnia/miner/server_test.go
@@ -31,7 +31,7 @@ func getTestKey() *ecdsa.PrivateKey {
 func defaultMockCfg(mock *gomock.Controller) *MockConfig {
 	cfg := NewMockConfig(mock)
 	mockedwallet := util.PubKeyToAddr(getTestKey().PublicKey).Hex()
-	cfg.EXPECT().HubEndpoint().AnyTimes().Return(mockedwallet + "@::1")
+	cfg.EXPECT().HubEndpoint().AnyTimes().Return(mockedwallet + "@42")
 	cfg.EXPECT().HubResources().AnyTimes()
 	cfg.EXPECT().Firewall().AnyTimes()
 	cfg.EXPECT().GPU().AnyTimes()
@@ -55,7 +55,7 @@ func TestServerNewExtractsHubEndpoint(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.NotNil(t, m)
-	assert.Equal(t, "::1", m.hubAddress)
+	assert.Equal(t, "42", m.hubAddress)
 }
 
 func TestServerNewFailsWhenFailedCollectResources(t *testing.T) {

--- a/insonmnia/miner/server_test.go
+++ b/insonmnia/miner/server_test.go
@@ -31,7 +31,7 @@ func getTestKey() *ecdsa.PrivateKey {
 func defaultMockCfg(mock *gomock.Controller) *MockConfig {
 	cfg := NewMockConfig(mock)
 	mockedwallet := util.PubKeyToAddr(getTestKey().PublicKey).Hex()
-	cfg.EXPECT().HubEndpoint().AnyTimes().Return(mockedwallet + "@42")
+	cfg.EXPECT().HubEndpoint().AnyTimes().Return(mockedwallet + "@localhost:4242")
 	cfg.EXPECT().HubResources().AnyTimes()
 	cfg.EXPECT().Firewall().AnyTimes()
 	cfg.EXPECT().GPU().AnyTimes()
@@ -55,7 +55,7 @@ func TestServerNewExtractsHubEndpoint(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.NotNil(t, m)
-	assert.Equal(t, "42", m.hubAddress)
+	assert.Equal(t, "localhost:4242", m.hubAddress)
 }
 
 func TestServerNewFailsWhenFailedCollectResources(t *testing.T) {

--- a/miner.yaml
+++ b/miner.yaml
@@ -1,8 +1,9 @@
 # Hub settings.
 hub:
   # Endpoint for hub communication
-  # Format is "ethAddr@ip:port".
-  endpoint: 8125721C2413d99a33E351e1F6Bb4e56b6b633FD@127.0.0.1:10002
+  # Format is either "ethAddr" or "ethAddr@ip:port". If only ethAddr is provided,
+  # ip:port will be resolved via locator.
+  endpoint: "8125721C2413d99a33E351e1F6Bb4e56b6b633FD@127.0.0.1:10002"
 
 #  Resources section is available only on Linux
 #  If configured, all tasks will share this pool of resources.
@@ -51,3 +52,8 @@ ethereum:
   key_store: "./keys"
   # passphrase for keystore
   pass_phrase: "any"
+
+# locator service allows nodes to discover each other
+locator:
+  # locator gRPC endpoint, required
+  endpoint: "8125721C2413d99a33E351e1F6Bb4e56b6b633FD@127.0.0.1:9090"

--- a/miner.yaml
+++ b/miner.yaml
@@ -1,8 +1,8 @@
 # Hub settings.
 hub:
   # Endpoint for hub communication
-  # Format is either "ethAddr" or "ethAddr@ip:port". If only ethAddr is provided,
-  # ip:port will be resolved via locator.
+  # Format is either "ethAddr@:port" or "ethAddr@ip:port". If only "ethAddr@:port" is provided,
+  # ip will be resolved via locator.
   endpoint: "8125721C2413d99a33E351e1F6Bb4e56b6b633FD@127.0.0.1:10002"
 
 #  Resources section is available only on Linux

--- a/miner.yaml
+++ b/miner.yaml
@@ -3,7 +3,7 @@ hub:
   # Endpoint for hub communication
   # Format is either "ethAddr@:port" or "ethAddr@ip:port". If only "ethAddr@:port" is provided,
   # ip will be resolved via locator.
-  endpoint: "8125721C2413d99a33E351e1F6Bb4e56b6b633FD@42"
+  endpoint: "8125721C2413d99a33E351e1F6Bb4e56b6b633FD@127.0.0.1:10002"
 
 #  Resources section is available only on Linux
 #  If configured, all tasks will share this pool of resources.

--- a/miner.yaml
+++ b/miner.yaml
@@ -3,7 +3,7 @@ hub:
   # Endpoint for hub communication
   # Format is either "ethAddr@:port" or "ethAddr@ip:port". If only "ethAddr@:port" is provided,
   # ip will be resolved via locator.
-  endpoint: "8125721C2413d99a33E351e1F6Bb4e56b6b633FD@127.0.0.1:10002"
+  endpoint: "8125721C2413d99a33E351e1F6Bb4e56b6b633FD@42"
 
 #  Resources section is available only on Linux
 #  If configured, all tasks will share this pool of resources.

--- a/util/grpcsecure.go
+++ b/util/grpcsecure.go
@@ -161,10 +161,11 @@ func ParseEndpoint(endpoint string) (string, ethcommon.Address, error) {
 	return socketAddr, ethcommon.HexToAddress(ethAddr), nil
 }
 
-func MakeWalletAuthenticatedClient(ctx context.Context, creds credentials.TransportCredentials, endpoint string) (*grpc.ClientConn, error) {
+func MakeWalletAuthenticatedClient(ctx context.Context, creds credentials.TransportCredentials, endpoint string,
+	opts ...grpc.DialOption) (*grpc.ClientConn, error) {
 	sockaddr, ethAddr, err := ParseEndpoint(endpoint)
 	if err != nil {
-		conn, err := MakeGrpcClient(ctx, endpoint, creds)
+		conn, err := MakeGrpcClient(ctx, endpoint, creds, opts...)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
* If hub's address is just an ethereum addr, miner looks up hub's addr via locator.
* Addresses returned by locator are checked for reachability, the first reachable address is used.