### PR TITLE
refactor: gpu tuner volumes

### DIFF
--- a/insonmnia/miner/config_test.go
+++ b/insonmnia/miner/config_test.go
@@ -75,8 +75,8 @@ plugins:
       ipfs: {}
 
   gpus:
-    nvidia: {}
     radeon: {}
+    nvidia: {}
 `
 	err := createTestConfigFile(raw)
 	assert.Nil(t, err)

--- a/insonmnia/miner/config_test.go
+++ b/insonmnia/miner/config_test.go
@@ -75,8 +75,8 @@ plugins:
       ipfs: {}
 
   gpus:
-    radeon: {}
     nvidia: {}
+    radeon: {}
 `
 	err := createTestConfigFile(raw)
 	assert.Nil(t, err)

--- a/insonmnia/miner/gpu/nvidia_tuner.go
+++ b/insonmnia/miner/gpu/nvidia_tuner.go
@@ -8,7 +8,6 @@ import (
 	"os"
 
 	"github.com/docker/docker/api/types/container"
-	"github.com/docker/docker/api/types/mount"
 	"github.com/docker/go-plugins-helpers/volume"
 	log "github.com/noxiouz/zapctx/ctxlog"
 	"github.com/sshaman1101/nvidia-docker/nvidia"
@@ -20,36 +19,7 @@ type nvidiaTuner struct {
 }
 
 func (g *nvidiaTuner) Tune(hostconfig *container.HostConfig) error {
-	hostconfig.Mounts = append(hostconfig.Mounts, mount.Mount{
-		Type:         mount.TypeVolume,
-		Source:       g.options.volumeName(),
-		Target:       "/usr/local/lib/nvidia",
-		ReadOnly:     true,
-		Consistency:  mount.ConsistencyDefault,
-		BindOptions:  nil,
-		TmpfsOptions: nil,
-		VolumeOptions: &mount.VolumeOptions{
-			NoCopy: false,
-			Labels: map[string]string{},
-			DriverConfig: &mount.Driver{
-				Name:    g.options.VolumeDriverName,
-				Options: map[string]string{},
-			},
-		},
-	})
-
-	if g.OpenCLVendorDir != "" {
-		hostconfig.Binds = append(hostconfig.Binds, g.OpenCLVendorDir+":"+g.OpenCLVendorDir+":ro")
-	}
-
-	for _, device := range g.devices {
-		hostconfig.Devices = append(hostconfig.Devices, container.DeviceMapping{
-			PathOnHost:        device,
-			PathInContainer:   device,
-			CgroupPermissions: "rwm",
-		})
-	}
-	return nil
+	return g.tune(hostconfig)
 }
 
 func (g *nvidiaTuner) Close() error {

--- a/insonmnia/miner/gpu/options.go
+++ b/insonmnia/miner/gpu/options.go
@@ -8,10 +8,12 @@ import (
 )
 
 const (
-	nvidiaVolumeDriver  = "nvidia-docker"
-	nvidiaDriverVersion = "300.0"
-	radeonVolumeDriver  = "radeon-docker"
-	radeonDriverVersion = "2482.3"
+	nvidiaVolumeDriver   = "nvidia-docker"
+	nvidiaDriverVersion  = "300.0"
+	nvidiaLibsMountPoint = "/usr/local/lib/nvidia"
+	radeonVolumeDriver   = "radeon-docker"
+	radeonDriverVersion  = "2482.3"
+	radeonLibsMountPoint = "/usr/local/lib/amdgpu"
 )
 
 // tunerOptions contains various options for embedded GPU tuners
@@ -20,6 +22,7 @@ type tunerOptions struct {
 	DriverVersion    string `mapstructure:"driver_version"`
 	VolumePath       string `mapstructure:"volume_path"`
 	SocketPath       string `mapstructure:"-"`
+	libsMountPoint   string `mapstructure:"-"`
 }
 
 type Option func(*tunerOptions)
@@ -41,6 +44,7 @@ func nvidiaDefaultOptions() *tunerOptions {
 	return &tunerOptions{
 		VolumeDriverName: nvidiaVolumeDriver,
 		DriverVersion:    nvidiaDriverVersion,
+		libsMountPoint:   nvidiaLibsMountPoint,
 		VolumePath:       fmt.Sprintf("/var/lib/%s/volumes", nvidiaVolumeDriver),
 		SocketPath:       fmt.Sprintf("/run/docker/plugins/%s.sock", nvidiaVolumeDriver),
 	}
@@ -50,6 +54,7 @@ func radeonDefaultOptions() *tunerOptions {
 	return &tunerOptions{
 		VolumeDriverName: radeonVolumeDriver,
 		DriverVersion:    radeonDriverVersion,
+		libsMountPoint:   radeonLibsMountPoint,
 		VolumePath:       fmt.Sprintf("/var/lib/%s/volumes", radeonVolumeDriver),
 		SocketPath:       fmt.Sprintf("/run/docker/plugins/%s.sock", radeonVolumeDriver),
 	}


### PR DESCRIPTION
Chained with #438

GPU tuners now use Docker volumes instead of binds to provide GPU-related stuff