### PR TITLE
fix: set leaderID to self if failover is disabled

### DIFF
--- a/insonmnia/hub/cluster.go
+++ b/insonmnia/hub/cluster.go
@@ -172,6 +172,7 @@ func (c *cluster) Run() error {
 		w.Go(c.hubGC)
 	} else {
 		log.G(c.ctx).Info("running in dev single-server mode")
+		c.leaderId = c.id
 	}
 
 	w.Go(c.watchEvents)

--- a/insonmnia/hub/server.go
+++ b/insonmnia/hub/server.go
@@ -1824,7 +1824,6 @@ func (h *Hub) startLocatorAnnouncer() error {
 }
 
 func (h *Hub) announceAddress() error {
-	// TODO: is it really wrong to announce from several nodes simultaneously?
 	if !h.cluster.IsLeader() {
 		return nil
 	}


### PR DESCRIPTION
With `failover` disabled, hub failed to announce client endpoints because `leaderID` was not set. This PR sets `leaderID` to current node ID when `failover` is disabled.