### PR TITLE
fix: duplicate runCluster

### DIFF
--- a/insonmnia/hub/cluster.go
+++ b/insonmnia/hub/cluster.go
@@ -111,6 +111,8 @@ func NewCluster(ctx context.Context, cfg *ClusterConfig, workerEndpoint string,
 
 	if cfg.Failover {
 		c.isLeader = false
+	} else {
+		c.leaderId = c.id
 	}
 
 	c.ctx, c.cancel = context.WithCancel(c.parentCtx)
@@ -172,7 +174,6 @@ func (c *cluster) Run() error {
 		w.Go(c.hubGC)
 	} else {
 		log.G(c.ctx).Info("running in dev single-server mode")
-		c.leaderId = c.id
 	}
 
 	w.Go(c.watchEvents)

--- a/insonmnia/hub/server.go
+++ b/insonmnia/hub/server.go
@@ -1426,10 +1426,9 @@ func (h *Hub) Serve() error {
 
 	h.waiter.Go(h.runCluster)
 	h.waiter.Go(h.listenClusterEvents)
-	h.waiter.Go(h.startLocatorAnnouncer)
 	h.waiter.Go(h.runAcceptedDealsWatcher)
-	h.waiter.Go(h.runCluster)
 	h.waiter.Go(h.watchDealsClosed)
+	h.waiter.Go(h.startLocatorAnnouncer)
 	h.waiter.Go(func() error {
 		return h.orderShelter.Run(h.ctx)
 	})


### PR DESCRIPTION
For some reason (possibly a broken merge) `runCluster()` is called twice.