### PR TITLE
fix: create ovs and cancel func as late as possible

### DIFF
--- a/insonmnia/miner/server.go
+++ b/insonmnia/miner/server.go
@@ -169,7 +169,6 @@ func NewMiner(cfg Config, opts ...Option) (m *Miner, err error) {
 	if o.ovs == nil {
 		o.ovs, err = NewOverseer(ctx, cfg.GPU())
 		if err != nil {
-			cancel()
 			return nil, err
 		}
 	}

--- a/insonmnia/miner/server.go
+++ b/insonmnia/miner/server.go
@@ -106,6 +106,65 @@ func NewMiner(cfg Config, opts ...Option) (m *Miner, err error) {
 		o.uuid = uuid.New()
 	}
 
+	if o.hardware == nil {
+		o.hardware = hardware.New()
+	}
+
+	hardwareInfo, err := o.hardware.Info()
+	if err != nil {
+		return nil, err
+	}
+
+	log.G(o.ctx).Info("collected hardware info", zap.Any("hw", hardwareInfo))
+
+	cgroup, cGroupManager, err := makeCgroupManager(cfg.HubResources())
+	if err != nil {
+		return nil, err
+	}
+
+	if o.locatorClient == nil {
+		_, TLSConf, err := util.NewHitlessCertRotator(o.ctx, o.key)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to create locator client")
+		}
+
+		locatorCC, err := xgrpc.NewWalletAuthenticatedClient(o.ctx, util.NewTLS(TLSConf), cfg.LocatorEndpoint())
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to create locator client")
+		}
+
+		o.locatorClient = pb.NewLocatorClient(locatorCC)
+	}
+
+	// The rotator will be stopped by ctx
+	certRotator, TLSConf, err := util.NewHitlessCertRotator(o.ctx, o.key)
+	if err != nil {
+		return nil, err
+	}
+
+	hubEndpoint, err := o.getHubConnectionInfo(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	creds := auth.NewWalletAuthenticator(util.NewTLS(TLSConf), hubEndpoint.EthAddress)
+	grpcServer := xgrpc.NewServer(log.GetLogger(o.ctx),
+		xgrpc.Credentials(creds),
+		xgrpc.DefaultTraceInterceptor(),
+	)
+
+	if !platformSupportCGroups && cfg.HubResources() != nil {
+		log.G(o.ctx).Warn("your platform does not support CGroup, but the config has resources section")
+	}
+
+	if err := o.setupNetworkOptions(cfg); err != nil {
+		return nil, errors.Wrap(err, "failed to set up network options")
+	}
+
+	log.G(o.ctx).Info("discovered public IPs",
+		zap.Any("public IPs", o.publicIPs),
+		zap.Any("nat", o.nat))
+
 	ctx, cancel := context.WithCancel(o.ctx)
 	if o.ovs == nil {
 		o.ovs, err = NewOverseer(ctx, cfg.GPU())
@@ -114,72 +173,6 @@ func NewMiner(cfg Config, opts ...Option) (m *Miner, err error) {
 			return nil, err
 		}
 	}
-
-	if o.hardware == nil {
-		o.hardware = hardware.New()
-	}
-
-	hardwareInfo, err := o.hardware.Info()
-	if err != nil {
-		cancel()
-		return nil, err
-	}
-
-	log.G(ctx).Info("collected hardware info", zap.Any("hw", hardwareInfo))
-
-	cgroup, cGroupManager, err := makeCgroupManager(cfg.HubResources())
-	if err != nil {
-		cancel()
-		return nil, err
-	}
-
-	if o.locatorClient == nil {
-		_, TLSConf, err := util.NewHitlessCertRotator(o.ctx, o.key)
-		if err != nil {
-			cancel()
-			return nil, errors.Wrap(err, "failed to create locator client")
-		}
-
-		locatorCC, err := xgrpc.NewWalletAuthenticatedClient(o.ctx, util.NewTLS(TLSConf), cfg.LocatorEndpoint())
-		if err != nil {
-			cancel()
-			return nil, errors.Wrap(err, "failed to create locator client")
-		}
-
-		o.locatorClient = pb.NewLocatorClient(locatorCC)
-	}
-
-	// The rotator will be stopped by ctx
-	certRotator, TLSConf, err := util.NewHitlessCertRotator(ctx, o.key)
-	if err != nil {
-		cancel()
-		return nil, err
-	}
-
-	hubEndpoint, err := o.getHubConnectionInfo(cfg)
-	if err != nil {
-		cancel()
-		return nil, err
-	}
-
-	creds := auth.NewWalletAuthenticator(util.NewTLS(TLSConf), hubEndpoint.EthAddress)
-	grpcServer := xgrpc.NewServer(log.GetLogger(ctx),
-		xgrpc.Credentials(creds),
-		xgrpc.DefaultTraceInterceptor(),
-	)
-
-	if !platformSupportCGroups && cfg.HubResources() != nil {
-		log.G(ctx).Warn("your platform does not support CGroup, but the config has resources section")
-	}
-
-	if err := o.setupNetworkOptions(cfg); err != nil {
-		cancel()
-		return nil, errors.Wrap(err, "failed to set up network options")
-	}
-
-	log.G(o.ctx).Info("discovered public IPs",
-		zap.Any("public IPs", o.publicIPs),
-		zap.Any("nat", o.nat))
 
 	m = &Miner{
 		ctx:        ctx,


### PR DESCRIPTION
This PR defers an overseer creation to the end of Worker's init.
In that case, we don't need to call `cancel()` and `ovs.Close()` every time we met an error.