### PR TITLE
FIX added path for cli.yaml file

### DIFF
--- a/debian/sonm-cli.install
+++ b/debian/sonm-cli.install
@@ -1,1 +1,2 @@
 sonmcli usr/bin
+~/.sonm/cli-default.yaml


### PR DESCRIPTION
When installing from repo the cli.yaml file does not find it's place I added this quick fix that hopefully solved the issue.