### PR TITLE
feat: represent logging level as string

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -114,7 +114,8 @@ mock:
 	echo "\`go get github.com/golang/mock/mockgen\`"; \
 	echo "and add your go bin directory to PATH"; exit 1; fi;
 	mockgen -package miner -destination insonmnia/miner/overseer_mock.go -source insonmnia/miner/overseer.go
-	mockgen -package miner -destination insonmnia/miner/config_mock.go -source insonmnia/miner/config.go
+	mockgen -package miner -destination insonmnia/miner/config_mock.go -source insonmnia/miner/config.go \
+		-aux_files logging=insonmnia/logging/logging.go
 	mockgen -package hardware -destination insonmnia/hardware/hardware_mock.go -source insonmnia/hardware/hardware.go
 	mockgen -package commands -destination cmd/cli/commands/interactor_mock.go  -source cmd/cli/commands/interactor.go
 	mockgen -package task_config -destination cmd/cli/task_config/config_mock.go  -source cmd/cli/task_config/config.go
@@ -124,9 +125,9 @@ mock:
 	mockgen -package sonm -destination proto/marketplace_mock.go  -source proto/marketplace.pb.go
 	mockgen -package hub -destination insonmnia/hub/cluster_mock.go  -source insonmnia/hub/cluster.go
 	mockgen -package config -destination cmd/cli/config/config_mock.go  -source cmd/cli/config/config.go \
-		-aux_files accounts=accounts/keys.go
+		-aux_files accounts=accounts/keys.go,logging=insonmnia/logging/logging.go
 	mockgen -package node -destination insonmnia/node/config_mock.go -source insonmnia/node/config.go \
-		-aux_files accounts=accounts/keys.go
+		-aux_files accounts=accounts/keys.go,logging=insonmnia/logging/logging.go
 	mockgen -imports "context=golang.org/x/net/context" -package node -destination insonmnia/node/hub_mock.go \
 		"github.com/sonm-io/core/proto" HubClient && ${SED}
 

--- a/cmd/hub/main.go
+++ b/cmd/hub/main.go
@@ -34,7 +34,7 @@ func run() {
 		os.Exit(1)
 	}
 
-	logger := logging.BuildLogger(cfg.Logging.Level, true)
+	logger := logging.BuildLogger(cfg.LogLevel())
 	ctx = log.WithLogger(ctx, logger)
 
 	key, err := cfg.Eth.LoadKey()

--- a/cmd/hub/main.go
+++ b/cmd/hub/main.go
@@ -34,7 +34,13 @@ func run() {
 		os.Exit(1)
 	}
 
-	logger := logging.BuildLogger(cfg.LogLevel())
+	logLevel, err := cfg.LogLevel()
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+
+	logger := logging.BuildLogger(logLevel)
 	ctx = log.WithLogger(ctx, logger)
 
 	key, err := cfg.Eth.LoadKey()

--- a/cmd/hub/main.go
+++ b/cmd/hub/main.go
@@ -34,13 +34,7 @@ func run() {
 		os.Exit(1)
 	}
 
-	logLevel, err := cfg.LogLevel()
-	if err != nil {
-		fmt.Println(err)
-		os.Exit(1)
-	}
-
-	logger := logging.BuildLogger(logLevel)
+	logger := logging.BuildLogger(cfg.LogLevel())
 	ctx = log.WithLogger(ctx, logger)
 
 	key, err := cfg.Eth.LoadKey()

