### PR TITLE
fix: BigInt serialization

### DIFF
--- a/cmd/cli/commands/printers.go
+++ b/cmd/cli/commands/printers.go
@@ -266,7 +266,7 @@ func printSearchResults(cmd *cobra.Command, orders []*pb.Order) {
 
 		for i, order := range orders {
 			cmd.Printf("%d) %s %s | price = %s\r\n", i+1,
-				order.OrderType.String(), order.GetId(), order.GetPricePerSecond())
+				order.OrderType.String(), order.GetId(), order.GetPricePerSecond().Unwrap().String())
 		}
 	} else {
 		showJSON(cmd, map[string]interface{}{"orders": orders})

--- a/cmd/cli/commands/printers_test.go
+++ b/cmd/cli/commands/printers_test.go
@@ -1,15 +1,15 @@
 package commands
 
 import (
+	"sort"
 	"testing"
 
-	"sort"
-
+	"github.com/sonm-io/core/cmd/cli/config"
 	pb "github.com/sonm-io/core/proto"
 	"github.com/stretchr/testify/assert"
 )
 
-func TestXXX(t *testing.T) {
+func TestOrdersSort(t *testing.T) {
 	in := &pb.GetProcessingReply{
 		Orders: map[string]*pb.GetProcessingReply_ProcessedOrder{
 			"ccc": {
@@ -43,4 +43,18 @@ func TestXXX(t *testing.T) {
 	assert.Equal(t, "ccc", ls[0].Id)
 	assert.Equal(t, "bbb", ls[1].Id)
 	assert.Equal(t, "aaa", ls[2].Id)
+}
+
+func TestJsonOutputForOrder(t *testing.T) {
+	buf := initRootCmd(t, config.OutputModeJSON)
+
+	bigVal, _ := pb.NewBigIntFromString("1000000000000000000000000000")
+	printSearchResults(rootCmd, []*pb.Order{{
+		PricePerSecond: bigVal,
+	},
+	})
+
+	out := buf.String()
+	assert.Equal(t, "{\"orders\":[{\"pricePerSecond\":\"1000000000000000000000000000\"}]}\r\n", out,
+		"price must be serialized as string, not `abs` and `neg` parts of pb.BigInt")
 }

--- a/proto/bigint.go
+++ b/proto/bigint.go
@@ -1,6 +1,7 @@
 package sonm
 
 import (
+	"encoding/json"
 	"fmt"
 	"math/big"
 )
@@ -43,4 +44,30 @@ func (m *BigInt) Unwrap() *big.Int {
 //  +1 if x >  y
 func (m *BigInt) Cmp(other *BigInt) int {
 	return m.Unwrap().Cmp(other.Unwrap())
+}
+
+func (m *BigInt) MarshalJSON() ([]byte, error) {
+	if m == nil {
+		return json.Marshal(nil)
+	}
+
+	return json.Marshal(m.Unwrap().String())
+}
+
+func (m *BigInt) UnmarshalJSON(data []byte) error {
+	var unmarshalled string
+	err := json.Unmarshal(data, &unmarshalled)
+	if err != nil {
+		return err
+	}
+
+	v, err := NewBigIntFromString(unmarshalled)
+	if err != nil {
+		return err
+	}
+
+	m.Abs = v.Abs
+	m.Neg = v.Neg
+
+	return nil
 }

--- a/proto/bigint_test.go
+++ b/proto/bigint_test.go
@@ -4,6 +4,8 @@ import (
 	"math/big"
 	"testing"
 
+	"encoding/json"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -26,4 +28,29 @@ func TestNewBigIntFromString(t *testing.T) {
 func TestBigIntString(t *testing.T) {
 	price := NewBigInt(big.NewInt(42000000002))
 	assert.Equal(t, "42000000002", price.Unwrap().String())
+}
+
+func TestBigIntUnmarshal(t *testing.T) {
+	in := []byte(`{"test": "100000000000000000000000"}`)
+	r := make(map[string]*BigInt)
+
+	err := json.Unmarshal(in, &r)
+	assert.NoError(t, err)
+	assert.Contains(t, r, "test")
+
+	intVal, _ := NewBigIntFromString("100000000000000000000000")
+	compare := r["test"].Cmp(intVal)
+	assert.Equal(t, compare, 0)
+}
+
+func TestBigIntMarshal(t *testing.T) {
+	intVal, _ := big.NewInt(0).SetString("100000000000000000000000", 10)
+	in := map[string]*BigInt{
+		"test": NewBigInt(intVal),
+	}
+
+	b, err := json.Marshal(&in)
+	assert.NoError(t, err)
+
+	assert.Equal(t, `{"test":"100000000000000000000000"}`, string(b))
 }


### PR DESCRIPTION
This PR adds (un)marshal methods for the `proto.BigInt` type, fixes marshaling issues for the `pb.Order`'s price into the CLI.

Closes DEV-366.