### PR TITLE
fix: close overseer

### DIFF
--- a/insonmnia/miner/server.go
+++ b/insonmnia/miner/server.go
@@ -852,14 +852,19 @@ func (m *Miner) Serve() error {
 // Close disposes all resources related to the Miner
 func (m *Miner) Close() {
 	log.G(m.ctx).Info("closing miner")
+
 	m.cancel()
 	m.grpcServer.Stop()
+
 	if m.ssh != nil {
 		m.ssh.Close()
 	}
+
 	if m.certRotator != nil {
 		m.certRotator.Close()
 	}
+
+	m.ovs.Close()
 	m.rl.Close()
 	m.controlGroup.Delete()
 }


### PR DESCRIPTION
This PR just close overseer at Worker's finishing. It required for correct GPU plugin unloading and socket closing when Nvidia-embedded is used;