### PR TITLE
fix: check for supplier and buyer auth on TaskStatus

### DIFF
--- a/insonmnia/hub/acl.go
+++ b/insonmnia/hub/acl.go
@@ -3,6 +3,7 @@ package hub
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"reflect"
 
 	"github.com/sonm-io/core/insonmnia/auth"
@@ -264,4 +265,22 @@ func (a *orderAuthorization) Authorize(ctx context.Context, request interface{})
 	}
 
 	return nil
+}
+
+type multiAuth struct {
+	authorizers []auth.Authorization
+}
+
+func (a *multiAuth) Authorize(ctx context.Context, request interface{}) error {
+	for _, au := range a.authorizers {
+		if err := au.Authorize(ctx, request); err == nil {
+			return nil
+		}
+	}
+
+	return errors.New("all of required auth methods is failed")
+}
+
+func newMultiAuth(a ...auth.Authorization) auth.Authorization {
+	return &multiAuth{authorizers: a}
 }

--- a/insonmnia/hub/server.go
+++ b/insonmnia/hub/server.go
@@ -49,6 +49,7 @@ var (
 		"List",
 		"Info",
 		"TaskList",
+		"TaskStatus",
 		"Devices",
 		"MinerDevices",
 		"GetDeviceProperties",
@@ -1005,7 +1006,12 @@ func New(ctx context.Context, cfg *Config, opts ...Option) (*Hub, error) {
 		auth.WithEventPrefix(hubAPIPrefix),
 		auth.Allow("Handshake", "ProposeDeal").With(auth.NewNilAuthorization()),
 		auth.Allow(hubManagementMethods...).With(auth.NewTransportAuthorization(h.ethAddr)),
-		auth.Allow("TaskStatus", "StopTask").With(newDealAuthorization(ctx, hubState, newFromTaskDealExtractor(hubState))),
+
+		auth.Allow("TaskStatus").With(newMultiAuth(
+			auth.NewTransportAuthorization(h.ethAddr),
+			newDealAuthorization(ctx, hubState, newFromTaskDealExtractor(hubState)),
+		)),
+		auth.Allow("StopTask").With(newDealAuthorization(ctx, hubState, newFromTaskDealExtractor(hubState))),
 		auth.Allow("StartTask").With(newDealAuthorization(ctx, hubState, newFieldDealExtractor())),
 		auth.Allow("TaskLogs").With(newDealAuthorization(ctx, hubState, newFromTaskDealExtractor(hubState))),
 		auth.Allow("PushTask").With(newDealAuthorization(ctx, hubState, newContextDealExtractor())),


### PR DESCRIPTION
added:
- `multiAuth` implementation of an `auth.Authorization` that allows to combine and apply different auth types.

changed:
- `Hub.TaskStatus` method wrapped with both `TransportAuthorization` and `DealAuthorization`.