### PR TITLE
fix: fill all fields in a deal meta struct

### DIFF
--- a/insonmnia/hub/task_info.go
+++ b/insonmnia/hub/task_info.go
@@ -18,6 +18,7 @@ type TaskInfo struct {
 }
 
 type DealMeta struct {
+	ID      DealID
 	BidID   string
 	MinerID string
 	Order   structs.Order


### PR DESCRIPTION
Fixed:
- Fill all fields in a deal meta info after accepting a deal to be able to properly synchronize.