### PR TITLE
Refact/slots

### DIFF
--- a/insonmnia/hub/config.go
+++ b/insonmnia/hub/config.go
@@ -2,6 +2,7 @@ package hub
 
 import (
 	"strings"
+	"time"
 
 	"github.com/jinzhu/configor"
 	"github.com/sonm-io/core/accounts"
@@ -21,8 +22,8 @@ type LocatorConfig struct {
 }
 
 type MarketConfig struct {
-	Endpoint        string `required:"true" yaml:"endpoint"`
-	UpdatePeriodSec uint64 `default:"60" yaml:"update_period_sec"`
+	Endpoint     string        `required:"true" yaml:"endpoint"`
+	UpdatePeriod time.Duration `default:"60s" yaml:"update_period_sec"`
 }
 
 type StoreConfig struct {

--- a/insonmnia/hub/config.go
+++ b/insonmnia/hub/config.go
@@ -21,7 +21,8 @@ type LocatorConfig struct {
 }
 
 type MarketConfig struct {
-	Endpoint string `required:"true" yaml:"endpoint"`
+	Endpoint        string `required:"true" yaml:"endpoint"`
+	UpdatePeriodSec uint64 `default:"60" yaml:"update_period_sec"`
 }
 
 type StoreConfig struct {

--- a/insonmnia/hub/server.go
+++ b/insonmnia/hub/server.go
@@ -766,7 +766,7 @@ func (h *Hub) ProposeDeal(ctx context.Context, r *pb.DealRequest) (*pb.Empty, er
 	}
 
 	if !h.askPlans.HasOrder(request.AskId) {
-		return nil, status.Errorf(codes.NotFound, "slot not found")
+		return nil, status.Errorf(codes.NotFound, "order not found")
 	}
 
 	bidOrder, err := h.market.GetOrderByID(h.ctx, &pb.ID{Id: request.GetBidId()})
@@ -1014,8 +1014,8 @@ func (h *Hub) HasResources(resources *structs.Resources) bool {
 		resources.GetGPUCount(),
 	)
 
-	ctx, err := h.findRandomMinerByUsage(&usage)
-	return ctx != nil && err == nil
+	miner, err := h.findRandomMinerByUsage(&usage)
+	return miner != nil && err == nil
 }
 
 func (h *Hub) DiscoverHub(ctx context.Context, request *pb.DiscoverHubRequest) (*pb.Empty, error) {
@@ -1097,6 +1097,7 @@ func (h *Hub) Slots(ctx context.Context, request *pb.Empty) (*pb.SlotsReply, err
 	return &pb.SlotsReply{Slots: h.askPlans.DumpSlots()}, nil
 }
 
+//TODO: Actually it is not slot, but AskPlan
 func (h *Hub) InsertSlot(ctx context.Context, request *pb.InsertSlotRequest) (*pb.ID, error) {
 	log.G(h.ctx).Info("handling InsertSlot request", zap.Any("request", request))
 
@@ -1130,6 +1131,7 @@ func (h *Hub) InsertSlot(ctx context.Context, request *pb.InsertSlotRequest) (*p
 	return &pb.ID{Id: id}, nil
 }
 
+//TODO: Actually it is not slot, but AskPlan
 func (h *Hub) RemoveSlot(ctx context.Context, request *pb.ID) (*pb.Empty, error) {
 	log.G(h.ctx).Info("RemoveSlot request", zap.Any("id", request.Id))
 

--- a/insonmnia/hub/slot.go
+++ b/insonmnia/hub/slot.go
@@ -36,6 +36,7 @@ func NewAskPlans(hub *Hub, market pb.MarketClient) *AskPlans {
 
 func (a *AskPlans) Run(ctx context.Context) error {
 	ticker := util.NewImmediateTicker(a.hub.cfg.Market.UpdatePeriod)
+	defer ticker.Stop()
 	for {
 		select {
 		case <-ctx.Done():

--- a/insonmnia/hub/slot.go
+++ b/insonmnia/hub/slot.go
@@ -42,9 +42,7 @@ func (a *AskPlans) Run(ctx context.Context) error {
 		case <-ctx.Done():
 			return nil
 		case <-ticker.C:
-			if err := a.checkAnnounces(ctx); err != nil {
-				return err
-			}
+			a.checkAnnounces(ctx)
 		}
 	}
 }
@@ -125,7 +123,7 @@ func (a *AskPlans) forceRenewAnnounces(ctx context.Context) {
 	}
 }
 
-func (a *AskPlans) checkAnnounces(ctx context.Context) error {
+func (a *AskPlans) checkAnnounces(ctx context.Context) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 	changed := false
@@ -156,7 +154,6 @@ func (a *AskPlans) checkAnnounces(ctx context.Context) error {
 	if changed {
 		a.sync(ctx)
 	}
-	return nil
 }
 
 //TODO: do we need to signal about error?

--- a/insonmnia/hub/slot.go
+++ b/insonmnia/hub/slot.go
@@ -27,12 +27,11 @@ type AskPlans struct {
 }
 
 func NewAskPlans(hub *Hub, market pb.MarketClient) *AskPlans {
-	askPlans := AskPlans{
+	return &AskPlans{
 		Data:   make(map[string]AskPlan),
 		hub:    hub,
 		market: market,
 	}
-	return &askPlans
 }
 
 func (a *AskPlans) Run(ctx context.Context) error {

--- a/insonmnia/hub/slot.go
+++ b/insonmnia/hub/slot.go
@@ -1,0 +1,167 @@
+package hub
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	log "github.com/noxiouz/zapctx/ctxlog"
+	"github.com/pborman/uuid"
+	"github.com/sonm-io/core/insonmnia/structs"
+	pb "github.com/sonm-io/core/proto"
+	"github.com/sonm-io/core/util"
+	"go.uber.org/zap"
+)
+
+type AskPlan struct {
+	Id    string
+	Order *structs.Order
+}
+
+type AskPlansData map[string]*AskPlan
+
+type AskPlans struct {
+	Data   AskPlansData
+	ctx    context.Context
+	mu     sync.Mutex
+	hub    *Hub
+	market pb.MarketClient
+}
+
+func NewAskPlans(ctx context.Context, hub *Hub, market pb.MarketClient) *AskPlans {
+	askPlans := AskPlans{
+		Data:   make(map[string]*AskPlan),
+		ctx:    ctx,
+		hub:    hub,
+		market: market,
+	}
+	return &askPlans
+}
+
+func (a *AskPlans) Run() error {
+	a.hub.cfg.Market
+	ticker := util.NewImmediateTicker(time.Second)
+	for {
+		select {
+		case <-a.ctx.Done():
+			return nil
+		case <-ticker.C:
+			if err := a.checkAnnounces(); err != nil {
+				return err
+			}
+		}
+	}
+}
+
+func (a *AskPlans) Add(order *structs.Order) (string, error) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	id := uuid.New()
+	a.Data[id] = &AskPlan{
+		Id:    id,
+		Order: order,
+	}
+	return id, nil
+}
+
+func (a *AskPlans) DumpSlots() map[string]*pb.Slot {
+	result := make(map[string]*pb.Slot)
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	for id, plan := range a.Data {
+		result[id] = plan.Order.Slot
+	}
+	return result
+}
+
+func (a *AskPlans) Dump() AskPlansData {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.Data
+}
+
+func (a *AskPlans) RestoreFrom(data AskPlansData) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.Data = data
+}
+
+func (a *AskPlans) Remove(planId string) error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	askPlan, ok := a.Data[planId]
+	if !ok {
+		return errSlotNotExists
+	}
+	a.deannouncePlan(askPlan)
+	delete(a.Data, planId)
+	a.sync()
+	return nil
+}
+
+func (a *AskPlans) HasOrder(orderId string) bool {
+	panic("unimplemented")
+}
+
+func (a *AskPlans) checkAnnounces() error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	changed := false
+	toUpdate := make([]string, 0)
+	for _, plan := range a.Data {
+
+		has := a.hub.HasResources(plan.Order.GetSlot().GetResources())
+		announced := plan.Order.Id != ""
+		if has && !announced {
+			changed = true
+			a.announcePlan(plan)
+		}
+		if !has && announced {
+			changed = true
+			a.deannouncePlan(plan)
+		}
+		if has && announced {
+			toUpdate = append(toUpdate, plan.Order.Id)
+		}
+	}
+	if len(toUpdate) > 0 {
+		_, err := a.market.TouchOrders(a.ctx, &pb.TouchOrdersRequest{IDs: toUpdate})
+		if err != nil {
+			log.G(a.ctx).Warn("failed to touch orders on market", zap.Error(err))
+		}
+	}
+	if changed {
+		a.sync()
+	}
+	return nil
+}
+
+//TODO: do we need to signal about error?
+func (a *AskPlans) announcePlan(plan *AskPlan) {
+	createdOrder, err := a.market.CreateOrder(a.ctx, plan.Order.Unwrap())
+	if err != nil {
+		log.S(a.ctx).Warnf("failed to announce ask plan with id{} on market - {}", plan.Id, zap.Error(err))
+		return
+	}
+	wrappedOrder, err := structs.NewOrder(createdOrder)
+	if err != nil {
+		log.S(a.ctx).Warnf("invalid order received from market - {}", plan.Id, zap.Error(err))
+		return
+	}
+	plan.Order = wrappedOrder
+}
+
+func (a *AskPlans) deannouncePlan(plan *AskPlan) {
+	_, err := a.market.CancelOrder(a.ctx, plan.Order.Unwrap())
+	if err != nil {
+		log.S(a.ctx).Warnf("failed to deannounce order {} (ask plan - {}) on market - {}", plan.Order.Id, plan.Id, zap.Error(err))
+	} else {
+		plan.Order.Id = ""
+	}
+}
+
+func (a *AskPlans) sync() {
+	if err := a.hub.SynchronizeAskPlans(a.Data); err != nil {
+		log.G(a.ctx).Warn("failed to sync ask plans to cluster", zap.Error(err))
+	}
+}


### PR DESCRIPTION
This PR introduces separated askPlans(slots) for hub with eventual announce/deannounce to market.
Now only slots which has enough resources on miners make announces on market. When resources are consumed and exhausted deannounce is made.
TODO: Proper tests
@3Hren @sshaman1101 @screwyprof PTAL