### PR TITLE
refactor: deal lifecycle

### DIFF
--- a/insonmnia/hub/eth.go
+++ b/insonmnia/hub/eth.go
@@ -19,10 +19,10 @@ type ETH interface {
 	// WaitForDealClosed blocks the current execution context until the
 	// specified deal is closed.
 	WaitForDealClosed(ctx context.Context, dealID DealID, buyerID string) error
-
-	// AcceptDeal approves deal on Hub-side
+	// AcceptDeal approves deal on Hub-side.
 	AcceptDeal(id string) error
-
+	// CloseDeal closes the specified deal on Hub-side.
+	CloseDeal(id DealID) error
 	// GetDeal checks whether a given deal exists.
 	GetDeal(id string) (*pb.Deal, error)
 }
@@ -136,6 +136,16 @@ func (e *eth) AcceptDeal(id string) error {
 	}
 
 	_, err = e.bc.AcceptDeal(e.key, bigID)
+	return err
+}
+
+func (e *eth) CloseDeal(id DealID) error {
+	bigID, err := util.ParseBigInt(string(id))
+	if err != nil {
+		return err
+	}
+
+	_, err = e.bc.CloseDeal(e.key, bigID)
 	return err
 }
 

--- a/insonmnia/structs/order.go
+++ b/insonmnia/structs/order.go
@@ -3,6 +3,7 @@ package structs
 import (
 	"errors"
 	"math/big"
+	"time"
 
 	pb "github.com/sonm-io/core/proto"
 	"github.com/sonm-io/core/util"
@@ -97,4 +98,8 @@ func (o *Order) GetType() pb.OrderType {
 
 func (o *Order) GetByuerID() string {
 	return o.inner.GetByuerID()
+}
+
+func (o *Order) GetDuration() time.Duration {
+	return time.Duration(o.inner.Slot.Duration)
 }

--- a/insonmnia/structs/order.go
+++ b/insonmnia/structs/order.go
@@ -101,5 +101,5 @@ func (o *Order) GetByuerID() string {
 }
 
 func (o *Order) GetDuration() time.Duration {
-	return time.Duration(o.inner.Slot.Duration)
+	return time.Duration(o.inner.Slot.Duration) * time.Second
 }


### PR DESCRIPTION
Changed:
- Closing a deal using blockchain API when it expires at Hub-side.

Fixed:
- Releasing resources after deal closing/expiration.

Closes DEV-189, DEV-258.