### PR TITLE
feat: entire task API authorization & authentication

### DIFF
--- a/cmd/cli/commands/common.go
+++ b/cmd/cli/commands/common.go
@@ -12,6 +12,7 @@ import (
 	"github.com/sonm-io/core/cmd/cli/config"
 	"github.com/sonm-io/core/util"
 	"github.com/spf13/cobra"
+	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 )
 
@@ -46,6 +47,7 @@ var (
 	cfg        config.Config
 	sessionKey *ecdsa.PrivateKey = nil
 	creds      credentials.TransportCredentials
+	walletAuth *util.SelfSignedWallet
 
 	// errors
 	errCannotParsePropsFile = errors.New("cannot parse props file")
@@ -169,9 +171,21 @@ func loadKeyStoreWrapper(cmd *cobra.Command, _ []string) {
 		os.Exit(1)
 	}
 	creds = util.NewTLS(TLSConfig)
+
+	wallet, err := util.NewSelfSignedWallet(sessionKey)
+	if err != nil {
+		showError(cmd, err.Error(), nil)
+		os.Exit(1)
+	}
+
+	walletAuth = wallet
 }
 
 func showJSON(cmd *cobra.Command, s interface{}) {
 	b, _ := json.Marshal(s)
 	cmd.Printf("%s\r\n", b)
+}
+
+func WithWalletPerRPCCredentials() grpc.DialOption {
+	return grpc.WithPerRPCCredentials(util.NewWalletAccess(walletAuth))
 }

