### PR TITLE
fix: decrease orders loading time

### DIFF
--- a/insonmnia/node/tasks.go
+++ b/insonmnia/node/tasks.go
@@ -34,8 +34,9 @@ func (t *tasksAPI) List(ctx context.Context, req *pb.TaskListRequest) (*pb.TaskL
 		return hubClient.TaskList(ctx, &pb.Empty{})
 	}
 
-	myAddr := util.PubKeyToAddr(t.remotes.key.PublicKey)
-	dealIDs, err := t.remotes.eth.GetDeals(myAddr.Hex())
+	clientAddr := util.PubKeyToAddr(t.remotes.key.PublicKey)
+	// get all accepted deals, because only on the accepted deals client can start the payloads.
+	dealIDs, err := t.remotes.eth.GetAcceptedDeal("", clientAddr.Hex())
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This PR fix deals retrieving for the `tasks list` command.

The deals used to obtain the Hub address, then resolving IP address via the Locator and then load tasks list via the gRPC.

the Node needs only accepted deals in that context because only with the accepted deal the Hub can start client's tasks.

the `tasks list` call now takes up to 2/3 less time from the previous implementation.