### PR TITLE
fix: do not remove container after commit

### DIFF
--- a/insonmnia/miner/overseer.go
+++ b/insonmnia/miner/overseer.go
@@ -267,7 +267,6 @@ func (o *overseer) handleStreamingEvents(ctx context.Context, sinceUnix int64, f
 						if err != nil {
 							log.G(ctx).Error("failed to commit container", zap.String("id", id), zap.Error(err))
 						}
-						c.remove()
 						c.cancel()
 					}()
 				}


### PR DESCRIPTION
In general we also need a cleanup gc routine, but for now we just need to leave containers to provide access to logs and so on.