### PR TITLE
fix: properly handle PLATFORM_NOT_FOUND error from OpenCL

### DIFF
--- a/insonmnia/hardware/gpu/cl.go
+++ b/insonmnia/hardware/gpu/cl.go
@@ -25,8 +25,9 @@ import (
 )
 
 const (
-	maxPlatforms   = 32
-	maxDeviceCount = 64
+	maxPlatforms              = 32
+	maxDeviceCount            = 64
+	CL_PLATFORM_NOT_FOUND_KHR = C.cl_int(-1001)
 )
 
 // GetGPUDevicesUsingOpenCL returns a list of available GPU devices on the machine using OpenCL API.
@@ -95,6 +96,10 @@ func getPlatforms() ([]*platform, error) {
 	var num C.cl_uint
 
 	if err := C.clGetPlatformIDs(C.cl_uint(maxPlatforms), &ids[0], &num); err != C.CL_SUCCESS {
+		if err == CL_PLATFORM_NOT_FOUND_KHR {
+			return []*platform{}, nil
+		}
+
 		return nil, fmt.Errorf("failed to obtain OpenCL platforms: %s", errorToString(err))
 	}
 
@@ -287,6 +292,8 @@ func errorToString(err C.cl_int) string {
 		return "invalid buffer size"
 	case C.CL_INVALID_MIP_LEVEL:
 		return "invalid mip-map level"
+	case CL_PLATFORM_NOT_FOUND_KHR:
+		return "no valid ICDs found"
 	default:
 		return "unknown OpenCL error: " + strconv.FormatInt(int64(err), 10)
 	}


### PR DESCRIPTION
changed:
- Checked that `getPlatforms` return code -1001, handling it as non-error case and return empty GPUs for the machine;
- Note: constant is hardcoded because of error -1001 returns from the plugins, [not OpenCL itself](https://streamhpc.com/blog/2013-04-28/opencl-error-codes/).