### PR TITLE
fix: avoid printing bytes

### DIFF
--- a/util/grpcsecure.go
+++ b/util/grpcsecure.go
@@ -132,7 +132,7 @@ func (w *WalletAuthenticator) compareWallets(authInfo credentials.AuthInfo) erro
 	switch authInfo := authInfo.(type) {
 	case EthAuthInfo:
 		if !EqualAddresses(authInfo.Wallet, w.Wallet) {
-			return fmt.Errorf("authorization failed: expected %s, actual %s", w.Wallet, authInfo.Wallet)
+			return fmt.Errorf("authorization failed: expected %s, actual %s", w.Wallet.Hex(), authInfo.Wallet.Hex())
 		}
 	default:
 		return fmt.Errorf("unsupported AuthInfo %s %T", authInfo.AuthType(), authInfo)


### PR DESCRIPTION
Before:

```
2017-12-23T17:02:16.041+0300	ERROR	node/server.go:151	cannot restart order processing	{"error": "rpc error: code = Internal desc = connection error: desc = \"transport: authentication handshake failed: authorization failed: expected \\x81%r\\x1c$\\x13ٚ3\\xe3Q\\xe1\\xf6\\xbbNV\\xb6\\xb63\\xfd, actual s1\\x93\\xd4\\vo\\x03\\xc3\\xda3۲\\xe0\\xe0p\\xac\\xbb\\xf8\\xd9\\x1b\""}
```

After:

```
2017-12-23T17:05:07.210+0300	ERROR	node/server.go:151	cannot restart order processing	{"error": "rpc error: code = Internal desc = connection error: desc = \"transport: authentication handshake failed: authorization failed: expected 0x8125721C2413d99a33E351e1F6Bb4e56b6b633FD, actual 0x733193d40B6F03c3da33Dbb2e0e070aCbBf8d91b\""}
```