### PR TITLE
fix: pass context to the ethereum interface

### DIFF
--- a/cmd/cli/commands/common.go
+++ b/cmd/cli/commands/common.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"context"
 	"crypto/ecdsa"
 	"encoding/json"
 	"errors"
@@ -165,4 +166,8 @@ func loadKeyStoreWrapper(cmd *cobra.Command, _ []string) {
 func showJSON(cmd *cobra.Command, s interface{}) {
 	b, _ := json.Marshal(s)
 	cmd.Printf("%s\r\n", b)
+}
+
+func newTimeoutContext() (context.Context, context.CancelFunc) {
+	return context.WithTimeout(context.Background(), timeoutFlag)
 }

--- a/cmd/cli/commands/tokens.go
+++ b/cmd/cli/commands/tokens.go
@@ -22,7 +22,10 @@ var getTokenCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		tx, err := bch.GetTokens(sessionKey)
+		ctx, cancel := newTimeoutContext()
+		defer cancel()
+
+		tx, err := bch.GetTokens(ctx, sessionKey)
 		if err != nil {
 			showError(cmd, "Cannot get tokens", err)
 			os.Exit(1)
@@ -52,21 +55,24 @@ var approveTokenCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		currentAllowance, err := bch.AllowanceOf(crypto.PubkeyToAddress(sessionKey.PublicKey).String(), tsc.DealsAddress)
+		ctx, cancel := newTimeoutContext()
+		defer cancel()
+
+		currentAllowance, err := bch.AllowanceOf(ctx, crypto.PubkeyToAddress(sessionKey.PublicKey).String(), tsc.DealsAddress)
 		if err != nil {
 			showError(cmd, "Cannot get allowance ", err)
 			os.Exit(1)
 		}
 
 		if currentAllowance.Cmp(zero) != 0 {
-			_, err = bch.Approve(sessionKey, tsc.DealsAddress, zero)
+			_, err = bch.Approve(ctx, sessionKey, tsc.DealsAddress, zero)
 			if err != nil {
 				showError(cmd, "Cannot set approved value to zero", err)
 				os.Exit(1)
 			}
 		}
 
-		tx, err := bch.Approve(sessionKey, tsc.DealsAddress, amount)
+		tx, err := bch.Approve(ctx, sessionKey, tsc.DealsAddress, amount)
 		if err != nil {
 			showError(cmd, "Cannot approve tokens", err)
 			os.Exit(1)

--- a/insonmnia/hub/eth_test.go
+++ b/insonmnia/hub/eth_test.go
@@ -29,12 +29,13 @@ func makeTestKey() (string, *ecdsa.PrivateKey) {
 }
 
 func TestEth_CheckDealExists(t *testing.T) {
+	ctx := context.Background()
 	addr, key := makeTestKey()
 	bC := blockchain.NewMockBlockchainer(gomock.NewController(t))
-	bC.EXPECT().GetDeals(addr).AnyTimes().Return([]*big.Int{big.NewInt(1), big.NewInt(2)}, nil)
-	bC.EXPECT().GetDealInfo(big.NewInt(1)).AnyTimes().Return(&pb.Deal{SupplierID: addr, Status: pb.DealStatus_ACCEPTED}, nil)
-	bC.EXPECT().GetDealInfo(big.NewInt(2)).AnyTimes().Return(&pb.Deal{SupplierID: addr, Status: pb.DealStatus_CLOSED}, nil)
-	bC.EXPECT().GetDealInfo(big.NewInt(3)).AnyTimes().Return(&pb.Deal{SupplierID: "anotherEthAddress", Status: pb.DealStatus_CLOSED}, nil)
+	bC.EXPECT().GetDeals(ctx, addr).AnyTimes().Return([]*big.Int{big.NewInt(1), big.NewInt(2)}, nil)
+	bC.EXPECT().GetDealInfo(ctx, big.NewInt(1)).AnyTimes().Return(&pb.Deal{SupplierID: addr, Status: pb.DealStatus_ACCEPTED}, nil)
+	bC.EXPECT().GetDealInfo(ctx, big.NewInt(2)).AnyTimes().Return(&pb.Deal{SupplierID: addr, Status: pb.DealStatus_CLOSED}, nil)
+	bC.EXPECT().GetDealInfo(ctx, big.NewInt(3)).AnyTimes().Return(&pb.Deal{SupplierID: "anotherEthAddress", Status: pb.DealStatus_CLOSED}, nil)
 
 	eeth := &eth{
 		ctx: context.Background(),
@@ -59,16 +60,18 @@ func TestEth_CheckDealExists(t *testing.T) {
 }
 
 func TestEth_WaitForDealCreated(t *testing.T) {
+	ctx := context.Background()
 	addr, key := makeTestKey()
+
 	bC := blockchain.NewMockBlockchainer(gomock.NewController(t))
-	bC.EXPECT().GetOpenedDeal(addr, clientAddrString).AnyTimes().Return(
+	bC.EXPECT().GetOpenedDeal(ctx, addr, clientAddrString).AnyTimes().Return(
 		[]*big.Int{
 			big.NewInt(100),
 			big.NewInt(200),
 		},
 		nil)
 
-	bC.EXPECT().GetDealInfo(big.NewInt(100)).AnyTimes().Return(
+	bC.EXPECT().GetDealInfo(ctx, big.NewInt(100)).AnyTimes().Return(
 		&pb.Deal{
 			Id:                "100",
 			SupplierID:        addr,
@@ -77,7 +80,7 @@ func TestEth_WaitForDealCreated(t *testing.T) {
 			SpecificationHash: "aaa",
 		},
 		nil)
-	bC.EXPECT().GetDealInfo(big.NewInt(200)).AnyTimes().Return(
+	bC.EXPECT().GetDealInfo(ctx, big.NewInt(200)).AnyTimes().Return(
 		&pb.Deal{
 			Id:                "200",
 			SupplierID:        addr,
@@ -102,15 +105,17 @@ func TestEth_WaitForDealCreated(t *testing.T) {
 }
 
 func TestEth_CheckDealExists2(t *testing.T) {
+	ctx := context.Background()
 	addr, key := makeTestKey()
+
 	bC := blockchain.NewMockBlockchainer(gomock.NewController(t))
-	bC.EXPECT().GetOpenedDeal(addr, clientAddrString).AnyTimes().Return(
+	bC.EXPECT().GetOpenedDeal(ctx, addr, clientAddrString).AnyTimes().Return(
 		[]*big.Int{
 			big.NewInt(100),
 		},
 		nil)
 
-	bC.EXPECT().GetDealInfo(big.NewInt(100)).AnyTimes().Return(
+	bC.EXPECT().GetDealInfo(ctx, big.NewInt(100)).AnyTimes().Return(
 		&pb.Deal{
 			Id:                "100",
 			SupplierID:        addr,

--- a/insonmnia/hub/server_test.go
+++ b/insonmnia/hub/server_test.go
@@ -133,10 +133,12 @@ func buildTestHub(ctrl *gomock.Controller) (*Hub, error) {
 	clustr := getTestCluster(ctrl)
 	config := getTestHubConfig()
 
-	bc := blockchain.NewMockBlockchainer(ctrl)
-	bc.EXPECT().GetDealInfo(gomock.Any()).AnyTimes().Return(&pb.Deal{}, nil)
+	ctx := context.Background()
 
-	return New(context.Background(), config, WithPrivateKey(key), WithMarket(market),
+	bc := blockchain.NewMockBlockchainer(ctrl)
+	bc.EXPECT().GetDealInfo(ctx, gomock.Any()).AnyTimes().Return(&pb.Deal{}, nil)
+
+	return New(ctx, config, WithPrivateKey(key), WithMarket(market),
 		WithCluster(clustr, nil), WithBlockchain(bc))
 }
 

--- a/insonmnia/node/deals.go
+++ b/insonmnia/node/deals.go
@@ -15,14 +15,14 @@ type dealsAPI struct {
 }
 
 func (d *dealsAPI) List(ctx context.Context, req *pb.DealListRequest) (*pb.DealListReply, error) {
-	IDs, err := d.remotes.eth.GetDeals(req.Owner)
+	IDs, err := d.remotes.eth.GetDeals(ctx, req.Owner)
 	if err != nil {
 		return nil, err
 	}
 
 	deals := make([]*pb.Deal, 0, len(IDs))
 	for _, id := range IDs {
-		deal, err := d.remotes.eth.GetDealInfo(id)
+		deal, err := d.remotes.eth.GetDealInfo(ctx, id)
 		if err != nil {
 			return nil, err
 		}
@@ -44,7 +44,7 @@ func (d *dealsAPI) Status(ctx context.Context, id *pb.ID) (*pb.DealStatusReply, 
 		return nil, err
 	}
 
-	deal, err := d.remotes.eth.GetDealInfo(bigID)
+	deal, err := d.remotes.eth.GetDealInfo(ctx, bigID)
 	if err != nil {
 		return nil, err
 	}
@@ -77,7 +77,7 @@ func (d *dealsAPI) Finish(ctx context.Context, id *pb.ID) (*pb.Empty, error) {
 		return nil, err
 	}
 
-	_, err = d.remotes.eth.CloseDeal(d.remotes.key, bigID)
+	_, err = d.remotes.eth.CloseDeal(ctx, d.remotes.key, bigID)
 	if err != nil {
 		return nil, err
 	}

--- a/insonmnia/node/market.go
+++ b/insonmnia/node/market.go
@@ -350,12 +350,12 @@ func (m *marketAPI) startExecOrderHandler(ord *pb.Order) {
 
 func (m *marketAPI) loadBalanceAndAllowance() (*big.Int, *big.Int, error) {
 	addr := util.PubKeyToAddr(m.remotes.key.PublicKey).Hex()
-	balance, err := m.remotes.eth.BalanceOf(addr)
+	balance, err := m.remotes.eth.BalanceOf(m.ctx, addr)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	allowance, err := m.remotes.eth.AllowanceOf(addr, tsc.DealsAddress)
+	allowance, err := m.remotes.eth.AllowanceOf(m.ctx, addr, tsc.DealsAddress)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/insonmnia/node/tasks.go
+++ b/insonmnia/node/tasks.go
@@ -36,7 +36,7 @@ func (t *tasksAPI) List(ctx context.Context, req *pb.TaskListRequest) (*pb.TaskL
 
 	clientAddr := util.PubKeyToAddr(t.remotes.key.PublicKey)
 	// get all accepted deals, because only on the accepted deals client can start the payloads.
-	dealIDs, err := t.remotes.eth.GetAcceptedDeal("", clientAddr.Hex())
+	dealIDs, err := t.remotes.eth.GetAcceptedDeal(ctx, "", clientAddr.Hex())
 	if err != nil {
 		return nil, err
 	}
@@ -45,7 +45,7 @@ func (t *tasksAPI) List(ctx context.Context, req *pb.TaskListRequest) (*pb.TaskL
 
 	var activeDeals []*pb.Deal
 	for _, id := range dealIDs {
-		dealInfo, err := t.remotes.eth.GetDealInfo(id)
+		dealInfo, err := t.remotes.eth.GetDealInfo(ctx, id)
 		if err != nil {
 			return nil, err
 		}
@@ -285,7 +285,7 @@ func getHubClientForDeal(ctx context.Context, rm *remoteOptions, id string) (pb.
 		return nil, nil, err
 	}
 
-	dealInfo, err := rm.eth.GetDealInfo(bigID)
+	dealInfo, err := rm.eth.GetDealInfo(ctx, bigID)
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
We need to perform a correct cancellation and do not want to break a context when communicating with blockchain.