### PR TITLE
refactor: auth configuration

### DIFF
--- a/cmd/cli/commands/common.go
+++ b/cmd/cli/commands/common.go
@@ -13,7 +13,6 @@ import (
 	"github.com/sonm-io/core/insonmnia/auth"
 	"github.com/sonm-io/core/util"
 	"github.com/spf13/cobra"
-	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 )
 
@@ -48,7 +47,6 @@ var (
 	cfg        config.Config
 	sessionKey *ecdsa.PrivateKey = nil
 	creds      credentials.TransportCredentials
-	walletAuth *util.SelfSignedWallet
 
 	// errors
 	errCannotParsePropsFile = errors.New("cannot parse props file")
@@ -173,20 +171,9 @@ func loadKeyStoreWrapper(cmd *cobra.Command, _ []string) {
 	}
 
 	creds = auth.NewWalletAuthenticator(util.NewTLS(TLSConfig), util.PubKeyToAddr(sessionKey.PublicKey))
-	wallet, err := util.NewSelfSignedWallet(sessionKey)
-	if err != nil {
-		showError(cmd, err.Error(), nil)
-		os.Exit(1)
-	}
-
-	walletAuth = wallet
 }
 
 func showJSON(cmd *cobra.Command, s interface{}) {
 	b, _ := json.Marshal(s)
 	cmd.Printf("%s\r\n", b)
-}
-
-func WithWalletPerRPCCredentials() grpc.DialOption {
-	return grpc.WithPerRPCCredentials(util.NewWalletAccess(walletAuth))
 }

