### PR TITLE
Fix/use buyer id for approve waiter

### DIFF
--- a/insonmnia/node/market.go
+++ b/insonmnia/node/market.go
@@ -221,7 +221,7 @@ func (h *orderHandler) waitForApprove(order *pb.Order, key *ecdsa.PrivateKey, wa
 	h.status = statusWaitForApprove
 
 	localCtx := context.Background()
-	deal, err := h.findDeals(localCtx, key, order.GetSupplierID(), h.slotSpecHash(), wait)
+	deal, err := h.findDeals(localCtx, key, order.GetByuerID(), h.slotSpecHash(), wait)
 	if err != nil {
 		log.G(h.ctx).Info("cannot find accepted deal", zap.Error(err))
 		h.setError(err)


### PR DESCRIPTION
Chained with #268.

This PR fixes buyer id for a case when the Node is waiting for accepted orders.