### PR TITLE
Fix/hw logs

### DIFF
--- a/cmd/miner/main.go
+++ b/cmd/miner/main.go
@@ -46,17 +46,19 @@ func main() {
 	if _, err := os.Stat(cfg.UUIDPath()); os.IsNotExist(err) {
 		ioutil.WriteFile(cfg.UUIDPath(), []byte(uuid.New()), 0660)
 	}
+
 	uuidData, err := ioutil.ReadFile(cfg.UUIDPath())
 	if err != nil {
 		log.G(ctx).Error("cannot load uuid", zap.Error(err))
 		os.Exit(1)
 	}
-	uuid := string(uuidData)
+
+	workerID := string(uuidData)
 
 	logger := logging.BuildLogger(cfg.Logging().Level, true)
 	ctx = log.WithLogger(ctx, logger)
 
-	m, err := miner.NewMiner(cfg, miner.WithContext(ctx), miner.WithKey(key), miner.WithUUID(uuid))
+	m, err := miner.NewMiner(cfg, miner.WithContext(ctx), miner.WithKey(key), miner.WithUUID(workerID))
 	if err != nil {
 		log.G(ctx).Error("cannot create worker instance", zap.Error(err))
 		os.Exit(1)

--- a/cmd/miner/main.go
+++ b/cmd/miner/main.go
@@ -33,7 +33,7 @@ func main() {
 
 	cfg, err := miner.NewConfig(*configPath)
 	if err != nil {
-		log.G(ctx).Error("Cannot load config", zap.Error(err))
+		log.G(ctx).Error("cannot load config", zap.Error(err))
 		os.Exit(1)
 	}
 
@@ -48,7 +48,7 @@ func main() {
 	}
 	uuidData, err := ioutil.ReadFile(cfg.UUIDPath())
 	if err != nil {
-		log.G(ctx).Error("Cannot load uuid", zap.Error(err))
+		log.G(ctx).Error("cannot load uuid", zap.Error(err))
 		os.Exit(1)
 	}
 	uuid := string(uuidData)
@@ -57,6 +57,11 @@ func main() {
 	ctx = log.WithLogger(ctx, logger)
 
 	m, err := miner.NewMiner(cfg, miner.WithContext(ctx), miner.WithKey(key), miner.WithUUID(uuid))
+	if err != nil {
+		log.G(ctx).Error("cannot create worker instance", zap.Error(err))
+		os.Exit(1)
+	}
+
 	go func() {
 		c := make(chan os.Signal, 1)
 		signal.Notify(c, os.Interrupt)

--- a/insonmnia/hardware/hardware.go
+++ b/insonmnia/hardware/hardware.go
@@ -1,13 +1,9 @@
 package hardware
 
 import (
-	"context"
-
-	log "github.com/noxiouz/zapctx/ctxlog"
 	"github.com/shirou/gopsutil/mem"
 	"github.com/sonm-io/core/insonmnia/hardware/cpu"
 	"github.com/sonm-io/core/insonmnia/hardware/gpu"
-	"go.uber.org/zap"
 )
 
 // Hardware accumulates the finest hardware information about system the miner
@@ -59,9 +55,7 @@ type HardwareInfo interface {
 	Info() (*Hardware, error)
 }
 
-type hardwareInfo struct {
-	ctx context.Context
-}
+type hardwareInfo struct{}
 
 func (*hardwareInfo) CPU() ([]cpu.Device, error) {
 	return cpu.GetCPUDevices()
@@ -88,8 +82,7 @@ func (h *hardwareInfo) Info() (*Hardware, error) {
 
 	gpuInfo, err := h.GPU()
 	if err != nil {
-		log.G(h.ctx).Warn("cannot get GPU devices list", zap.Error(err))
-		gpuInfo = make([]gpu.Device, 0)
+		return nil, err
 	}
 
 	hardware := &Hardware{
@@ -102,6 +95,6 @@ func (h *hardwareInfo) Info() (*Hardware, error) {
 }
 
 // New constructs a new hardware info collector.
-func New(ctx context.Context) HardwareInfo {
-	return &hardwareInfo{ctx: ctx}
+func New() HardwareInfo {
+	return &hardwareInfo{}
 }

--- a/insonmnia/hardware/hardware.go
+++ b/insonmnia/hardware/hardware.go
@@ -1,9 +1,13 @@
 package hardware
 
 import (
+	"context"
+
+	log "github.com/noxiouz/zapctx/ctxlog"
 	"github.com/shirou/gopsutil/mem"
 	"github.com/sonm-io/core/insonmnia/hardware/cpu"
 	"github.com/sonm-io/core/insonmnia/hardware/gpu"
+	"go.uber.org/zap"
 )
 
 // Hardware accumulates the finest hardware information about system the miner
@@ -56,6 +60,7 @@ type HardwareInfo interface {
 }
 
 type hardwareInfo struct {
+	ctx context.Context
 }
 
 func (*hardwareInfo) CPU() ([]cpu.Device, error) {
@@ -83,6 +88,7 @@ func (h *hardwareInfo) Info() (*Hardware, error) {
 
 	gpuInfo, err := h.GPU()
 	if err != nil {
+		log.G(h.ctx).Warn("cannot get GPU devices list", zap.Error(err))
 		gpuInfo = make([]gpu.Device, 0)
 	}
 
@@ -96,6 +102,6 @@ func (h *hardwareInfo) Info() (*Hardware, error) {
 }
 
 // New constructs a new hardware info collector.
-func New() HardwareInfo {
-	return &hardwareInfo{}
+func New(ctx context.Context) HardwareInfo {
+	return &hardwareInfo{ctx: ctx}
 }

--- a/insonmnia/miner/server.go
+++ b/insonmnia/miner/server.go
@@ -101,10 +101,6 @@ func NewMiner(cfg Config, opts ...Option) (m *Miner, err error) {
 		o.ctx = context.Background()
 	}
 
-	if o.hardware == nil {
-		o.hardware = hardware.New()
-	}
-
 	if len(o.uuid) == 0 {
 		o.uuid = uuid.New()
 	}
@@ -116,6 +112,10 @@ func NewMiner(cfg Config, opts ...Option) (m *Miner, err error) {
 			cancel()
 			return nil, err
 		}
+	}
+
+	if o.hardware == nil {
+		o.hardware = hardware.New(ctx)
 	}
 
 	hardwareInfo, err := o.hardware.Info()

--- a/insonmnia/miner/server.go
+++ b/insonmnia/miner/server.go
@@ -115,7 +115,7 @@ func NewMiner(cfg Config, opts ...Option) (m *Miner, err error) {
 	}
 
 	if o.hardware == nil {
-		o.hardware = hardware.New(ctx)
+		o.hardware = hardware.New()
 	}
 
 	hardwareInfo, err := o.hardware.Info()

--- a/insonmnia/miner/server.go
+++ b/insonmnia/miner/server.go
@@ -124,6 +124,8 @@ func NewMiner(cfg Config, opts ...Option) (m *Miner, err error) {
 		return nil, err
 	}
 
+	log.G(ctx).Info("collected hardware info", zap.Any("hw", hardwareInfo))
+
 	cgroup, cGroupManager, err := makeCgroupManager(cfg.HubResources())
 	if err != nil {
 		cancel()


### PR DESCRIPTION
Added: 
- log error if the worker cannot collect GPU info
- log collected hardware on worker's start

Fixed:
- handler error if NewMiner has failed

Outofscope:
- lowercase logs is awesome;
- do not clash variables and import names;