--- a/cmd/locator/main.go
+++ b/cmd/locator/main.go
@@ -10,6 +10,7 @@ import (
 	"github.com/sonm-io/core/insonmnia/logging"
 	"github.com/sonm-io/core/util"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 )
 
 var (
@@ -23,7 +24,7 @@ func main() {
 }
 
 func run() {
-	logger := logging.BuildLogger(-1, true)
+	logger := logging.BuildLogger(zapcore.DebugLevel)
 	ctx := log.WithLogger(context.Background(), logger)
 
 	cfg, err := locator.NewConfig(configFlag)

--- a/cmd/miner/main.go
+++ b/cmd/miner/main.go
@@ -34,7 +34,7 @@ func run() {
 		os.Exit(1)
 	}
 
-	logger := logging.BuildLogger(cfg.Logging().Level, true)
+	logger := logging.BuildLogger(cfg.LogLevel())
 	ctx := log.WithLogger(context.Background(), logger)
 
 	key, err := cfg.ETH().LoadKey()

--- a/cmd/miner/main.go
+++ b/cmd/miner/main.go
@@ -34,13 +34,7 @@ func run() {
 		os.Exit(1)
 	}
 
-	logLevel, err := cfg.LogLevel()
-	if err != nil {
-		fmt.Println(err)
-		os.Exit(1)
-	}
-
-	logger := logging.BuildLogger(logLevel)
+	logger := logging.BuildLogger(cfg.LogLevel())
 	ctx := log.WithLogger(context.Background(), logger)
 
 	key, err := cfg.ETH().LoadKey()

--- a/cmd/miner/main.go
+++ b/cmd/miner/main.go
@@ -34,7 +34,13 @@ func run() {
 		os.Exit(1)
 	}
 
-	logger := logging.BuildLogger(cfg.LogLevel())
+	logLevel, err := cfg.LogLevel()
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+
+	logger := logging.BuildLogger(logLevel)
 	ctx := log.WithLogger(context.Background(), logger)
 
 	key, err := cfg.ETH().LoadKey()

--- a/cmd/node/main.go
+++ b/cmd/node/main.go
@@ -32,7 +32,7 @@ func run() {
 		os.Exit(1)
 	}
 
-	logger := logging.BuildLogger(cfg.LogLevel(), true)
+	logger := logging.BuildLogger(cfg.LogLevel())
 	ctx := log.WithLogger(context.Background(), logger)
 
 	key, err := loadKeys(cfg)

--- a/cmd/node/main.go
+++ b/cmd/node/main.go
@@ -32,7 +32,13 @@ func run() {
 		os.Exit(1)
 	}
 
-	logger := logging.BuildLogger(cfg.LogLevel())
+	logLevel, err := cfg.LogLevel()
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+
+	logger := logging.BuildLogger(logLevel)
 	ctx := log.WithLogger(context.Background(), logger)
 
 	key, err := loadKeys(cfg)

--- a/cmd/node/main.go
+++ b/cmd/node/main.go
@@ -32,13 +32,7 @@ func run() {
 		os.Exit(1)
 	}
 
-	logLevel, err := cfg.LogLevel()
-	if err != nil {
-		fmt.Println(err)
-		os.Exit(1)
-	}
-
-	logger := logging.BuildLogger(logLevel)
+	logger := logging.BuildLogger(cfg.LogLevel())
 	ctx := log.WithLogger(context.Background(), logger)
 
 	key, err := loadKeys(cfg)

--- a/hub.yaml
+++ b/hub.yaml
@@ -56,8 +56,8 @@ cluster:
 # Logging settings.
 logging:
   # The desired logging level.
-  # Allowed values in range of -1 (high verbosity) to 3 (most quiet)
-  level: -1
+  # Allowed values is "debug", "info", "warn", "error", "panic" and "fatal"
+  level: debug
 
 # blockchain-specific settings.
 ethereum:

--- a/hub.yaml
+++ b/hub.yaml
@@ -56,7 +56,7 @@ cluster:
 # Logging settings.
 logging:
   # The desired logging level.
-  # Allowed values is "debug", "info", "warn", "error", "panic" and "fatal"
+  # Allowed values are "debug", "info", "warn", "error", "panic" and "fatal"
   level: debug
 
 # blockchain-specific settings.

--- a/insonmnia/hub/config.go
+++ b/insonmnia/hub/config.go
@@ -11,7 +11,8 @@ import (
 )
 
 type LoggingConfig struct {
-	Level string `required:"true" default:"debug"`
+	Level       string `required:"true" default:"debug"`
+	parsedLevel zapcore.Level
 }
 
 type GatewayConfig struct {
@@ -69,8 +70,8 @@ type Config struct {
 	MetricsListenAddr string             `yaml:"metrics_listen_addr" default:"127.0.0.1:14000"`
 }
 
-func (c *Config) LogLevel() (zapcore.Level, error) {
-	return logging.ParseLogLevel(c.Logging.Level)
+func (c *Config) LogLevel() zapcore.Level {
+	return c.Logging.parsedLevel
 }
 
 // NewConfig loads a hub config from the specified YAML file.
@@ -80,6 +81,13 @@ func NewConfig(path string) (*Config, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	lvl, err := logging.ParseLogLevel(conf.Logging.Level)
+	if err != nil {
+		return nil, err
+	}
+	conf.Logging.parsedLevel = lvl
+
 	return conf, nil
 }
 

--- a/insonmnia/hub/config.go
+++ b/insonmnia/hub/config.go
@@ -69,7 +69,7 @@ type Config struct {
 	MetricsListenAddr string             `yaml:"metrics_listen_addr" default:"127.0.0.1:14000"`
 }
 
-func (c *Config) LogLevel() zapcore.Level {
+func (c *Config) LogLevel() (zapcore.Level, error) {
 	return logging.ParseLogLevel(c.Logging.Level)
 }
 

--- a/insonmnia/hub/config.go
+++ b/insonmnia/hub/config.go
@@ -6,10 +6,12 @@ import (
 
 	"github.com/jinzhu/configor"
 	"github.com/sonm-io/core/accounts"
+	"github.com/sonm-io/core/insonmnia/logging"
+	"go.uber.org/zap/zapcore"
 )
 
 type LoggingConfig struct {
-	Level int `required:"true" default:"1"`
+	Level string `required:"true" default:"debug"`
 }
 
 type GatewayConfig struct {
@@ -65,6 +67,10 @@ type Config struct {
 	Cluster           ClusterConfig      `yaml:"cluster"`
 	Whitelist         WhitelistConfig    `yaml:"whitelist"`
 	MetricsListenAddr string             `yaml:"metrics_listen_addr" default:"127.0.0.1:14000"`
+}
+
+func (c *Config) LogLevel() zapcore.Level {
+	return logging.ParseLogLevel(c.Logging.Level)
 }
 
 // NewConfig loads a hub config from the specified YAML file.

--- a/insonmnia/hub/config_test.go
+++ b/insonmnia/hub/config_test.go
@@ -86,7 +86,10 @@ market:
 	conf, err := NewConfig(testHubConfigPath)
 	assert.Nil(t, err)
 
-	assert.Equal(t, zapcore.InfoLevel, conf.LogLevel())
+	lvl, err := conf.LogLevel()
+	assert.NoError(t, err)
+
+	assert.Equal(t, zapcore.InfoLevel, lvl)
 }
 
 func TestLoadConfigLoggerDefault(t *testing.T) {
@@ -108,7 +111,10 @@ market:
 	conf, err := NewConfig(testHubConfigPath)
 	assert.Nil(t, err)
 
-	assert.Equal(t, zapcore.DebugLevel, conf.LogLevel())
+	lvl, err := conf.LogLevel()
+	assert.NoError(t, err)
+
+	assert.Equal(t, zapcore.DebugLevel, lvl)
 }
 
 func TestLoadConfigWithoutLocator(t *testing.T) {

--- a/insonmnia/hub/config_test.go
+++ b/insonmnia/hub/config_test.go
@@ -86,13 +86,10 @@ market:
 	conf, err := NewConfig(testHubConfigPath)
 	assert.Nil(t, err)
 
-	lvl, err := conf.LogLevel()
-	assert.NoError(t, err)
-
-	assert.Equal(t, zapcore.InfoLevel, lvl)
+	assert.Equal(t, zapcore.InfoLevel, conf.LogLevel())
 }
 
-func TestLoadConfigLoggerDefault(t *testing.T) {
+func TestLoadConfigInvalidLogLevel(t *testing.T) {
 	defer deleteTestConfigFile()
 	raw := `
 ethereum:
@@ -103,18 +100,16 @@ monitoring:
 locator:
   endpoint: "127.0.0.1:9090"
 market:
-  endpoint: "127.0.0.1:9095"`
+  endpoint: "127.0.0.1:9095"
+logging:
+  level: wtf
+`
 
 	err := createTestConfigFile(raw)
 	assert.Nil(t, err)
 
-	conf, err := NewConfig(testHubConfigPath)
-	assert.Nil(t, err)
-
-	lvl, err := conf.LogLevel()
-	assert.NoError(t, err)
-
-	assert.Equal(t, zapcore.DebugLevel, lvl)
+	_, err = NewConfig(testHubConfigPath)
+	assert.Error(t, err)
 }
 
 func TestLoadConfigWithoutLocator(t *testing.T) {

--- a/insonmnia/hub/config_test.go
+++ b/insonmnia/hub/config_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap/zapcore"
 )
 
 const (
@@ -32,7 +33,10 @@ cluster:
 locator:
   endpoint: "127.0.0.1:9090"
 market:
-  endpoint: "127.0.0.1:9095"`
+  endpoint: "127.0.0.1:9095"
+logging:
+  level: info
+`
 
 	err := createTestConfigFile(raw)
 	assert.Nil(t, err)
@@ -70,7 +74,7 @@ endpoint: ":10002"
 monitoring:
   endpoint: ":10001"
 logging:
-  level: -1
+  level: info
 locator:
   endpoint: "127.0.0.1:9090"
 market:
@@ -82,7 +86,7 @@ market:
 	conf, err := NewConfig(testHubConfigPath)
 	assert.Nil(t, err)
 
-	assert.Equal(t, -1, conf.Logging.Level)
+	assert.Equal(t, zapcore.InfoLevel, conf.LogLevel())
 }
 
 func TestLoadConfigLoggerDefault(t *testing.T) {
@@ -104,7 +108,7 @@ market:
 	conf, err := NewConfig(testHubConfigPath)
 	assert.Nil(t, err)
 
-	assert.Equal(t, 1, conf.Logging.Level)
+	assert.Equal(t, zapcore.DebugLevel, conf.LogLevel())
 }
 
 func TestLoadConfigWithoutLocator(t *testing.T) {

--- a/insonmnia/logging/logging.go
+++ b/insonmnia/logging/logging.go
@@ -3,6 +3,8 @@ package logging
 import (
 	"strings"
 
+	"fmt"
+
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 )
@@ -29,18 +31,18 @@ func BuildLogger(level zapcore.Level) *zap.Logger {
 
 type Leveler interface {
 	// LogLevel return log verbosity
-	LogLevel() zapcore.Level
+	LogLevel() (zapcore.Level, error)
 }
 
 // ParseLogLevel returns zap logger level by it's name
-func ParseLogLevel(s string) zapcore.Level {
+func ParseLogLevel(s string) (zapcore.Level, error) {
 	s = strings.ToLower(s)
 
 	var lvl = zapcore.DebugLevel
 	err := lvl.Set(s)
 	if err != nil {
-		return zapcore.DebugLevel
+		return zapcore.DebugLevel, fmt.Errorf("cannot parse config file: \"%s\" is invalid log level", s)
 	}
 
-	return lvl
+	return lvl, nil
 }

--- a/insonmnia/logging/logging.go
+++ b/insonmnia/logging/logging.go
@@ -1,6 +1,8 @@
 package logging
 
 import (
+	"strings"
+
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 )
@@ -10,27 +12,35 @@ var (
 )
 
 // BuildLogger return new zap.Logger instance with given severity and debug settings
-func BuildLogger(level int, development bool) *zap.Logger {
-	var encoding string
-	var encodingConfig zapcore.EncoderConfig
-	if development {
-		encoding = "console"
-		encodingConfig = zap.NewDevelopmentEncoderConfig()
-	} else {
-		encoding = "json"
-		encodingConfig = zap.NewProductionEncoderConfig()
-	}
-
-	atom.SetLevel(zapcore.Level(level))
+func BuildLogger(level zapcore.Level) *zap.Logger {
+	atom.SetLevel(level)
 	loggerConfig := zap.Config{
-		Development:      development,
+		Development:      false,
 		Level:            atom,
 		OutputPaths:      []string{"stdout"},
 		ErrorOutputPaths: []string{"stderr"},
-		Encoding:         encoding,
-		EncoderConfig:    encodingConfig,
+		Encoding:         "console",
+		EncoderConfig:    zap.NewDevelopmentEncoderConfig(),
 	}
 
 	log, _ := loggerConfig.Build()
 	return log
+}
+
+type Leveler interface {
+	// LogLevel return log verbosity
+	LogLevel() zapcore.Level
+}
+
+// ParseLogLevel returns zap logger level by it's name
+func ParseLogLevel(s string) zapcore.Level {
+	s = strings.ToLower(s)
+
+	var lvl = zapcore.DebugLevel
+	err := lvl.Set(s)
+	if err != nil {
+		return zapcore.DebugLevel
+	}
+
+	return lvl
 }

--- a/insonmnia/logging/logging.go
+++ b/insonmnia/logging/logging.go
@@ -31,7 +31,7 @@ func BuildLogger(level zapcore.Level) *zap.Logger {
 
 type Leveler interface {
 	// LogLevel return log verbosity
-	LogLevel() (zapcore.Level, error)
+	LogLevel() zapcore.Level
 }
 
 // ParseLogLevel returns zap logger level by it's name

--- a/insonmnia/logging/logging_test.go
+++ b/insonmnia/logging/logging_test.go
@@ -1,0 +1,28 @@
+package logging
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap/zapcore"
+)
+
+func TestParseLogLevel(t *testing.T) {
+	tests := []struct {
+		in  string
+		out zapcore.Level
+	}{
+		// any case must be parsed
+		{in: "warn", out: zapcore.WarnLevel},
+		{in: "Warn", out: zapcore.WarnLevel},
+		{in: "WARN", out: zapcore.WarnLevel},
+		// any other values must be represented as default debug level
+		{in: "-1", out: zapcore.DebugLevel},
+		{in: "666", out: zapcore.DebugLevel},
+	}
+
+	for _, tt := range tests {
+		out := ParseLogLevel(tt.in)
+		assert.Equal(t, tt.out, out)
+	}
+}

--- a/insonmnia/logging/logging_test.go
+++ b/insonmnia/logging/logging_test.go
@@ -9,20 +9,27 @@ import (
 
 func TestParseLogLevel(t *testing.T) {
 	tests := []struct {
-		in  string
-		out zapcore.Level
+		in       string
+		out      zapcore.Level
+		mustFail bool
 	}{
 		// any case must be parsed
 		{in: "warn", out: zapcore.WarnLevel},
 		{in: "Warn", out: zapcore.WarnLevel},
 		{in: "WARN", out: zapcore.WarnLevel},
 		// any other values must be represented as default debug level
-		{in: "-1", out: zapcore.DebugLevel},
-		{in: "666", out: zapcore.DebugLevel},
+		{in: "-1", mustFail: true},
+		{in: "5", mustFail: true},
+		{in: "666", mustFail: true},
 	}
 
 	for _, tt := range tests {
-		out := ParseLogLevel(tt.in)
-		assert.Equal(t, tt.out, out)
+		out, err := ParseLogLevel(tt.in)
+		if tt.mustFail {
+			assert.Error(t, err)
+		} else {
+			assert.NoError(t, err)
+			assert.Equal(t, tt.out, out)
+		}
 	}
 }

--- a/insonmnia/miner/cgroup_test.go
+++ b/insonmnia/miner/cgroup_test.go
@@ -24,6 +24,8 @@ hub:
         cpus: "ddd"
 locator:
   endpoint: "8125721C2413d99a33E351e1F6Bb4e56b6b633FD@127.0.0.1:9090"
+logging:
+  level: debug
 `
 	err := createTestConfigFile(raw)
 	assertions.NoError(err)

--- a/insonmnia/miner/config.go
+++ b/insonmnia/miner/config.go
@@ -30,7 +30,8 @@ type SSHConfig struct {
 }
 
 type LoggingConfig struct {
-	Level string `required:"true" default:"debug"`
+	Level       string `required:"true" default:"debug"`
+	parsedLevel zapcore.Level
 }
 
 type ResourcesConfig struct {
@@ -55,8 +56,8 @@ type config struct {
 	PluginsConfig           plugin.Config       `yaml:"plugins"`
 }
 
-func (c *config) LogLevel() (zapcore.Level, error) {
-	return logging.ParseLogLevel(c.LoggingConfig.Level)
+func (c *config) LogLevel() zapcore.Level {
+	return c.LoggingConfig.parsedLevel
 }
 
 func (c *config) HubResolveEndpoints() bool {
@@ -137,6 +138,12 @@ func NewConfig(path string) (Config, error) {
 	if err := cfg.validate(); err != nil {
 		return nil, err
 	}
+
+	lvl, err := logging.ParseLogLevel(cfg.LoggingConfig.Level)
+	if err != nil {
+		return nil, err
+	}
+	cfg.LoggingConfig.parsedLevel = lvl
 
 	return cfg, nil
 }

--- a/insonmnia/miner/config.go
+++ b/insonmnia/miner/config.go
@@ -55,7 +55,7 @@ type config struct {
 	PluginsConfig           plugin.Config       `yaml:"plugins"`
 }
 
-func (c *config) LogLevel() zapcore.Level {
+func (c *config) LogLevel() (zapcore.Level, error) {
 	return logging.ParseLogLevel(c.LoggingConfig.Level)
 }
 

--- a/insonmnia/miner/config.go
+++ b/insonmnia/miner/config.go
@@ -5,7 +5,9 @@ import (
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/pkg/errors"
 	"github.com/sonm-io/core/accounts"
+	"github.com/sonm-io/core/insonmnia/logging"
 	"github.com/sonm-io/core/insonmnia/miner/plugin"
+	"go.uber.org/zap/zapcore"
 )
 
 // HubConfig describes Hub configuration.
@@ -28,7 +30,7 @@ type SSHConfig struct {
 }
 
 type LoggingConfig struct {
-	Level int `required:"true" default:"1"`
+	Level string `required:"true" default:"debug"`
 }
 
 type ResourcesConfig struct {
@@ -51,6 +53,10 @@ type config struct {
 	PublicIPsConfig         []string            `required:"false" yaml:"public_ip_addrs"`
 	MetricsListenAddrConfig string              `yaml:"metrics_listen_addr" default:"127.0.0.1:14001"`
 	PluginsConfig           plugin.Config       `yaml:"plugins"`
+}
+
+func (c *config) LogLevel() zapcore.Level {
+	return logging.ParseLogLevel(c.LoggingConfig.Level)
 }
 
 func (c *config) HubResolveEndpoints() bool {
@@ -79,10 +85,6 @@ func (c *config) PublicIPs() []string {
 
 func (c *config) SSH() *SSHConfig {
 	return c.SSHConfig
-}
-
-func (c *config) Logging() LoggingConfig {
-	return c.LoggingConfig
 }
 
 func (c *config) UUIDPath() string {
@@ -141,6 +143,8 @@ func NewConfig(path string) (Config, error) {
 
 // Config represents a Miner configuration interface.
 type Config interface {
+	logging.Leveler
+
 	// HubEndpoints returns a string representation of a Hub endpoint to communicate with.
 	HubEndpoints() []string
 	// HubEthAddr returns hub's ethereum address.
@@ -155,8 +159,6 @@ type Config interface {
 	PublicIPs() []string
 	// SSH returns settings for built-in ssh server
 	SSH() *SSHConfig
-	// Logging returns logging settings.
-	Logging() LoggingConfig
 	// Path to store Miner uuid
 	UUIDPath() string
 	// ETH returns ethereum configuration

--- a/insonmnia/miner/config_test.go
+++ b/insonmnia/miner/config_test.go
@@ -39,7 +39,11 @@ logging:
 	assert.Nil(t, err)
 
 	assert.Equal(t, []string{"127.0.0.1:10002"}, conf.HubEndpoints())
-	assert.Equal(t, zapcore.WarnLevel, conf.LogLevel())
+
+	lvl, err := conf.LogLevel()
+	assert.NoError(t, err)
+
+	assert.Equal(t, zapcore.WarnLevel, lvl)
 }
 
 func TestConfigPluginsDefaults(t *testing.T) {

--- a/insonmnia/miner/config_test.go
+++ b/insonmnia/miner/config_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap/zapcore"
 )
 
 const (
@@ -27,7 +28,10 @@ hub:
   eth_addr: "8125721C2413d99a33E351e1F6Bb4e56b6b633FD"
   endpoints: ["127.0.0.1:10002"]
 locator:
-  endpoint: "8125721C2413d99a33E351e1F6Bb4e56b6b633FD@127.0.0.1:9090"`
+  endpoint: "8125721C2413d99a33E351e1F6Bb4e56b6b633FD@127.0.0.1:9090"
+logging:
+  level: warn
+`
 	err := createTestConfigFile(raw)
 	assert.Nil(t, err)
 
@@ -35,6 +39,7 @@ locator:
 	assert.Nil(t, err)
 
 	assert.Equal(t, []string{"127.0.0.1:10002"}, conf.HubEndpoints())
+	assert.Equal(t, zapcore.WarnLevel, conf.LogLevel())
 }
 
 func TestConfigPluginsDefaults(t *testing.T) {

--- a/insonmnia/miner/config_test.go
+++ b/insonmnia/miner/config_test.go
@@ -39,11 +39,7 @@ logging:
 	assert.Nil(t, err)
 
 	assert.Equal(t, []string{"127.0.0.1:10002"}, conf.HubEndpoints())
-
-	lvl, err := conf.LogLevel()
-	assert.NoError(t, err)
-
-	assert.Equal(t, zapcore.WarnLevel, lvl)
+	assert.Equal(t, zapcore.WarnLevel, conf.LogLevel())
 }
 
 func TestConfigPluginsDefaults(t *testing.T) {

--- a/insonmnia/node/config.go
+++ b/insonmnia/node/config.go
@@ -3,6 +3,8 @@ package node
 import (
 	"github.com/jinzhu/configor"
 	"github.com/sonm-io/core/accounts"
+	"github.com/sonm-io/core/insonmnia/logging"
+	"go.uber.org/zap/zapcore"
 )
 
 // Config is LocalNode config
@@ -15,14 +17,13 @@ type Config interface {
 	HubEndpoint() string
 	// LocatorEndpoint is Locator service gRPC endpoint
 	LocatorEndpoint() string
-	// LogLevel return log verbosity
-	LogLevel() int
 	// MetricsListenAddr returns the address that can be used by Prometheus to get
 	// metrics.
 	MetricsListenAddr() string
 	// KeyStorager included into config because of
 	// Node instance must know how to open the keystore
 	accounts.KeyStorager
+	logging.Leveler
 }
 
 type nodeConfig struct {
@@ -38,7 +39,7 @@ type hubConfig struct {
 }
 
 type logConfig struct {
-	Level int `required:"true" default:"-1" yaml:"level"`
+	Level string `required:"true" default:"debug" yaml:"level"`
 }
 
 type locatorConfig struct {
@@ -74,8 +75,8 @@ func (y *yamlConfig) HubEndpoint() string {
 	return ""
 }
 
-func (y *yamlConfig) LogLevel() int {
-	return y.Log.Level
+func (y *yamlConfig) LogLevel() zapcore.Level {
+	return logging.ParseLogLevel(y.Log.Level)
 }
 
 func (y *yamlConfig) KeyStore() string {

--- a/insonmnia/node/config.go
+++ b/insonmnia/node/config.go
@@ -75,7 +75,7 @@ func (y *yamlConfig) HubEndpoint() string {
 	return ""
 }
 
-func (y *yamlConfig) LogLevel() zapcore.Level {
+func (y *yamlConfig) LogLevel() (zapcore.Level, error) {
 	return logging.ParseLogLevel(y.Log.Level)
 }
 

--- a/insonmnia/node/config.go
+++ b/insonmnia/node/config.go
@@ -39,7 +39,8 @@ type hubConfig struct {
 }
 
 type logConfig struct {
-	Level string `required:"true" default:"debug" yaml:"level"`
+	Level       string `required:"true" default:"debug" yaml:"level"`
+	parsedLevel zapcore.Level
 }
 
 type locatorConfig struct {
@@ -75,8 +76,8 @@ func (y *yamlConfig) HubEndpoint() string {
 	return ""
 }
 
-func (y *yamlConfig) LogLevel() (zapcore.Level, error) {
-	return logging.ParseLogLevel(y.Log.Level)
+func (y *yamlConfig) LogLevel() zapcore.Level {
+	return y.Log.parsedLevel
 }
 
 func (y *yamlConfig) KeyStore() string {
@@ -100,5 +101,11 @@ func NewConfig(path string) (Config, error) {
 		return nil, err
 	}
 
+	lvl, err := logging.ParseLogLevel(cfg.Log.Level)
+	if err != nil {
+		return nil, err
+	}
+
+	cfg.Log.parsedLevel = lvl
 	return cfg, nil
 }

--- a/node.yaml
+++ b/node.yaml
@@ -13,7 +13,7 @@ market:
 # Logging settings.
 log:
   # The desired logging level.
-  # Allowed values is "debug", "info", "warn", "error", "panic" and "fatal"
+  # Allowed values are "debug", "info", "warn", "error", "panic" and "fatal"
   level: debug
 
 # locator settings

--- a/node.yaml
+++ b/node.yaml
@@ -13,8 +13,8 @@ market:
 # Logging settings.
 log:
   # The desired logging level.
-  # Allowed values in range of -1 (high verbosity) to 3 (most quiet)
-  level: -1
+  # Allowed values is "debug", "info", "warn", "error", "panic" and "fatal"
+  level: debug
 
 # locator settings
 locator:

--- a/vendor/github.com/jinzhu/configor/README.md
+++ b/vendor/github.com/jinzhu/configor/README.md
@@ -50,6 +50,18 @@ contacts:
   email: test@test.com
 ```
 
+## Debug Mode & Verbose Mode
+
+Debug/Verbose mode is helpful when debuging your application, `debug mode` will let you know how `configor` loaded your configurations, like from which file, shell env, `verbose mode` will tell you even more, like those shell environments `configor` tried to load.
+
+```go
+// Enable debug mode or set env `CONFIGOR_DEBUG_MODE` to true when running your application
+configor.New(&configor.Config{Debug: true}).Load(&Config, "config.json")
+
+// Enable verbose mode or set env `CONFIGOR_VERBOSE_MODE` to true when running your application
+configor.New(&configor.Config{Verbose: true}).Load(&Config, "config.json")
+```
+
 # Advanced Usage
 
 * Load mutiple configurations

--- a/vendor/github.com/jinzhu/configor/utils.go
+++ b/vendor/github.com/jinzhu/configor/utils.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 
 	"github.com/BurntSushi/toml"
-	yaml "gopkg.in/yaml.v1"
+	yaml "gopkg.in/yaml.v2"
 )
 
 func (configor *Configor) getENVPrefix(config interface{}) string {
@@ -44,6 +44,10 @@ func getConfigurationFileWithENVPrefix(file, env string) (string, error) {
 
 func (configor *Configor) getConfigurationFiles(files ...string) []string {
 	var results []string
+
+	if configor.Config.Debug || configor.Config.Verbose {
+		fmt.Printf("Current environment: '%v'\n", configor.GetEnvironment())
+	}
 
 	for i := len(files) - 1; i >= 0; i-- {
 		foundFile := false
@@ -106,7 +110,7 @@ func getPrefixForStruct(prefixes []string, fieldStruct *reflect.StructField) []s
 	return append(prefixes, fieldStruct.Name)
 }
 
-func processTags(config interface{}, prefixes ...string) error {
+func (configor *Configor) processTags(config interface{}, prefixes ...string) error {
 	configValue := reflect.Indirect(reflect.ValueOf(config))
 	if configValue.Kind() != reflect.Struct {
 		return errors.New("invalid config, should be struct")
@@ -121,6 +125,10 @@ func processTags(config interface{}, prefixes ...string) error {
 			envName     = fieldStruct.Tag.Get("env") // read configuration from shell env
 		)
 
+		if !field.CanAddr() || !field.CanInterface() {
+			continue
+		}
+
 		if envName == "" {
 			envNames = append(envNames, strings.Join(append(prefixes, fieldStruct.Name), "_"))                  // Configor_DB_Name
 			envNames = append(envNames, strings.ToUpper(strings.Join(append(prefixes, fieldStruct.Name), "_"))) // CONFIGOR_DB_NAME
@@ -128,9 +136,16 @@ func processTags(config interface{}, prefixes ...string) error {
 			envNames = []string{envName}
 		}
 
+		if configor.Config.Verbose {
+			fmt.Printf("Trying to load struct `%v`'s field `%v` from env %v\n", configType.Name(), fieldStruct.Name, strings.Join(envNames, ", "))
+		}
+
 		// Load From Shell ENV
 		for _, env := range envNames {
 			if value := os.Getenv(env); value != "" {
+				if configor.Config.Debug || configor.Config.Verbose {
+					fmt.Printf("Loading configuration for struct `%v`'s field `%v` from env %v...\n", configType.Name(), fieldStruct.Name, env)
+				}
 				if err := yaml.Unmarshal([]byte(value), field.Addr().Interface()); err != nil {
 					return err
 				}
@@ -155,7 +170,7 @@ func processTags(config interface{}, prefixes ...string) error {
 		}
 
 		if field.Kind() == reflect.Struct {
-			if err := processTags(field.Addr().Interface(), getPrefixForStruct(prefixes, &fieldStruct)...); err != nil {
+			if err := configor.processTags(field.Addr().Interface(), getPrefixForStruct(prefixes, &fieldStruct)...); err != nil {
 				return err
 			}
 		}
@@ -163,7 +178,7 @@ func processTags(config interface{}, prefixes ...string) error {
 		if field.Kind() == reflect.Slice {
 			for i := 0; i < field.Len(); i++ {
 				if reflect.Indirect(field.Index(i)).Kind() == reflect.Struct {
-					if err := processTags(field.Index(i).Addr().Interface(), append(getPrefixForStruct(prefixes, &fieldStruct), fmt.Sprint(i))...); err != nil {
+					if err := configor.processTags(field.Index(i).Addr().Interface(), append(getPrefixForStruct(prefixes, &fieldStruct), fmt.Sprint(i))...); err != nil {
 						return err
 					}
 				}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -1069,10 +1069,10 @@
 			"revisionTime": "2017-07-26T07:40:41Z"
 		},
 		{
-			"checksumSHA1": "NrY6tAvq3l68HNfSwsJ98O5KXCs=",
+			"checksumSHA1": "OLqprTiaOxrn4X2yJ9LV+WbFJ14=",
 			"path": "github.com/jinzhu/configor",
-			"revision": "ff2ac2b1ce3d687c3a1da0d2847fbce42524a7f3",
-			"revisionTime": "2017-05-22T02:16:20Z"
+			"revision": "6ecfe629230f24c2e92c7894c6ab21b83b757a39",
+			"revisionTime": "2017-10-24T08:10:03Z"
 		},
 		{
 			"checksumSHA1": "gKyBj05YkfuLFruAyPZ4KV9nFp8=",

--- a/worker.yaml
+++ b/worker.yaml
@@ -27,7 +27,7 @@ hub:
 # Logging settings.
 logging:
   # The desired logging level.
-  # Allowed values is "debug", "info", "warn", "error", "panic" and "fatal"
+  # Allowed values are "debug", "info", "warn", "error", "panic" and "fatal"
   level: debug
 
 # Firewall discovery settings, optional param

--- a/worker.yaml
+++ b/worker.yaml
@@ -27,8 +27,8 @@ hub:
 # Logging settings.
 logging:
   # The desired logging level.
-  # Allowed values in range of -1 (high verbosity) to 3 (most quiet)
-  level: -1
+  # Allowed values is "debug", "info", "warn", "error", "panic" and "fatal"
+  level: debug
 
 # Firewall discovery settings, optional param
 # If enabled the miner tries to discover its own public IP address and the


### PR DESCRIPTION
changed:
- Service configs now receive logging level as a string, not a numeric value. Fallback level is "debug".
- Config interface returns zapcore.Level to build logger instance from configured values.
- `debug` parameter is removed from BuildLogger, logger always in "production" mode with the eye-candy "console" encoding. Because nobody changes this mode during half a year `¯\(ツ)/¯`