### PR TITLE
fix: show price as SNM-ordered value, not as Wei-ordered

### DIFF
--- a/proto/bigint.go
+++ b/proto/bigint.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"math/big"
+
+	"github.com/ethereum/go-ethereum/params"
 )
 
 // NewBigInt constructs a new value using specified big.Int.
@@ -66,4 +68,12 @@ func (m *BigInt) UnmarshalJSON(data []byte) error {
 	m.Neg = v.Neg
 
 	return nil
+}
+
+func (m *BigInt) ToPriceString() string {
+	v := big.NewFloat(0).SetInt(m.Unwrap())
+	div := big.NewFloat(params.Ether)
+
+	r := big.NewFloat(0).Quo(v, div)
+	return r.Text('f', -18)
 }

--- a/proto/bigint_test.go
+++ b/proto/bigint_test.go
@@ -2,6 +2,7 @@ package sonm
 
 import (
 	"encoding/json"
+	"fmt"
 	"math/big"
 	"testing"
 
@@ -81,4 +82,30 @@ func TestBigInt_MarshalEmptyValue(t *testing.T) {
 	b, err := json.Marshal(&in)
 	assert.NoError(t, err)
 	assert.Equal(t, `{"value":"0"}`, string(b))
+}
+
+func TestBigInt_ToPriceString(t *testing.T) {
+	tests := []struct {
+		in  float64
+		out string
+	}{
+		{in: 1e18, out: "1"},
+		{in: 1e15, out: "0.001"},
+		{in: 1e20, out: "100"},
+		{in: 1.2e18, out: "1.2"},
+		{in: 1.3333333e18, out: "1.3333333"},
+		{in: 1e12, out: "0.000001"},
+		{in: 1e10, out: "0.00000001"},
+		{in: 1e7, out: "0.00000000001"},
+		{in: 1e4, out: "0.00000000000001"},
+		{in: 1, out: "0.000000000000000001"},
+		{in: 1234, out: "0.000000000000001234"},
+	}
+
+	for _, tt := range tests {
+		bint, _ := big.NewFloat(tt.in).Int(nil)
+		v := NewBigInt(bint)
+		out := v.ToPriceString()
+		assert.Equal(t, tt.out, out, fmt.Sprintf("expect %v == %s SNM (result is \"%s\")", tt.in, tt.out, out))
+	}
 }


### PR DESCRIPTION
added:
- Bigint.ToPriceString() method to convent Wei-ordered to Ether-ordered values

changed:
- update deal info printer, now it shows price per second and deal duration