### PR TITLE
aux: add autocomplete for the sonmcli

### DIFF
--- a/cmd/cli/commands/common.go
+++ b/cmd/cli/commands/common.go
@@ -60,7 +60,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&outputModeFlag, "out", "", "Output mode: simple or json")
 
 	rootCmd.AddCommand(hubRootCmd, marketRootCmd, nodeDealsRootCmd, taskRootCmd)
-	rootCmd.AddCommand(loginCmd, approveTokenCmd, getTokenCmd, versionCmd)
+	rootCmd.AddCommand(loginCmd, approveTokenCmd, getTokenCmd, versionCmd, autoCompleteCmd)
 }
 
 // Root configure and return root command

--- a/cmd/cli/commands/version.go
+++ b/cmd/cli/commands/version.go
@@ -1,6 +1,8 @@
 package commands
 
 import (
+	"os"
+
 	"github.com/spf13/cobra"
 )
 
@@ -9,5 +11,30 @@ var versionCmd = &cobra.Command{
 	Short: "Show version",
 	Run: func(cmd *cobra.Command, args []string) {
 		printVersion(cmd, version)
+	},
+}
+
+var autoCompleteCmd = &cobra.Command{
+	Use:   "completion <bash|zsh>",
+	Short: "Generate shell-completion script",
+	Args:  cobra.MinimumNArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		var err error
+		shell := args[0]
+
+		switch shell {
+		case "zsh":
+			err = rootCmd.GenZshCompletion(os.Stdout)
+		case "bash":
+			err = rootCmd.GenBashCompletion(os.Stdout)
+		default:
+			showError(cmd, "Unknown shell type", nil)
+			os.Exit(1)
+		}
+
+		if err != nil {
+			showError(cmd, "Cannot generate completion script", nil)
+			os.Exit(1)
+		}
 	},
 }


### PR DESCRIPTION
Usage: 

```
sonmcli completion bash > completion.sh
. ./completion.sh

sonmcli [tab]
approve     completion  deals       get         hub         login       market      tasks       version
```
  