### PR TITLE
fix: add libcuda to the NVidia drivers volume

### DIFF
--- a/insonmnia/miner/gpu/nvidia_tuner.go
+++ b/insonmnia/miner/gpu/nvidia_tuner.go
@@ -90,7 +90,10 @@ func newNvidiaTuner(ctx context.Context, opts ...Option) (Tuner, error) {
 					"nvidia-smi", // System management interface
 				},
 				"libraries": {
-					"libnvidia-ml.so", // Management library
+					"libnvidia-ml.so",              // Management library
+					"libcuda.so",                   // CUDA driver library
+					"libnvidia-ptxjitcompiler.so",  // PTX-SASS JIT compiler (used by libcuda)
+					"libnvidia-fatbinaryloader.so", // fatbin loader (used by libcuda)
 				},
 			},
 		},


### PR DESCRIPTION
libcuda.so is coming from NVidia drivers, not with CUDA runtime installer,
so we need to add it to the container