### PR TITLE
[WIP] feat: allow cli generate and save certs for eth key

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,8 @@ sonmlocator
 sonmnode
 .idea/
 
+sonm.crt
+sonm.key
 
 fusrodah/examples/bootnode/main
 fusrodah/examples/fusrodah/main

--- a/cmd/cli/commands/cert.go
+++ b/cmd/cli/commands/cert.go
@@ -1,0 +1,48 @@
+package commands
+
+import (
+	"io/ioutil"
+	"os"
+	"time"
+
+	"github.com/sonm-io/core/util"
+	"github.com/spf13/cobra"
+)
+
+var (
+	certCertOutput string
+	certKeyOutput  string
+)
+
+func init() {
+	makeCertCmd.PersistentFlags().StringVar(&certCertOutput, "cert", "sonm.crt", "file to save certificate")
+	makeCertCmd.PersistentFlags().StringVar(&certKeyOutput, "key", "sonm.key", "file to save key")
+}
+
+var makeCertCmd = &cobra.Command{
+	Use:    "make-cert",
+	Short:  "Make TLS certificate for gRPC based on Eth key",
+	PreRun: loadKeyStoreWrapper,
+	Run: func(cmd *cobra.Command, args []string) {
+		cert, key, err := util.GenerateCert(sessionKey, time.Duration(time.Hour))
+		if err != nil {
+			showError(cmd, "cannot generate cert", err)
+			os.Exit(1)
+		}
+
+		keyFile := cmd.Flag("key").Value.String()
+		certFile := cmd.Flag("cert").Value.String()
+
+		err = ioutil.WriteFile(certFile, cert, 0600)
+		if err != nil {
+			showError(cmd, "cannot write cert file", err)
+			os.Exit(1)
+		}
+
+		err = ioutil.WriteFile(keyFile, key, 0600)
+		if err != nil {
+			showError(cmd, "cannot write key file", err)
+			os.Exit(1)
+		}
+	},
+}

--- a/cmd/cli/commands/common.go
+++ b/cmd/cli/commands/common.go
@@ -58,7 +58,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&outputModeFlag, "out", "", "Output mode: simple or json")
 
 	rootCmd.AddCommand(hubRootCmd, marketRootCmd, nodeDealsRootCmd, taskRootCmd)
-	rootCmd.AddCommand(loginCmd, approveTokenCmd, getTokenCmd, versionCmd, autoCompleteCmd)
+	rootCmd.AddCommand(loginCmd, approveTokenCmd, getTokenCmd, versionCmd, autoCompleteCmd, makeCertCmd)
 }
 
 // Root configure and return root command


### PR DESCRIPTION
added:
- `make-cert` cli command to export ethereum-based certificate as cert and key files.