### PR TITLE
refactor: minify amount of libs used for GPU Tuners

### DIFF
--- a/insonmnia/miner/gpu/interface.go
+++ b/insonmnia/miner/gpu/interface.go
@@ -24,7 +24,7 @@ type Tuner interface {
 func New(ctx context.Context, gpuType pb.GPUVendorType, opts ...Option) (Tuner, error) {
 	switch gpuType {
 	case pb.GPUVendorType_RADEON:
-		return newRadeonTuner(ctx, opts...)
+		return newRadeonTuner(opts...)
 	case pb.GPUVendorType_NVIDIA:
 		return newNvidiaTuner(ctx, opts...)
 	default:

--- a/insonmnia/miner/gpu/radeon_tuner.go
+++ b/insonmnia/miner/gpu/radeon_tuner.go
@@ -4,22 +4,17 @@ package gpu
 
 import (
 	"context"
-	"net"
 	"os"
 
 	"github.com/docker/docker/api/types/container"
-	"github.com/docker/go-plugins-helpers/volume"
-	log "github.com/noxiouz/zapctx/ctxlog"
 	"github.com/sonm-io/core/proto"
-	"github.com/sshaman1101/nvidia-docker/nvidia"
-	"go.uber.org/zap"
 )
 
 type radeonTuner struct {
 	volumePluginHandler
 }
 
-func newRadeonTuner(ctx context.Context, opts ...Option) (Tuner, error) {
+func newRadeonTuner(_ context.Context, opts ...Option) (Tuner, error) {
 	options := radeonDefaultOptions()
 	for _, f := range opts {
 		f(options)
@@ -33,63 +28,6 @@ func newRadeonTuner(ctx context.Context, opts ...Option) (Tuner, error) {
 	}
 
 	tun.devices = tun.getDevices()
-
-	if _, err := os.Stat(openCLVendorDir); err == nil {
-		tun.OpenCLVendorDir = openCLVendorDir
-	}
-
-	volInfo := []nvidia.VolumeInfo{
-		{
-			Name:         tun.options.VolumeDriverName,
-			Mountpoint:   "/opt/amdgpu-pro",
-			MountOptions: "ro",
-			Components: map[string][]string{
-				"libraries": {
-					"amdvlk64.so",
-					"libEGL.so",
-					"libGL.so",
-					"libGLESv2.so",
-					"libOpenCL.so",
-					"libamdocl12cl64.so",
-					"libamdocl64.so",
-					// vdpau
-					"libvdpau_amdgpu.so.1.0.0",
-					// dri
-					"radeonsi_drv_video.so",
-					// gbm
-					"gbm_amdgpu.so",
-
-					// by noxiouz from prev impl
-					"libMesaOpenCL.so",
-					"pipe_vmwgfx.so",
-					"pipe_r600.so",
-					"pipe_r300.so",
-					"pipe_radeonsi.so",
-					"pipe_swrast.so",
-					"pipe_nouveau.so",
-				},
-			},
-		},
-	}
-
-	log.G(ctx).Info("provisioning volumes", zap.String("at", tun.options.VolumePath))
-	volumes, err := nvidia.LookupVolumes(tun.options.VolumePath, tun.options.DriverVersion, volInfo)
-	if err != nil {
-		return nil, err
-	}
-
-	tun.handler = volume.NewHandler(NewPlugin(volumes))
-	tun.listener, err = net.Listen("unix", tun.options.SocketPath)
-	if err != nil {
-		log.G(ctx).Error("failed to create listening socket for to communicate with Docker as plugin",
-			zap.String("path", tun.options.SocketPath), zap.Error(err))
-		return nil, err
-	}
-
-	go func() {
-		tun.handler.Serve(tun.listener)
-	}()
-
 	return tun, nil
 }
 

--- a/insonmnia/miner/gpu/radeon_tuner.go
+++ b/insonmnia/miner/gpu/radeon_tuner.go
@@ -3,7 +3,6 @@
 package gpu
 
 import (
-	"context"
 	"os"
 
 	"github.com/docker/docker/api/types/container"
@@ -14,7 +13,7 @@ type radeonTuner struct {
 	volumePluginHandler
 }
 
-func newRadeonTuner(_ context.Context, opts ...Option) (Tuner, error) {
+func newRadeonTuner(opts ...Option) (Tuner, error) {
 	options := radeonDefaultOptions()
 	for _, f := range opts {
 		f(options)

--- a/insonmnia/miner/gpu/tuner_other.go
+++ b/insonmnia/miner/gpu/tuner_other.go
@@ -8,7 +8,7 @@ import (
 
 // override all Tuner implementation with NilTuner if we building without GPU support
 
-func newRadeonTuner(_ context.Context, opts ...Option) (Tuner, error) {
+func newRadeonTuner(opts ...Option) (Tuner, error) {
 	return NilTuner{}, nil
 }
 


### PR DESCRIPTION
This PR remove lots of GPU-related libraries collected on host, leaves an only minimal amount of libs required to set-up tasks executed on the graphics card.

NVidia:
- `libnvidia-ml.so` is required;
- leaving `nvidia-smi` as useful diagnostic tool;

Radeon:
- collecting libs on the host is not required at all, only the `/dev/dri` and `/dev/kfd` is required to be mounted into the container;