### PR TITLE
Fix: opened and approved deal selection

### DIFF
--- a/insonmnia/hub/eth.go
+++ b/insonmnia/hub/eth.go
@@ -112,9 +112,9 @@ func (e *eth) findDealOnce(addr, hash string) *pb.Deal {
 		zap.String("hash", hash),
 		zap.Int("count", len(IDs)))
 
-	for _, id := range IDs {
+	for i := len(IDs) - 1; i >= 0; i-- {
 		// then get extended info
-		deal, err := e.bc.GetDealInfo(id)
+		deal, err := e.bc.GetDealInfo(IDs[i])
 		if err != nil {
 			continue
 		}

--- a/insonmnia/hub/server.go
+++ b/insonmnia/hub/server.go
@@ -765,7 +765,7 @@ func (h *Hub) ProposeDeal(ctx context.Context, r *pb.DealRequest) (*pb.Empty, er
 
 	order, err := structs.NewOrder(bidOrder)
 	if err != nil {
-		return nil, status.Errorf(codes.DataLoss, "bid order is malformed")
+		return nil, status.Errorf(codes.DataLoss, "bid order is malformed: %v", err)
 	}
 
 	askOrder, err := h.market.GetOrderByID(h.ctx, &pb.ID{Id: r.GetAskId()})
@@ -860,7 +860,7 @@ func (h *Hub) watchForDealClosed(dealID DealID, buyerId string) {
 		return
 	}
 
-	log.S(h.ctx).Info("stopping at max %d tasks due to deal closing", len(tasks))
+	log.S(h.ctx).Infof("stopping at max %d tasks due to deal closing", len(tasks))
 	for _, task := range tasks {
 		if h.isTaskFinished(task.ID) {
 			continue

--- a/insonmnia/hub/server.go
+++ b/insonmnia/hub/server.go
@@ -744,7 +744,6 @@ func (h *Hub) TaskLogs(request *pb.TaskLogsRequest, server pb.Hub_TaskLogsServer
 
 func (h *Hub) ProposeDeal(ctx context.Context, r *pb.DealRequest) (*pb.Empty, error) {
 	log.G(h.ctx).Info("handling ProposeDeal request", zap.Any("request", r))
-
 	request, err := structs.NewDealRequest(r)
 	if err != nil {
 		return nil, err

--- a/insonmnia/node/market_test.go
+++ b/insonmnia/node/market_test.go
@@ -147,7 +147,6 @@ func TestCreateOrder_FullAsyncOrderHandler(t *testing.T) {
 
 	// wait for async handler is finished
 	time.Sleep(1 * time.Second)
-
 	assert.True(t, len(inner.tasks) == 1, "Handler must not be removed")
 
 	handlr := inner.tasks[created.Id]

--- a/insonmnia/node/market_test.go
+++ b/insonmnia/node/market_test.go
@@ -120,7 +120,7 @@ func getTestRemotes(ctx context.Context, ctrl *gomock.Controller) *remoteOptions
 	opts.eth = getTestEth(ctrl)
 	opts.market = getTestMarket(ctrl)
 	opts.locator = getTestLocator(ctrl)
-	opts.approveTimeout = 3 * time.Second
+	opts.dealApproveTimeout = 3 * time.Second
 	opts.hubCreator = func(addr string) (pb.HubClient, error) {
 		return getTestHubClient(ctrl), nil
 	}

--- a/insonmnia/node/market_test.go
+++ b/insonmnia/node/market_test.go
@@ -380,7 +380,6 @@ func TestCreateOrder_CannotWaitForApprove(t *testing.T) {
 func TestCreateOrder_LackAllowanceBalance(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
-
 	ctx := context.Background()
 
 	eth := blockchain.NewMockBlockchainer(ctrl)

--- a/insonmnia/node/market_test.go
+++ b/insonmnia/node/market_test.go
@@ -52,7 +52,7 @@ func makeOrder() *pb.Order {
 
 func getTestEth(ctrl *gomock.Controller) blockchain.Blockchainer {
 	deal := &pb.Deal{
-		Id:                "my-deal-id",
+		Id:                "1",
 		Status:            pb.DealStatus_ACCEPTED,
 		SpecificationHash: "217643283185136810854905094570012887099",
 	}
@@ -69,6 +69,8 @@ func getTestEth(ctrl *gomock.Controller) blockchain.Blockchainer {
 		Return([]*big.Int{big.NewInt(1)}, nil)
 	bc.EXPECT().GetDealInfo(big.NewInt(1)).AnyTimes().
 		Return(deal, nil)
+	bc.EXPECT().OpenDealPending(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().
+		Return(big.NewInt(1), nil)
 
 	return bc
 }
@@ -152,7 +154,7 @@ func TestCreateOrder_FullAsyncOrderHandler(t *testing.T) {
 	handlr := inner.tasks[created.Id]
 	assert.Equal(t, statusDone, handlr.status,
 		fmt.Sprintf("Wait for status %s, but has %s", statusMap[statusDone], statusMap[handlr.status]))
-	assert.Equal(t, "my-deal-id", handlr.dealID)
+	assert.Equal(t, "1", handlr.dealID)
 }
 
 func TestCreateOrder_CannotCreateHandler(t *testing.T) {
@@ -303,6 +305,8 @@ func TestCreateOrder_CannotCreateDeal(t *testing.T) {
 		Return(big.NewInt(big.MaxPrec), nil)
 	eth.EXPECT().OpenDeal(gomock.Any(), gomock.Any()).AnyTimes().
 		Return(nil, errors.New("TEST: cannot open deal"))
+	eth.EXPECT().OpenDealPending(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().
+		Return(nil, errors.New("TEST: cannot open deal"))
 	eth.EXPECT().GetAcceptedDeal(gomock.Any(), gomock.Any()).AnyTimes().
 		Return(nil, errors.New("TEST: cannot get accepted deals"))
 	eth.EXPECT().GetDealInfo(big.NewInt(1)).AnyTimes().
@@ -345,8 +349,8 @@ func TestCreateOrder_CannotWaitForApprove(t *testing.T) {
 		Return(big.NewInt(big.MaxPrec), nil)
 	eth.EXPECT().AllowanceOf(gomock.Any(), gomock.Any()).AnyTimes().
 		Return(big.NewInt(big.MaxPrec), nil)
-	eth.EXPECT().OpenDeal(gomock.Any(), gomock.Any()).AnyTimes().
-		Return(&types.Transaction{}, nil)
+	eth.EXPECT().OpenDealPending(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().
+		Return(big.NewInt(1), nil)
 	eth.EXPECT().GetAcceptedDeal(gomock.Any(), gomock.Any()).AnyTimes().
 		Return([]*big.Int{big.NewInt(1), big.NewInt(2)}, nil)
 	eth.EXPECT().GetDealInfo(big.NewInt(1)).AnyTimes().
@@ -459,7 +463,7 @@ func TestCreateOrder_LackBalance(t *testing.T) {
 		Return(big.NewInt(100), nil)
 	eth.EXPECT().AllowanceOf(gomock.Any(), gomock.Any()).AnyTimes().
 		Return(big.NewInt(50000), nil)
-	eth.EXPECT().OpenDeal(gomock.Any(), gomock.Any()).AnyTimes().
+	eth.EXPECT().OpenDealPending(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().
 		Return(nil, errors.New("1"))
 
 	opts := getTestRemotes(ctx, ctrl)

--- a/insonmnia/node/market_test.go
+++ b/insonmnia/node/market_test.go
@@ -58,6 +58,7 @@ func getTestEth(ctrl *gomock.Controller) blockchain.Blockchainer {
 	}
 
 	bc := blockchain.NewMockBlockchainer(ctrl)
+
 	bc.EXPECT().BalanceOf(gomock.Any()).AnyTimes().
 		Return(big.NewInt(big.MaxPrec), nil)
 	bc.EXPECT().AllowanceOf(gomock.Any(), gomock.Any()).AnyTimes().

--- a/insonmnia/node/server.go
+++ b/insonmnia/node/server.go
@@ -19,15 +19,16 @@ type hubClientCreator func(addr string) (pb.HubClient, error)
 
 // remoteOptions describe options related to remove gRPC services
 type remoteOptions struct {
-	ctx            context.Context
-	key            *ecdsa.PrivateKey
-	conf           Config
-	creds          credentials.TransportCredentials
-	approveTimeout time.Duration
-	locator        pb.LocatorClient
-	market         pb.MarketClient
-	eth            blockchain.Blockchainer
-	hubCreator     hubClientCreator
+	ctx                context.Context
+	key                *ecdsa.PrivateKey
+	conf               Config
+	creds              credentials.TransportCredentials
+	locator            pb.LocatorClient
+	market             pb.MarketClient
+	eth                blockchain.Blockchainer
+	hubCreator         hubClientCreator
+	dealApproveTimeout time.Duration
+	dealCreateTimeout  time.Duration
 }
 
 func newRemoteOptions(ctx context.Context, key *ecdsa.PrivateKey, conf Config, creds credentials.TransportCredentials) (*remoteOptions, error) {
@@ -56,15 +57,16 @@ func newRemoteOptions(ctx context.Context, key *ecdsa.PrivateKey, conf Config, c
 	}
 
 	return &remoteOptions{
-		key:            key,
-		conf:           conf,
-		ctx:            ctx,
-		creds:          creds,
-		locator:        pb.NewLocatorClient(locatorCC),
-		market:         pb.NewMarketClient(marketCC),
-		eth:            bcAPI,
-		approveTimeout: 900 * time.Second,
-		hubCreator:     hc,
+		key:                key,
+		conf:               conf,
+		ctx:                ctx,
+		creds:              creds,
+		locator:            pb.NewLocatorClient(locatorCC),
+		market:             pb.NewMarketClient(marketCC),
+		eth:                bcAPI,
+		dealApproveTimeout: 900 * time.Second,
+		dealCreateTimeout:  180 * time.Second,
+		hubCreator:         hc,
 	}, nil
 }
 


### PR DESCRIPTION
Chained with #278, #284.

This PR fixes an opened and an approved deal selection. 

Changed: 
- Using sync deal creation method (added in #281) to get a created deal ID on the Node;
- Reverse the deals traversal on Hub (newest first);