--- a/cmd/cli/commands/tasks.go
+++ b/cmd/cli/commands/tasks.go
@@ -78,7 +78,7 @@ var taskStartCmd = &cobra.Command{
 	PreRun: loadKeyStoreWrapper,
 	Args:   cobra.MinimumNArgs(2),
 	Run: func(cmd *cobra.Command, args []string) {
-		node, err := NewTasksInteractor(nodeAddressFlag, timeoutFlag, WithWalletPerRPCCredentials())
+		node, err := NewTasksInteractor(nodeAddressFlag, timeoutFlag)
 		if err != nil {
 			showError(cmd, "Cannot connect to Node", err)
 			os.Exit(1)
@@ -124,7 +124,7 @@ var taskStatusCmd = &cobra.Command{
 	PreRun: loadKeyStoreWrapper,
 	Args:   cobra.MinimumNArgs(2),
 	Run: func(cmd *cobra.Command, args []string) {
-		node, err := NewTasksInteractor(nodeAddressFlag, timeoutFlag, WithWalletPerRPCCredentials())
+		node, err := NewTasksInteractor(nodeAddressFlag, timeoutFlag)
 		if err != nil {
 			showError(cmd, "Cannot connect to Node", err)
 			os.Exit(1)
@@ -148,7 +148,7 @@ var taskLogsCmd = &cobra.Command{
 	PreRun: loadKeyStoreWrapper,
 	Args:   cobra.MinimumNArgs(2),
 	Run: func(cmd *cobra.Command, args []string) {
-		node, err := NewTasksInteractor(nodeAddressFlag, timeoutFlag, WithWalletPerRPCCredentials())
+		node, err := NewTasksInteractor(nodeAddressFlag, timeoutFlag)
 		if err != nil {
 			showError(cmd, "Cannot connect to Node", err)
 			os.Exit(1)
@@ -196,7 +196,7 @@ var taskStopCmd = &cobra.Command{
 	PreRun: loadKeyStoreWrapper,
 	Args:   cobra.MinimumNArgs(2),
 	Run: func(cmd *cobra.Command, args []string) {
-		node, err := NewTasksInteractor(nodeAddressFlag, timeoutFlag, WithWalletPerRPCCredentials())
+		node, err := NewTasksInteractor(nodeAddressFlag, timeoutFlag)
 		if err != nil {
 			showError(cmd, "Cannot connect to Node", err)
 			os.Exit(1)
@@ -240,7 +240,7 @@ var taskPullCmd = &cobra.Command{
 
 		w := bufio.NewWriter(wr)
 
-		node, err := NewTasksInteractor(nodeAddressFlag, timeoutFlag, WithWalletPerRPCCredentials())
+		node, err := NewTasksInteractor(nodeAddressFlag, timeoutFlag)
 		if err != nil {
 			showError(cmd, "Cannot connect to Node", err)
 			os.Exit(1)
@@ -337,7 +337,7 @@ var taskPushCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		node, err := NewTasksInteractor(nodeAddressFlag, timeoutFlag, WithWalletPerRPCCredentials())
+		node, err := NewTasksInteractor(nodeAddressFlag, timeoutFlag)
 		if err != nil {
 			showError(cmd, "Cannot connect to Node", err)
 			os.Exit(1)

--- a/insonmnia/auth/auth.go
+++ b/insonmnia/auth/auth.go
@@ -1,0 +1,177 @@
+package auth
+
+import (
+	"context"
+	"sync"
+
+	"github.com/ethereum/go-ethereum/common"
+	"go.uber.org/zap"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/peer"
+	"google.golang.org/grpc/status"
+)
+
+// Event describes fully-qualified gRPC method name.
+type Event string
+
+func (e Event) String() string {
+	return string(e)
+}
+
+// AuthRouter is an entry point of our gRPC authorization.
+//
+// By default the router allows unregistered events, but this behavior can be
+// changed using `DenyUnregistered` option.
+type AuthRouter struct {
+	ctx       context.Context
+	log       *zap.Logger
+	mu        sync.RWMutex
+	prefix    string
+	fallback  Authorization
+	verifiers map[Event]Authorization
+}
+
+// NewEventAuthorization constructs a new event authorization.
+func NewEventAuthorization(ctx context.Context, options ...EventAuthorizationOption) *AuthRouter {
+	router := &AuthRouter{
+		ctx:       ctx,
+		log:       zap.NewNop(),
+		verifiers: make(map[Event]Authorization, 0),
+		fallback:  NewNilAuthorization(),
+	}
+
+	for _, option := range options {
+		option(router)
+	}
+
+	return router
+}
+
+func (r *AuthRouter) addAuthorization(event Event, auth Authorization) {
+	r.verifiers[Event(r.prefix+string(event))] = auth
+}
+
+func (r *AuthRouter) Authorize(ctx context.Context, event Event, request interface{}) error {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	r.log.Debug("authorizing request", zap.Stringer("method", event))
+
+	verify, ok := r.verifiers[event]
+	if !ok {
+		return r.fallback.Authorize(ctx, request)
+	}
+
+	return verify.Authorize(ctx, request)
+}
+
+// EventAuthorizationOption describes authorization option.
+type EventAuthorizationOption func(router *AuthRouter)
+
+// WithLog is an option that assigns the specified logger to be able to log
+// some important events.
+func WithLog(log *zap.Logger) EventAuthorizationOption {
+	return func(router *AuthRouter) {
+		router.log = log
+	}
+}
+
+// WithEventPrefix is an option that specifies event prefix for configuration.
+func WithEventPrefix(prefix string) EventAuthorizationOption {
+	return func(router *AuthRouter) {
+		router.prefix = prefix
+	}
+}
+
+type AuthOption struct {
+	events []string
+}
+
+// Allow constructs an AuthOption that is used for further authorization
+// attachment.
+func Allow(events ...string) AuthOption {
+	return AuthOption{
+		events: events,
+	}
+}
+
+// With attaches the given authorization to previously specified events.
+func (o AuthOption) With(auth Authorization) EventAuthorizationOption {
+	return func(router *AuthRouter) {
+		for _, event := range o.events {
+			router.addAuthorization(Event(event), auth)
+		}
+	}
+}
+
+// WithFallback constructs an option to assign fallback authorization, that
+// will act when an unregistered event comes.
+func WithFallback(auth Authorization) EventAuthorizationOption {
+	return func(router *AuthRouter) {
+		router.fallback = auth
+	}
+}
+
+type Authorization interface {
+	Authorize(ctx context.Context, request interface{}) error
+}
+
+type nilAuthorization struct{}
+
+// NewNilAuthorization constructs a new authorization, that will allow any
+// incoming event.
+func NewNilAuthorization() Authorization {
+	return &nilAuthorization{}
+}
+
+func (nilAuthorization) Authorize(ctx context.Context, request interface{}) error {
+	return nil
+}
+
+type denyAuthorization struct{}
+
+// NewDenyAuthorization constructs a new authorization, that will deny any
+// incoming event.
+func NewDenyAuthorization() Authorization {
+	return &denyAuthorization{}
+}
+
+func (denyAuthorization) Authorize(ctx context.Context, request interface{}) error {
+	return status.Error(codes.Unauthenticated, "permission denied")
+}
+
+func (denyAuthorization) AuthorizeStream(ctx context.Context, stream grpc.ServerStream) (grpc.ServerStream, error) {
+	return stream, nil
+}
+
+// NewTransportAuthorization constructs an authorization that allows to call
+// methods from the context which has required transport credentials.
+// More precisely the caller context must have peer info with verified
+// Ethereum address to compare with.
+func NewTransportAuthorization(ethAddr common.Address) Authorization {
+	return &transportCredentialsAuthorization{
+		ethAddr: ethAddr,
+	}
+}
+
+type transportCredentialsAuthorization struct {
+	ethAddr common.Address
+}
+
+func (a *transportCredentialsAuthorization) Authorize(ctx context.Context, request interface{}) error {
+	peerInfo, ok := peer.FromContext(ctx)
+	if !ok {
+		return status.Error(codes.Unauthenticated, "no peer info")
+	}
+
+	switch authInfo := peerInfo.AuthInfo.(type) {
+	case EthAuthInfo:
+		if equalAddresses(authInfo.Wallet, a.ethAddr) {
+			return nil
+		}
+		return status.Errorf(codes.Unauthenticated, "the wallet %s has no access", authInfo.Wallet.Hex())
+	default:
+		return status.Error(codes.Unauthenticated, "unknown auth info")
+	}
+}

--- a/insonmnia/auth/common_test.go
+++ b/insonmnia/auth/common_test.go
@@ -1,0 +1,59 @@
+package auth
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEqualAddresses(t *testing.T) {
+	cases := []struct {
+		a    string
+		b    string
+		isEq bool
+	}{
+		{
+			a:    "1aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaB",
+			b:    "1aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab",
+			isEq: true,
+		},
+		{
+			a:    "1aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaB",
+			b:    "0x1aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab",
+			isEq: true,
+		},
+		{
+			a:    "1aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaB",
+			b:    "2aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaB",
+			isEq: false,
+		},
+		{
+			a:    "0x1aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaB",
+			b:    "0x1aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaB",
+			isEq: true,
+		},
+		{
+			a:    "0x0",
+			b:    "0x1",
+			isEq: false,
+		},
+		{
+			a:    "0",
+			b:    "1",
+			isEq: false,
+		},
+		{
+			a:    "0x",
+			b:    "0x",
+			isEq: true,
+		},
+	}
+
+	for _, cc := range cases {
+		a := common.HexToAddress(cc.a)
+		b := common.HexToAddress(cc.b)
+		assert.Equal(t, cc.isEq, equalAddresses(a, b), fmt.Sprintf("compare %s and %s failed", cc.a, cc.b))
+	}
+}

--- a/insonmnia/hub/acl.go
+++ b/insonmnia/hub/acl.go
@@ -226,17 +226,22 @@ func (contextDealMetaData) Deal(ctx context.Context, request interface{}) (DealI
 
 // FieldIdMetaData is a deal meta info extractor that requires the specified
 // request to have "Id" field, which is the task id.
-type fieldIdMetaData struct {
-	hub *Hub
+type stringerFieldMetaData struct {
+	hub  *Hub
+	name string
 }
 
-func newFieldIdMetaData(hub *Hub) DealMetaData {
-	return &fieldIdMetaData{hub: hub}
+func newStringerFieldMetaData(hub *Hub) DealMetaData {
+	return &stringerFieldMetaData{hub: hub, name: "Id"}
 }
 
-func (t *fieldIdMetaData) Deal(ctx context.Context, request interface{}) (DealID, error) {
+func newNamedStringerFieldMetaData(hub *Hub, name string) DealMetaData {
+	return &stringerFieldMetaData{hub: hub, name: name}
+}
+
+func (t *stringerFieldMetaData) Deal(ctx context.Context, request interface{}) (DealID, error) {
 	requestValue := reflect.Indirect(reflect.ValueOf(request))
-	taskID := reflect.Indirect(requestValue.FieldByName("Id"))
+	taskID := reflect.Indirect(requestValue.FieldByName(t.name))
 	if !taskID.IsValid() {
 		return "", errNoTaskFieldFound
 	}

--- a/insonmnia/hub/acl.go
+++ b/insonmnia/hub/acl.go
@@ -240,7 +240,13 @@ func newFromNamedTaskDealExtractor(hub *Hub, name string) DealExtractor {
 }
 
 func newRequestDealExtractor(fn func(request interface{}) (DealID, error)) DealExtractor {
-	return func(ctx context.Context, request interface{}) (DealID, error) {
+	return newCustomDealExtractor(func(ctx context.Context, request interface{}) (DealID, error) {
 		return fn(request)
+	})
+}
+
+func newCustomDealExtractor(fn func(ctx context.Context, request interface{}) (DealID, error)) DealExtractor {
+	return func(ctx context.Context, request interface{}) (DealID, error) {
+		return fn(ctx, request)
 	}
 }

--- a/insonmnia/hub/acl_test.go
+++ b/insonmnia/hub/acl_test.go
@@ -46,8 +46,8 @@ func TestFieldDealMetaData(t *testing.T) {
 		},
 	}
 
-	md := fieldDealMetaData{}
-	dealID, err := md.Deal(context.Background(), request)
+	md := newFieldDealExtractor()
+	dealID, err := md(context.Background(), request)
 	require.NoError(t, err)
 	assert.Equal(t, DealID("0x42"), dealID)
 }
@@ -60,8 +60,8 @@ func TestFieldDealMetaDataErrorsOnInvalidType(t *testing.T) {
 		Deal: "0x42",
 	}
 
-	md := fieldDealMetaData{}
-	dealID, err := md.Deal(context.Background(), request)
+	md := newFieldDealExtractor()
+	dealID, err := md(context.Background(), request)
 	assert.Error(t, err)
 	assert.Equal(t, DealID(""), dealID)
 }
@@ -79,8 +79,8 @@ func TestFieldDealMetaDataErrorsOnInvalidInnerType(t *testing.T) {
 		},
 	}
 
-	md := fieldDealMetaData{}
-	dealID, err := md.Deal(context.Background(), request)
+	md := newFieldDealExtractor()
+	dealID, err := md(context.Background(), request)
 	assert.Error(t, err)
 	assert.Equal(t, DealID(""), dealID)
 }
@@ -90,8 +90,8 @@ func TestContextDealMetaData(t *testing.T) {
 		"deal": {"0x42"},
 	}))
 
-	md := contextDealMetaData{}
-	dealID, err := md.Deal(ctx, nil)
+	md := newContextDealExtractor()
+	dealID, err := md(ctx, nil)
 	require.NoError(t, err)
 	assert.Equal(t, DealID("0x42"), dealID)
 }
@@ -107,8 +107,8 @@ func TestDealAuthorization(t *testing.T) {
 		},
 	}
 
-	md := fieldDealMetaData{}
-	authorization := newDealAuthorization(context.Background(), makeHubWithOrder(t, addr.Hex(), "0x42"), &md)
+	md := newFieldDealExtractor()
+	authorization := newDealAuthorization(context.Background(), makeHubWithOrder(t, addr.Hex(), "0x42"), md)
 
 	require.NoError(t, authorization.Authorize(ctx, request))
 }
@@ -124,8 +124,8 @@ func TestDealAuthorizationErrors(t *testing.T) {
 		},
 	}
 
-	md := fieldDealMetaData{}
-	au := newDealAuthorization(context.Background(), makeHubWithOrder(t, "0x100500", "0x42"), &md)
+	md := newFieldDealExtractor()
+	au := newDealAuthorization(context.Background(), makeHubWithOrder(t, "0x100500", "0x42"), md)
 
 	require.Error(t, au.Authorize(ctx, request))
 }
@@ -145,8 +145,8 @@ func TestDealAuthorizationErrorsOnInvalidWallet(t *testing.T) {
 		},
 	}
 
-	md := fieldDealMetaData{}
-	au := newDealAuthorization(context.Background(), makeHubWithOrder(t, "0x100500", "0x42"), &md)
+	md := newFieldDealExtractor()
+	au := newDealAuthorization(context.Background(), makeHubWithOrder(t, "0x100500", "0x42"), md)
 
 	require.Error(t, au.Authorize(ctx, request))
 }

--- a/insonmnia/hub/server.go
+++ b/insonmnia/hub/server.go
@@ -1344,7 +1344,7 @@ func New(ctx context.Context, cfg *Config, version string, opts ...Option) (*Hub
 		auth.Allow("TaskLogs").With(newDealAuthorization(ctx, h, newFromTaskDealExtractor(h))),
 		auth.Allow("PushTask").With(newDealAuthorization(ctx, h, newContextDealExtractor())),
 		auth.Allow("PullTask").With(newDealAuthorization(ctx, h, newRequestDealExtractor(func(request interface{}) (DealID, error) {
-			return DealID(request.(pb.PullTaskRequest).DealId), nil
+			return DealID(request.(*pb.PullTaskRequest).DealId), nil
 		}))),
 		auth.WithFallback(auth.NewDenyAuthorization()),
 	)

--- a/insonmnia/hub/server.go
+++ b/insonmnia/hub/server.go
@@ -1339,10 +1339,10 @@ func New(ctx context.Context, cfg *Config, version string, opts ...Option) (*Hub
 		auth.WithEventPrefix(hubAPIPrefix),
 		auth.Allow("Handshake", "ProposeDeal").With(auth.NewNilAuthorization()),
 		auth.Allow(hubManagementMethods...).With(auth.NewTransportAuthorization(h.ethAddr)),
-		auth.Allow("TaskStatus", "StopTask").With(newDealAuthorization(ctx, h, &fieldIdMetaData{hub: h})),
-		auth.Allow("StartTask").With(newDealAuthorization(ctx, h, &fieldDealMetaData{})),
-		auth.Allow("TaskLogs").With(newDealAuthorization(ctx, h, &fieldIdMetaData{})),
-		auth.Allow("PushTask", "PullTask").With(newDealAuthorization(ctx, h, &contextDealMetaData{})),
+		auth.Allow("TaskStatus", "StopTask").With(newDealAuthorization(ctx, h, newFieldIdMetaData(h))),
+		auth.Allow("StartTask").With(newDealAuthorization(ctx, h, newFieldDealMetaData())),
+		auth.Allow("TaskLogs").With(newDealAuthorization(ctx, h, newFieldIdMetaData(h))),
+		auth.Allow("PushTask", "PullTask").With(newDealAuthorization(ctx, h, newContextDealMetaData())),
 		auth.WithFallback(auth.NewDenyAuthorization()),
 	)
 

--- a/insonmnia/hub/server.go
+++ b/insonmnia/hub/server.go
@@ -267,7 +267,7 @@ func proxyRequestCall(ctx context.Context, client pb.HubClient, request interfac
 func (h *Hub) PushTask(stream pb.Hub_PushTaskServer) error {
 	log.G(h.ctx).Info("handling PushTask request")
 
-	if err := h.eventAuthorization.Authorize(stream.Context(), auth.Event("PushTask"), nil); err != nil {
+	if err := h.eventAuthorization.Authorize(stream.Context(), auth.Event(hubAPIPrefix+"PushTask"), nil); err != nil {
 		return err
 	}
 
@@ -360,7 +360,7 @@ func (h *Hub) PushTask(stream pb.Hub_PushTaskServer) error {
 func (h *Hub) PullTask(request *pb.PullTaskRequest, stream pb.Hub_PullTaskServer) error {
 	log.G(h.ctx).Info("handling PullTask request", zap.Any("request", request))
 
-	if err := h.eventAuthorization.Authorize(stream.Context(), auth.Event("PullTask"), nil); err != nil {
+	if err := h.eventAuthorization.Authorize(stream.Context(), auth.Event(hubAPIPrefix+"PullTask"), nil); err != nil {
 		return err
 	}
 
@@ -750,7 +750,7 @@ func (h *Hub) TaskStatus(ctx context.Context, request *pb.ID) (*pb.TaskStatusRep
 
 func (h *Hub) TaskLogs(request *pb.TaskLogsRequest, server pb.Hub_TaskLogsServer) error {
 	log.G(h.ctx).Info("handling TaskLogs request", zap.Any("request", request))
-	if err := h.eventAuthorization.Authorize(server.Context(), auth.Event("TaskLogs"), request); err != nil {
+	if err := h.eventAuthorization.Authorize(server.Context(), auth.Event(hubAPIPrefix+"TaskLogs"), request); err != nil {
 		return err
 	}
 

--- a/insonmnia/hub/server.go
+++ b/insonmnia/hub/server.go
@@ -1339,13 +1339,13 @@ func New(ctx context.Context, cfg *Config, version string, opts ...Option) (*Hub
 		auth.WithEventPrefix(hubAPIPrefix),
 		auth.Allow("Handshake", "ProposeDeal", "ApproveDeal").With(auth.NewNilAuthorization()),
 		auth.Allow(hubManagementMethods...).With(auth.NewTransportAuthorization(h.ethAddr)),
-		auth.Allow("TaskStatus", "StopTask").With(newDealAuthorization(ctx, h, newStringerFieldMetaData(h))),
-		auth.Allow("StartTask").With(newDealAuthorization(ctx, h, newFieldDealMetaData())),
-		auth.Allow("TaskLogs").With(newDealAuthorization(ctx, h, newStringerFieldMetaData(h))),
-		auth.Allow("PushTask").With(newDealAuthorization(ctx, h, newContextDealMetaData())),
-		// TODO: Tactical architectural solution.
-		// auth.Allow("PullTask").With(newDealAuthorization(ctx, h, newNamedStringerFieldMetaData(h, "TaskId"))),
-		auth.Allow("PullTask").With(auth.NewNilAuthorization()),
+		auth.Allow("TaskStatus", "StopTask").With(newDealAuthorization(ctx, h, newFromTaskDealExtractor(h))),
+		auth.Allow("StartTask").With(newDealAuthorization(ctx, h, newFieldDealExtractor())),
+		auth.Allow("TaskLogs").With(newDealAuthorization(ctx, h, newFromTaskDealExtractor(h))),
+		auth.Allow("PushTask").With(newDealAuthorization(ctx, h, newContextDealExtractor())),
+		auth.Allow("PullTask").With(newDealAuthorization(ctx, h, newRequestDealExtractor(func(request interface{}) (DealID, error) {
+			return DealID(request.(pb.PullTaskRequest).DealId), nil
+		}))),
 		auth.WithFallback(auth.NewDenyAuthorization()),
 	)
 

--- a/insonmnia/hub/server.go
+++ b/insonmnia/hub/server.go
@@ -1339,11 +1339,11 @@ func New(ctx context.Context, cfg *Config, version string, opts ...Option) (*Hub
 		auth.WithEventPrefix(hubAPIPrefix),
 		auth.Allow("Handshake", "ProposeDeal", "ApproveDeal").With(auth.NewNilAuthorization()),
 		auth.Allow(hubManagementMethods...).With(auth.NewTransportAuthorization(h.ethAddr)),
-		auth.Allow("TaskStatus", "StopTask").With(newDealAuthorization(ctx, h, newFieldIdMetaData(h))),
+		auth.Allow("TaskStatus", "StopTask").With(newDealAuthorization(ctx, h, newStringerFieldMetaData(h))),
 		auth.Allow("StartTask").With(newDealAuthorization(ctx, h, newFieldDealMetaData())),
-		auth.Allow("TaskLogs").With(newDealAuthorization(ctx, h, newFieldIdMetaData(h))),
+		auth.Allow("TaskLogs").With(newDealAuthorization(ctx, h, newStringerFieldMetaData(h))),
 		auth.Allow("PushTask").With(newDealAuthorization(ctx, h, newContextDealMetaData())),
-		auth.Allow("PullTask").With(newDealAuthorization(ctx, h, newFieldDealMetaData())),
+		auth.Allow("PullTask").With(newDealAuthorization(ctx, h, newNamedStringerFieldMetaData(h, "TaskId"))),
 		auth.WithFallback(auth.NewDenyAuthorization()),
 	)
 

--- a/insonmnia/hub/server.go
+++ b/insonmnia/hub/server.go
@@ -16,6 +16,7 @@ import (
 	log "github.com/noxiouz/zapctx/ctxlog"
 	"github.com/pkg/errors"
 	"github.com/sonm-io/core/blockchain"
+	"github.com/sonm-io/core/insonmnia/auth"
 	"github.com/sonm-io/core/util/xgrpc"
 	"go.uber.org/zap"
 	"golang.org/x/net/context"
@@ -126,7 +127,7 @@ type Hub struct {
 
 	// Per-call ACL.
 	// Must be synchronized with the Hub cluster.
-	eventAuthorization *eventACL
+	eventAuthorization *auth.AuthRouter
 
 	// Currently running deals.
 	// Retroactive deals to tasks association. Tasks aren't popped when
@@ -220,9 +221,6 @@ type routeMapping struct {
 
 func (h *Hub) onRequest(ctx context.Context, request interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
 	log.G(h.ctx).Debug("intercepting request")
-	if err := h.eventAuthorization.authorize(ctx, method(info.FullMethod), request); err != nil {
-		return nil, err
-	}
 
 	forwarded, r, err := h.tryForwardToLeader(ctx, request, info)
 	if forwarded {
@@ -269,7 +267,7 @@ func proxyRequestCall(ctx context.Context, client pb.HubClient, request interfac
 func (h *Hub) PushTask(stream pb.Hub_PushTaskServer) error {
 	log.G(h.ctx).Info("handling PushTask request")
 
-	if err := h.eventAuthorization.authorize(stream.Context(), method("PushTask"), nil); err != nil {
+	if err := h.eventAuthorization.Authorize(stream.Context(), auth.Event("PushTask"), nil); err != nil {
 		return err
 	}
 
@@ -362,7 +360,7 @@ func (h *Hub) PushTask(stream pb.Hub_PushTaskServer) error {
 func (h *Hub) PullTask(request *pb.PullTaskRequest, stream pb.Hub_PullTaskServer) error {
 	log.G(h.ctx).Info("handling PullTask request", zap.Any("request", request))
 
-	if err := h.eventAuthorization.authorize(stream.Context(), method("PullTask"), nil); err != nil {
+	if err := h.eventAuthorization.Authorize(stream.Context(), auth.Event("PullTask"), nil); err != nil {
 		return err
 	}
 
@@ -752,7 +750,7 @@ func (h *Hub) TaskStatus(ctx context.Context, request *pb.ID) (*pb.TaskStatusRep
 
 func (h *Hub) TaskLogs(request *pb.TaskLogsRequest, server pb.Hub_TaskLogsServer) error {
 	log.G(h.ctx).Info("handling TaskLogs request", zap.Any("request", request))
-	if err := h.eventAuthorization.authorize(server.Context(), method("TaskLogs"), request); err != nil {
+	if err := h.eventAuthorization.Authorize(server.Context(), auth.Event("TaskLogs"), request); err != nil {
 		return err
 	}
 
@@ -1298,8 +1296,6 @@ func New(ctx context.Context, cfg *Config, version string, opts ...Option) (*Hub
 
 	wl := NewWhitelist(ctx, &cfg.Whitelist)
 
-	eventACL := newEventACL(ctx)
-
 	h := &Hub{
 		cfg:              cfg,
 		ctx:              ctx,
@@ -1327,7 +1323,7 @@ func New(ctx context.Context, cfg *Config, version string, opts ...Option) (*Hub
 		slots:            make(map[string]*structs.Slot),
 		acl:              acl,
 
-		eventAuthorization: eventACL,
+		eventAuthorization: nil,
 
 		certRotator: defaults.rot,
 		creds:       defaults.creds,
@@ -1338,27 +1334,25 @@ func New(ctx context.Context, cfg *Config, version string, opts ...Option) (*Hub
 		whitelist: wl,
 	}
 
-	dealAuthorization := map[string]DealMetaData{
-		"TaskStatus": &taskFieldDealMetaData{hub: h},
-		"StartTask":  &fieldDealMetaData{},
-		"StopTask":   &taskFieldDealMetaData{hub: h},
-		"TaskLogs":   &taskFieldDealMetaData{hub: h},
-		"PushTask":   &contextDealMetaData{},
-		"PullTask":   &contextDealMetaData{},
-	}
+	authorization := auth.NewEventAuthorization(h.ctx,
+		auth.WithLog(log.G(ctx)),
+		auth.WithEventPrefix(hubAPIPrefix),
+		auth.Allow("Handshake", "ProposeDeal").With(auth.NewNilAuthorization()),
+		auth.Allow(hubManagementMethods...).With(auth.NewTransportAuthorization(h.ethAddr)),
+		auth.Allow("TaskStatus", "StopTask").With(newDealAuthorization(ctx, h, &fieldIdMetaData{hub: h})),
+		auth.Allow("StartTask").With(newDealAuthorization(ctx, h, &fieldDealMetaData{})),
+		auth.Allow("TaskLogs").With(newDealAuthorization(ctx, h, &fieldIdMetaData{})),
+		auth.Allow("PushTask", "PullTask").With(newDealAuthorization(ctx, h, &contextDealMetaData{})),
+		auth.WithFallback(auth.NewDenyAuthorization()),
+	)
 
-	for event, metadata := range dealAuthorization {
-		eventACL.addAuthorization(method(hubAPIPrefix+event), newDealAuthorization(ctx, h, metadata))
-	}
-
-	for _, event := range hubManagementMethods {
-		eventACL.addAuthorization(method(hubAPIPrefix+event), newHubManagementAuthorization(ctx, h.ethAddr))
-	}
+	h.eventAuthorization = authorization
 
 	logger := log.GetLogger(h.ctx)
 	grpcServer := xgrpc.NewServer(logger,
 		xgrpc.Credentials(h.creds),
 		xgrpc.DefaultTraceInterceptor(),
+		xgrpc.AuthorizationInterceptor(authorization),
 		xgrpc.UnaryServerInterceptor(h.onRequest),
 	)
 	h.externalGrpc = grpcServer

--- a/insonmnia/hub/server.go
+++ b/insonmnia/hub/server.go
@@ -1343,7 +1343,9 @@ func New(ctx context.Context, cfg *Config, version string, opts ...Option) (*Hub
 		auth.Allow("StartTask").With(newDealAuthorization(ctx, h, newFieldDealMetaData())),
 		auth.Allow("TaskLogs").With(newDealAuthorization(ctx, h, newStringerFieldMetaData(h))),
 		auth.Allow("PushTask").With(newDealAuthorization(ctx, h, newContextDealMetaData())),
-		auth.Allow("PullTask").With(newDealAuthorization(ctx, h, newNamedStringerFieldMetaData(h, "TaskId"))),
+		// TODO: Tactical architectural solution.
+		// auth.Allow("PullTask").With(newDealAuthorization(ctx, h, newNamedStringerFieldMetaData(h, "TaskId"))),
+		auth.Allow("PullTask").With(auth.NewNilAuthorization()),
 		auth.WithFallback(auth.NewDenyAuthorization()),
 	)
 

--- a/util/util.go
+++ b/util/util.go
@@ -135,13 +135,3 @@ func GetAvailableIPs() (availableIPs []net.IP, err error) {
 
 	return availableIPs, nil
 }
-
-// EqualAddresses checks if provided Addresses are equal
-func EqualAddresses(a, b common.Address) bool {
-	for i := range a {
-		if a[i] != b[i] {
-			return false
-		}
-	}
-	return true
-}

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -1,10 +1,8 @@
 package util
 
 import (
-	"fmt"
 	"testing"
 
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -49,55 +47,5 @@ func TestParseEndpoint(t *testing.T) {
 		} else {
 			assert.NoError(t, err)
 		}
-	}
-}
-
-func TestEqualAddresses(t *testing.T) {
-	cases := []struct {
-		a    string
-		b    string
-		isEq bool
-	}{
-		{
-			a:    "1aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaB",
-			b:    "1aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab",
-			isEq: true,
-		},
-		{
-			a:    "1aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaB",
-			b:    "0x1aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab",
-			isEq: true,
-		},
-		{
-			a:    "1aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaB",
-			b:    "2aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaB",
-			isEq: false,
-		},
-		{
-			a:    "0x1aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaB",
-			b:    "0x1aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaB",
-			isEq: true,
-		},
-		{
-			a:    "0x0",
-			b:    "0x1",
-			isEq: false,
-		},
-		{
-			a:    "0",
-			b:    "1",
-			isEq: false,
-		},
-		{
-			a:    "0x",
-			b:    "0x",
-			isEq: true,
-		},
-	}
-
-	for _, cc := range cases {
-		a := common.HexToAddress(cc.a)
-		b := common.HexToAddress(cc.b)
-		assert.Equal(t, cc.isEq, EqualAddresses(a, b), fmt.Sprintf("compare %s and %s failed", cc.a, cc.b))
 	}
 }


### PR DESCRIPTION
## Summary

This PR introduces new way to configure server authorization through chained interceptor middlewares. Things that can be configured:
- Global prefix.
- Fallback logic for unregistered events (allow/deny).
- Custom authorization for specific events.
- Predefined helpers, such as checking for specific transport credentials. 

For example:

```go
authorization := auth.NewEventAuthorization(h.ctx,
 	auth.WithLog(log.G(ctx)),
 	auth.WithEventPrefix(hubAPIPrefix),
 	auth.Allow("Handshake", "ProposeDeal").With(auth.NewNilAuthorization()),
 	auth.Allow(hubManagementMethods...).With(auth.NewTransportAuthorization(h.ethAddr)),
 	auth.Allow("TaskStatus", "StopTask").With(newDealAuthorization(ctx, h, &fieldIdMetaData{hub: h})),
 	auth.Allow("StartTask").With(newDealAuthorization(ctx, h, &fieldDealMetaData{})),
 	auth.Allow("TaskLogs").With(newDealAuthorization(ctx, h, &fieldIdMetaData{})),
 	auth.Allow("PushTask", "PullTask").With(newDealAuthorization(ctx, h, &contextDealMetaData{})),
 	auth.WithFallback(auth.NewDenyAuthorization()),
 )
```

Summary:
- Both proposing deal and handshake were left accessible without additional authorization.
- Task-specific methods require the proper deal ID.
- Hub management methods require proper transport credentials.
- All other methods are denied.

Please, review carefully.

## Detailed

Fixed:
- Pushing, pulling and log fetching for task now shouldn't allow to be used by everyone.

Changed:
- New package - `auth` for maintaining AAA stuff.
- Flawless flow-like authorization configuration.
- Replaced direct comparing bytes with `bytes` package.
- Decompose server handshake's wallet comparison.
- Minor renamings.

Removed:
- Self signed wallet no longer required, because wallet info can be extracted from peer credentials. All associated functions and structs were removed.

## TBD
- Streaming auth - not the scope of this PR.