### PR TITLE
fix: zero division if deal duration is zero

### DIFF
--- a/cmd/cli/commands/printers.go
+++ b/cmd/cli/commands/printers.go
@@ -392,13 +392,16 @@ func printDealsList(cmd *cobra.Command, deals []*pb.Deal) {
 
 func printDealInfo(cmd *cobra.Command, deal *pb.Deal) {
 	if isSimpleFormat() {
-		start := time.Unix(deal.GetStartTime().GetSeconds(), int64(deal.GetStartTime().GetNanos()))
-		end := time.Unix(deal.GetEndTime().GetSeconds(), int64(deal.GetEndTime().GetNanos()))
+		start := deal.StartTime.Unix()
+		end := deal.EndTime.Unix()
 
+		ppsBig := pb.NewBigInt(nil)
 		dealDuration := end.Sub(start)
-		durationBig := big.NewInt(int64(dealDuration.Seconds()))
-		pps := big.NewInt(0).Div(deal.GetPrice().Unwrap(), durationBig)
-		ppsBig := pb.NewBigInt(pps)
+		if dealDuration > 0 {
+			durationBig := big.NewInt(int64(dealDuration.Seconds()))
+			pps := big.NewInt(0).Div(deal.GetPrice().Unwrap(), durationBig)
+			ppsBig = pb.NewBigInt(pps)
+		}
 
 		cmd.Printf("ID:       %s\r\n", deal.GetId())
 		cmd.Printf("Status:   %s\r\n", deal.GetStatus())

--- a/cmd/cli/commands/printers_test.go
+++ b/cmd/cli/commands/printers_test.go
@@ -58,3 +58,21 @@ func TestJsonOutputForOrder(t *testing.T) {
 	assert.Equal(t, "{\"orders\":[{\"pricePerSecond\":\"1000000000000000000000000000\"}]}\r\n", out,
 		"price must be serialized as string, not `abs` and `neg` parts of pb.BigInt")
 }
+
+func TestDealInfoWithZeroDuration(t *testing.T) {
+	deal := &pb.Deal{
+		WorkTime:   606060,
+		Status:     pb.DealStatus_CLOSED,
+		Id:         "1488",
+		BuyerID:    "0x111",
+		SupplierID: "0x222",
+		Price:      pb.NewBigIntFromInt(1e18),
+		StartTime:  &pb.Timestamp{Seconds: 0},
+		EndTime:    &pb.Timestamp{Seconds: 0},
+	}
+
+	buf := initRootCmd(t, "", config.OutputModeSimple)
+	printDealInfo(rootCmd, deal)
+
+	assert.Contains(t, buf.String(), "Duraton:  0s")
+}

--- a/proto/bigint.go
+++ b/proto/bigint.go
@@ -10,6 +10,10 @@ import (
 
 // NewBigInt constructs a new value using specified big.Int.
 func NewBigInt(v *big.Int) *BigInt {
+	if v == nil {
+		v = big.NewInt(0)
+	}
+
 	return &BigInt{
 		Neg: v.Sign() < 0,
 		Abs: v.Bytes(),

--- a/proto/timestamp.go
+++ b/proto/timestamp.go
@@ -5,5 +5,5 @@ import "time"
 // Unix returns the local time.Time corresponding to the given Unix time
 // since January 1, 1970 UTC.
 func (m Timestamp) Unix() time.Time {
-	return time.Unix(m.Seconds, int64(m.Nanos))
+	return time.Unix(m.Seconds, int64(m.Nanos)).In(time.UTC)
 }


### PR DESCRIPTION
changed:
- check deal duration before price calculation
- typecast proto's Timestamp to time.Time with UTC, not local timezone