--- a/cmd/cli/commands/interactor.go
+++ b/cmd/cli/commands/interactor.go
@@ -7,6 +7,7 @@ import (
 	pb "github.com/sonm-io/core/proto"
 	"github.com/sonm-io/core/util"
 	"golang.org/x/net/context"
+	"google.golang.org/grpc"
 )
 
 type NodeHubInteractor interface {
@@ -358,8 +359,8 @@ func (it *tasksInteractor) ImagePull(dealID, taskID string) (pb.Hub_PullTaskClie
 	return it.tasks.PullTask(ctx, req)
 }
 
-func NewTasksInteractor(addr string, timeout time.Duration) (TasksInteractor, error) {
-	cc, err := util.MakeGrpcClient(context.Background(), addr, creds)
+func NewTasksInteractor(addr string, timeout time.Duration, opts ...grpc.DialOption) (TasksInteractor, error) {
+	cc, err := util.MakeGrpcClient(context.Background(), addr, creds, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/cli/commands/node_tasks.go
+++ b/cmd/cli/commands/node_tasks.go
@@ -1,13 +1,11 @@
 package commands
 
 import (
-	"os"
-
-	"io"
-
 	"bufio"
 	"bytes"
 	"fmt"
+	"io"
+	"os"
 	"strconv"
 
 	"github.com/gosuri/uiprogress"
@@ -80,7 +78,7 @@ var taskStartCmd = &cobra.Command{
 	PreRun: loadKeyStoreWrapper,
 	Args:   cobra.MinimumNArgs(2),
 	Run: func(cmd *cobra.Command, args []string) {
-		node, err := NewTasksInteractor(nodeAddressFlag, timeoutFlag)
+		node, err := NewTasksInteractor(nodeAddressFlag, timeoutFlag, WithWalletPerRPCCredentials())
 		if err != nil {
 			showError(cmd, "Cannot connect to Node", err)
 			os.Exit(1)
@@ -125,7 +123,7 @@ var taskStatusCmd = &cobra.Command{
 	PreRun: loadKeyStoreWrapper,
 	Args:   cobra.MinimumNArgs(2),
 	Run: func(cmd *cobra.Command, args []string) {
-		node, err := NewTasksInteractor(nodeAddressFlag, timeoutFlag)
+		node, err := NewTasksInteractor(nodeAddressFlag, timeoutFlag, WithWalletPerRPCCredentials())
 		if err != nil {
 			showError(cmd, "Cannot connect to Node", err)
 			os.Exit(1)
@@ -149,7 +147,7 @@ var taskLogsCmd = &cobra.Command{
 	PreRun: loadKeyStoreWrapper,
 	Args:   cobra.MinimumNArgs(2),
 	Run: func(cmd *cobra.Command, args []string) {
-		node, err := NewTasksInteractor(nodeAddressFlag, timeoutFlag)
+		node, err := NewTasksInteractor(nodeAddressFlag, timeoutFlag, WithWalletPerRPCCredentials())
 		if err != nil {
 			showError(cmd, "Cannot connect to Node", err)
 			os.Exit(1)
@@ -197,7 +195,7 @@ var taskStopCmd = &cobra.Command{
 	PreRun: loadKeyStoreWrapper,
 	Args:   cobra.MinimumNArgs(2),
 	Run: func(cmd *cobra.Command, args []string) {
-		node, err := NewTasksInteractor(nodeAddressFlag, timeoutFlag)
+		node, err := NewTasksInteractor(nodeAddressFlag, timeoutFlag, WithWalletPerRPCCredentials())
 		if err != nil {
 			showError(cmd, "Cannot connect to Node", err)
 			os.Exit(1)
@@ -241,7 +239,7 @@ var taskPullCmd = &cobra.Command{
 
 		w := bufio.NewWriter(wr)
 
-		node, err := NewTasksInteractor(nodeAddressFlag, timeoutFlag)
+		node, err := NewTasksInteractor(nodeAddressFlag, timeoutFlag, WithWalletPerRPCCredentials())
 		if err != nil {
 			showError(cmd, "Cannot connect to Node", err)
 			os.Exit(1)
@@ -338,7 +336,7 @@ var taskPushCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		node, err := NewTasksInteractor(nodeAddressFlag, timeoutFlag)
+		node, err := NewTasksInteractor(nodeAddressFlag, timeoutFlag, WithWalletPerRPCCredentials())
 		if err != nil {
 			showError(cmd, "Cannot connect to Node", err)
 			os.Exit(1)

--- a/insonmnia/hub/acl.go
+++ b/insonmnia/hub/acl.go
@@ -145,6 +145,13 @@ func (e *eventACL) authorize(ctx context.Context, method method, request interfa
 	return authorization.Authorize(ctx, request)
 }
 
+func (e *eventACL) addAuthorization(method method, auth EventAuthorization) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	e.verifiers[method] = auth
+}
+
 // InsertDealCredentials inserts the specified deal credentials for entire
 // Deal API.
 func (e *eventACL) insertDealCredentials(dealID DealID, wallet string) {

--- a/insonmnia/hub/acl.go
+++ b/insonmnia/hub/acl.go
@@ -21,6 +21,7 @@ var (
 	errNoPeerInfo       = status.Error(codes.Unauthenticated, "no peer info")
 	errNoDealProvided   = status.Error(codes.Unauthenticated, "no `deal` metadata provided")
 	errNoDealFieldFound = status.Error(codes.Internal, "no `Deal` field found")
+	errNoTaskFieldFound = status.Errorf(codes.Internal, "no task `ID` field found")
 	errNoMetadata       = status.Error(codes.Unauthenticated, "no metadata provided")
 	errNoWalletProvided = status.Error(codes.Unauthenticated, "no wallet provided")
 )
@@ -237,8 +238,10 @@ func (d *dealAuthorization) Authorize(ctx context.Context, request interface{}) 
 		return err
 	}
 
+	log.G(d.ctx).Debug("recovered address", zap.String("addr", string(recoveredAddr)))
+
 	if allowedWallet != recoveredAddr {
-		status.Errorf(codes.Unauthenticated, "wallet mismatch: want: %x have: %x", allowedWallet, recoveredAddr)
+		return status.Errorf(codes.Unauthenticated, "wallet mismatch: %s", recoveredAddr)
 	}
 
 	return nil

--- a/insonmnia/hub/acl.go
+++ b/insonmnia/hub/acl.go
@@ -275,11 +275,14 @@ type fieldDealRequestMetaData struct{}
 func (fieldDealRequestMetaData) Deal(ctx context.Context, request interface{}) (DealID, error) {
 	requestValue := reflect.Indirect(reflect.ValueOf(request))
 	deal := requestValue.FieldByName("Deal")
-	if deal.IsNil() {
+	if !deal.IsValid() {
 		return "", errNoDealFieldFound
 	}
 
 	dealId := reflect.Indirect(deal).FieldByName("Id")
+	if !dealId.IsValid() {
+		return "", errNoDealFieldFound
+	}
 
 	return DealID(dealId.String()), nil
 }
@@ -320,6 +323,10 @@ type taskFieldDealRequestMetaData struct {
 func (t *taskFieldDealRequestMetaData) Deal(ctx context.Context, request interface{}) (DealID, error) {
 	requestValue := reflect.Indirect(reflect.ValueOf(request))
 	taskID := requestValue.FieldByName("Id")
+	if !taskID.IsValid() {
+		return "", errNoTaskFieldFound
+	}
+
 	taskInfo, ok := t.hub.tasks[taskID.String()]
 	if !ok {
 		return "", errTaskNotFound

--- a/insonmnia/hub/acl_test.go
+++ b/insonmnia/hub/acl_test.go
@@ -1,0 +1,7 @@
+package hub
+
+import "testing"
+
+func testFieldDealMetaData(t *testing.T) {
+
+}

--- a/insonmnia/hub/acl_test.go
+++ b/insonmnia/hub/acl_test.go
@@ -1,7 +1,152 @@
 package hub
 
-import "testing"
+import (
+	"context"
+	"testing"
 
-func testFieldDealMetaData(t *testing.T) {
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/sonm-io/core/proto"
+	"github.com/sonm-io/core/util"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/peer"
+)
 
+func TestFieldDealMetaData(t *testing.T) {
+	request := &sonm.HubStartTaskRequest{
+		Deal: &sonm.Deal{
+			Id: "0x42",
+		},
+	}
+
+	md := fieldDealMetaData{}
+	dealID, err := md.Deal(context.Background(), request)
+	require.NoError(t, err)
+	assert.Equal(t, DealID("0x42"), dealID)
+}
+
+func TestFieldDealMetaDataErrorsOnInvalidType(t *testing.T) {
+	type Request struct {
+		Deal string
+	}
+	request := &Request{
+		Deal: "0x42",
+	}
+
+	md := fieldDealMetaData{}
+	dealID, err := md.Deal(context.Background(), request)
+	assert.Error(t, err)
+	assert.Equal(t, DealID(""), dealID)
+}
+
+func TestFieldDealMetaDataErrorsOnInvalidInnerType(t *testing.T) {
+	type Deal struct {
+		Id int
+	}
+	type Request struct {
+		Deal *Deal
+	}
+	request := &Request{
+		Deal: &Deal{
+			Id: 42,
+		},
+	}
+
+	md := fieldDealMetaData{}
+	dealID, err := md.Deal(context.Background(), request)
+	assert.Error(t, err)
+	assert.Equal(t, DealID(""), dealID)
+}
+
+func TestFieldDealMetaDataWallet(t *testing.T) {
+	peerCtx := peer.NewContext(context.Background(), &peer.Peer{
+		AuthInfo: util.EthAuthInfo{TLS: credentials.TLSInfo{}, Wallet: common.Address{}},
+	})
+
+	ctx := metadata.NewIncomingContext(peerCtx, metadata.MD(map[string][]string{
+		"wallet": {"0x42"},
+	}))
+
+	md := contextDealMetaData{}
+	dealID, err := md.Wallet(ctx, nil)
+	require.NoError(t, err)
+	assert.Equal(t, "0x42", dealID)
+}
+
+func TestFieldDealMetaDataWalletErrorsOnEmptyMD(t *testing.T) {
+	peerCtx := peer.NewContext(context.Background(), &peer.Peer{
+		AuthInfo: util.EthAuthInfo{TLS: credentials.TLSInfo{}, Wallet: common.Address{}},
+	})
+
+	ctx := metadata.NewIncomingContext(peerCtx, metadata.MD(map[string][]string{}))
+
+	md := contextDealMetaData{}
+	dealID, err := md.Wallet(ctx, nil)
+	assert.Error(t, err)
+	assert.Equal(t, "", dealID)
+}
+
+func TestContextDealMetaData(t *testing.T) {
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.MD(map[string][]string{
+		"deal": {"0x42"},
+	}))
+
+	md := contextDealMetaData{}
+	dealID, err := md.Deal(ctx, nil)
+	require.NoError(t, err)
+	assert.Equal(t, DealID("0x42"), dealID)
+}
+
+func TestDealAuthorizationErrors(t *testing.T) {
+	wallet, err := util.NewSelfSignedWallet(key)
+	require.NoError(t, err)
+
+	access := util.NewWalletAccess(wallet)
+
+	peerCtx := peer.NewContext(context.Background(), &peer.Peer{
+		AuthInfo: util.EthAuthInfo{TLS: credentials.TLSInfo{}, Wallet: common.Address{}},
+	})
+
+	requestMD, err := access.GetRequestMetadata(nil)
+	require.NoError(t, err)
+
+	ctx := metadata.NewIncomingContext(peerCtx, metadata.MD(map[string][]string{
+		"wallet": {requestMD["wallet"]},
+	}))
+
+	request := &sonm.HubStartTaskRequest{
+		Deal: &sonm.Deal{
+			Id: "0x42",
+		},
+	}
+
+	md := fieldDealMetaData{}
+	auth := newDealAuthorization(context.Background(), &md)
+	auth.(*dealAuthorization).allowedWallets[DealID("0x42")] = "0x100500"
+
+	require.Error(t, auth.Authorize(ctx, request))
+}
+
+func TestDealAuthorizationErrorsOnInvalidWallet(t *testing.T) {
+	peerCtx := peer.NewContext(context.Background(), &peer.Peer{
+		AuthInfo: util.EthAuthInfo{TLS: credentials.TLSInfo{}, Wallet: common.Address{}},
+	})
+
+	ctx := metadata.NewIncomingContext(peerCtx, metadata.MD(map[string][]string{
+		"wallet": {"0x100500"},
+	}))
+
+	request := &sonm.HubStartTaskRequest{
+		Deal: &sonm.Deal{
+			Id: "0x42",
+		},
+	}
+
+	md := fieldDealMetaData{}
+	auth := newDealAuthorization(context.Background(), &md)
+	auth.(*dealAuthorization).allowedWallets[DealID("0x42")] = "0x100500"
+
+	require.Error(t, auth.Authorize(ctx, request))
 }

--- a/insonmnia/hub/server.go
+++ b/insonmnia/hub/server.go
@@ -1172,13 +1172,13 @@ func New(ctx context.Context, cfg *Config, version string, opts ...Option) (*Hub
 		clusterEvents: defaults.clusterEvents,
 	}
 
-	dealAuthorization := map[string]DealRequestMetaData{
-		"TaskStatus": &taskFieldDealRequestMetaData{hub: h},
-		"StartTask":  &fieldDealRequestMetaData{},
-		"StopTask":   &taskFieldDealRequestMetaData{hub: h},
-		"TaskLogs":   &taskFieldDealRequestMetaData{hub: h},
-		"PushTask":   &contextDealRequestMetaData{},
-		"PullTask":   &contextDealRequestMetaData{},
+	dealAuthorization := map[string]DealMetaData{
+		"TaskStatus": &taskFieldDealMetaData{hub: h},
+		"StartTask":  &fieldDealMetaData{},
+		"StopTask":   &taskFieldDealMetaData{hub: h},
+		"TaskLogs":   &taskFieldDealMetaData{hub: h},
+		"PushTask":   &contextDealMetaData{},
+		"PullTask":   &contextDealMetaData{},
 	}
 
 	for event, metadata := range dealAuthorization {

--- a/util/grpcsecure.go
+++ b/util/grpcsecure.go
@@ -1,13 +1,18 @@
 package util
 
 import (
+	"bytes"
+	"crypto/ecdsa"
 	"crypto/tls"
+	"encoding/base32"
 	"fmt"
+	"io/ioutil"
 	"net"
 
 	"strings"
 
 	ethcommon "github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
@@ -175,4 +180,71 @@ func MakeWalletAuthenticatedClient(ctx context.Context, creds credentials.Transp
 	}
 
 	return conn, nil
+}
+
+type SelfSignedWallet struct {
+	Message string
+}
+
+func NewSelfSignedWallet(key *ecdsa.PrivateKey) (*SelfSignedWallet, error) {
+	address := crypto.PubkeyToAddress(key.PublicKey).Hex()
+	message := crypto.Keccak256([]byte(address))
+
+	sign, err := crypto.Sign(message, key)
+	if err != nil {
+		return nil, err
+	}
+
+	signed := new(bytes.Buffer)
+	signed.WriteString(address)
+	signed.WriteByte('@')
+	signed.WriteString(base32.StdEncoding.EncodeToString(sign))
+
+	return &SelfSignedWallet{Message: signed.String()}, nil
+}
+
+// WalletAccess supplies PerRPCCredentials from a given self-signed wallet.
+type WalletAccess struct {
+	wallet *SelfSignedWallet
+}
+
+// NewWalletAccess constructs the new PerRPCCredentials using with given
+// self-signed wallet.
+func NewWalletAccess(wallet *SelfSignedWallet) credentials.PerRPCCredentials {
+	return &WalletAccess{
+		wallet: wallet,
+	}
+}
+
+func (c WalletAccess) GetRequestMetadata(ctx context.Context, uri ...string) (map[string]string, error) {
+	return map[string]string{
+		"wallet": c.wallet.Message,
+	}, nil
+}
+
+func (c WalletAccess) RequireTransportSecurity() bool {
+	return true
+}
+
+func VerifySelfSignedWallet(signedWallet string) (string, error) {
+	parts := strings.Split(signedWallet, "@")
+	if len(parts) != 2 {
+		return "", fmt.Errorf("malformed wallet provided")
+	}
+
+	address := []byte(parts[0])
+	sign, err := ioutil.ReadAll(base32.NewDecoder(base32.StdEncoding, strings.NewReader(parts[1])))
+	if err != nil {
+		return "", err
+	}
+
+	recoveredPub, err := crypto.Ecrecover(crypto.Keccak256(address), sign)
+	if err != nil {
+		return "", err
+	}
+
+	pubKey := crypto.ToECDSAPub(recoveredPub)
+	recoveredAddr := crypto.PubkeyToAddress(*pubKey).Hex()
+
+	return recoveredAddr, nil
 }


### PR DESCRIPTION
The entire task API now requires wallet authentication.

When a deal is accepted a new auth rule is created at the Hub. For such deal only clients with proper auth info can start tasks, stop them etc.

Technically this is done using per-call authorization options, which requires wallet information passing through.

The wallet itself is self-signed using private key at the client side. The server can verify passed signed wallet to ensure that no one else will stop for example other tasks.