### PR TITLE
feat: only_public_ips mode for locator

### DIFF
--- a/insonmnia/locator/config.go
+++ b/insonmnia/locator/config.go
@@ -14,10 +14,11 @@ type storeConfig struct {
 }
 
 type Config struct {
-	ListenAddr string             `yaml:"address"`
-	NodeTTL    time.Duration      `yaml:"node_ttl"`
-	Eth        accounts.EthConfig `required:"true" yaml:"ethereum"`
-	Store      storeConfig        `required:"true" yaml:"store"`
+	ListenAddr    string             `yaml:"address"`
+	NodeTTL       time.Duration      `yaml:"node_ttl"`
+	Eth           accounts.EthConfig `required:"true" yaml:"ethereum"`
+	OnlyPublicIPs bool               `required:"false" yaml:"only_public_ips"`
+	Store         storeConfig        `required:"true" yaml:"store"`
 }
 
 // NewConfig loads a hub config from the specified YAML file.

--- a/insonmnia/miner/util.go
+++ b/insonmnia/miner/util.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/sonm-io/core/proto"
+	"github.com/sonm-io/core/util"
 )
 
 // BackoffTimer implementation
@@ -76,7 +77,7 @@ type sortableIPs []net.IP
 func (s sortableIPs) Len() int      { return len(s) }
 func (s sortableIPs) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
 func (s sortableIPs) Less(i, j int) bool {
-	iIsPrivate, jIsPrivate := isPrivate(s[i]), isPrivate(s[j])
+	iIsPrivate, jIsPrivate := util.IsPrivateIP(s[i]), util.IsPrivateIP(s[j])
 	if iIsPrivate && !jIsPrivate {
 		return false
 	}
@@ -92,26 +93,6 @@ func (s sortableIPs) Less(i, j int) bool {
 	}
 
 	return true
-}
-
-func isPrivate(ip net.IP) bool {
-	return isPrivateIPv4(ip) || isPrivateIPv6(ip)
-}
-
-func isPrivateIPv4(ip net.IP) bool {
-	private := false
-	_, private24BitBlock, _ := net.ParseCIDR("10.0.0.0/8")
-	_, private20BitBlock, _ := net.ParseCIDR("172.16.0.0/12")
-	_, private16BitBlock, _ := net.ParseCIDR("192.168.0.0/16")
-	private = private24BitBlock.Contains(ip) || private20BitBlock.Contains(ip) || private16BitBlock.Contains(ip)
-
-	return private
-}
-
-func isPrivateIPv6(ip net.IP) bool {
-	_, block, _ := net.ParseCIDR("fc00::/7")
-
-	return block.Contains(ip)
 }
 
 func isIPv4(ip net.IP) bool {

--- a/locator.yaml
+++ b/locator.yaml
@@ -11,6 +11,8 @@ ethereum:
   # passphrase for keystore
   pass_phrase: "any"
 
+only_public_ips: false
+
 store:
   # Type of the storage to use.
   # Possible types are: "consul", "zookeeper", "etcd" and "boltdb"

--- a/util/util.go
+++ b/util/util.go
@@ -135,3 +135,23 @@ func GetAvailableIPs() (availableIPs []net.IP, err error) {
 
 	return availableIPs, nil
 }
+
+func IsPrivateIP(ip net.IP) bool {
+	return isPrivateIPv4(ip) || isPrivateIPv6(ip)
+}
+
+func isPrivateIPv4(ip net.IP) bool {
+	private := false
+	_, private24BitBlock, _ := net.ParseCIDR("10.0.0.0/8")
+	_, private20BitBlock, _ := net.ParseCIDR("172.16.0.0/12")
+	_, private16BitBlock, _ := net.ParseCIDR("192.168.0.0/16")
+	private = private24BitBlock.Contains(ip) || private20BitBlock.Contains(ip) || private16BitBlock.Contains(ip)
+
+	return private
+}
+
+func isPrivateIPv6(ip net.IP) bool {
+	_, block, _ := net.ParseCIDR("fc00::/7")
+
+	return block.Contains(ip)
+}


### PR DESCRIPTION
Locator can now work in `only_public_ips` mode.

* If hub announces its IPs and none of them is public, an error is returned.
* If some of the announced IPs are public, announcement is successful (only public IPs are written to db, skipped IPs are logged).
* Config field `only_public_ips` is optional.