### PR TITLE
ci: add target to preparing and uploading release binaries

### DIFF
--- a/.ci/release.sh
+++ b/.ci/release.sh
@@ -1,0 +1,147 @@
+#!/bin/bash
+
+set -e
+
+VER=$1
+TOKEN=$2
+
+if [[ -z ${VER} ]]; then
+    echo "Err: please specify version to release"
+    exit 1
+fi
+
+if [[ -z ${TOKEN} ]]; then
+    echo "Err: please set Github token for release publishing"
+    exit 1
+fi
+
+
+LINUX_ZIP=sonm_${VER}_linux.zip
+LINUX_ZIP_PATH=release/${VER}/${LINUX_ZIP}
+
+DARWIN_ZIP=sonm_${VER}_darwin.zip
+DARWIN_ZIP_PATH=release/${VER}/${DARWIN_ZIP}
+
+WINDOWS_ZIP=sonm_${VER}_win32.zip
+WINDOWS_ZIP_PATH=release/${VER}/${WINDOWS_ZIP}
+
+CURL="curl -s"
+
+for_linux () {
+    echo " >>> building for Linux (native)...";
+
+    # make dir structure
+    mkdir -p release/${VER}/linux/cli
+    mkdir -p release/${VER}/linux/node
+    mkdir -p release/${VER}/linux/hub
+    mkdir -p release/${VER}/linux/worker
+
+    # configs
+    cp .ci/v0.3_config/cli.yaml release/${VER}/linux/cli/cli.yaml
+    cp .ci/v0.3_config/node.yaml release/${VER}/linux/node/node.yaml
+    cp .ci/v0.3_config/hub.yaml release/${VER}/linux/hub/hub.yaml
+    cp .ci/v0.3_config/worker.yaml release/${VER}/linux/worker/worker.yaml
+
+    # build
+    GPU_SUPPORT=true make build/insomnia VER=${VER}
+
+    # binaries
+    cp target/sonmcli_linux_x86_64 release/${VER}/linux/cli/sonmcli
+    cp target/sonmnode_linux_x86_64 release/${VER}/linux/node/sonmnode
+    cp target/sonmhub_linux_x86_64 release/${VER}/linux/hub/sonmhub
+    cp target/sonmworker_linux_x86_64 release/${VER}/linux/worker/sonmworker
+
+    # archive for github
+    zip -r ${LINUX_ZIP_PATH} release/${VER}/linux/
+
+    echo " >>> release for Linux is done";
+}
+
+for_windows () {
+    echo " >>> building for Windows (xgo)...";
+
+    # make dir structure
+    mkdir -p release/${VER}/windows/cli
+    mkdir -p release/${VER}/windows/node
+
+    # configs
+    cp .ci/v0.3_config/cli.yaml release/${VER}/windows/cli/cli.yaml
+    cp .ci/v0.3_config/node.yaml release/${VER}/windows/node/node.yaml
+
+    # build
+    xgo -tags='nocgo' -ldflags='-X main.appVersion=$(VER)' --targets=windows/386 --pkg cmd/cli -out sonmcli github.com/sonm-io/core
+    xgo -tags='nocgo' -ldflags='-X main.appVersion=$(VER)' --targets=windows/386 --pkg cmd/node -out sonmnode github.com/sonm-io/core
+
+    # binaries
+    cp sonmcli-windows-4.0-386.exe release/${VER}/windows/cli/sonmcli.exe
+    cp sonmnode-windows-4.0-386.exe release/${VER}/windows/node/sonmnode.exe
+
+    # archive for github
+    zip -r ${WINDOWS_ZIP_PATH} release/${VER}/windows/
+
+    echo " >>> release for Windows is done";
+}
+
+for_macos () {
+    echo " >>> building for macOS (xgo)...";
+
+    # make dir structure
+    mkdir -p release/${VER}/darwin/cli
+    mkdir -p release/${VER}/darwin/node
+
+    # configs
+    cp .ci/v0.3_config/cli.yaml release/${VER}/darwin/cli/cli.yaml
+    cp .ci/v0.3_config/node.yaml release/${VER}/darwin/node/node.yaml
+
+    # build
+    xgo -tags='nocgo' -ldflags='-X main.appVersion=$(VER)' --targets=darwin/amd64 --pkg cmd/cli -out sonmcli github.com/sonm-io/core
+    xgo -tags='nocgo' -ldflags='-X main.appVersion=$(VER)' --targets=darwin/amd64 --pkg cmd/node -out sonmnode github.com/sonm-io/core
+
+    # binaries
+    cp sonmcli-darwin-10.6-amd64 release/${VER}/darwin/cli/sonmcli
+    cp sonmnode-darwin-10.6-amd64 release/${VER}/darwin/node/sonmcli
+
+    # archive for github
+    zip -r ${DARWIN_ZIP_PATH} release/${VER}/darwin/
+
+    echo " >>> release for macOS is done";
+}
+
+upload_release () {
+    echo " >>> uploading artifacts to Github...";
+
+    GH_AUTH="-u sshaman1101:${TOKEN}"
+    GH_RELEASE_REQUEST="-d '{\"tag_name\": \"${VER}\", \"name\": \"${VER}\", \"target_commitish\": \"master\", \"draft\": true, \"body\": \"created automatically by TeamCity\"}'"
+    GH_CREATE_RELEASE_URI=https://api.github.com/repos/sonm-io/core/releases
+
+    CURL_REQ="${CURL} $GH_AUTH $GH_RELEASE_REQUEST $GH_CREATE_RELEASE_URI"
+    RES=$(eval ${CURL_REQ})
+
+    UPLOAD_URL=$(echo ${RES} | jq '.upload_url' | sed -e s/'{?name,label}'//)
+    echo " **** UPLOAD URL = ${UPLOAD_URL}"
+
+
+    UPLOAD_LINUX_REQ="${CURL} ${GH_AUTH} -H 'Content-Type: application/zip' --data-binary @'${LINUX_ZIP_PATH}' ${UPLOAD_URL}?name=${LINUX_ZIP}"
+    UPLOAD_WINDOWS_REQ="${CURL} ${GH_AUTH} -H 'Content-Type: application/zip' --data-binary @'${WINDOWS_ZIP_PATH}' ${UPLOAD_URL}?name=${WINDOWS_ZIP}"
+    UPLOAD_DARWIN_REQ="${CURL} ${GH_AUTH} -H 'Content-Type: application/zip' --data-binary @'${DARWIN_ZIP_PATH}' ${UPLOAD_URL}?name=${DARWIN_ZIP}"
+
+    eval ${UPLOAD_LINUX_REQ}
+    eval ${UPLOAD_WINDOWS_REQ}
+    eval ${UPLOAD_DARWIN_REQ}
+
+    echo " >>> release uploading is complete";
+}
+remove_artifacts () {
+    rm -f sonmcli-darwin-10.6-amd64 sonmnode-darwin-10.6-amd64
+    rm -f sonmcli-windows-4.0-386.exe sonmnode-darwin-10.6-amd64
+
+    make clean
+}
+
+
+for_linux
+for_macos
+for_windows
+
+upload_release
+remove_artifacts

--- a/.ci/v0.3_config/cli.yaml
+++ b/.ci/v0.3_config/cli.yaml
@@ -1,0 +1,13 @@
+### This config must be stored at 'home/<current user>/.sonm/' folder,
+### otherwise CLI will work with default settings
+
+# In what format CLI must show their output
+# can be "simple" for human-readable messages
+# and "json" for output in machine-readable JSON format
+output_format: "simple"
+
+ethereum:
+  # path to keystore, for example "/home/sonm/keys"
+  key_store: "keystore_path"
+  # passphrase for keystore
+  pass_phrase: "yourSecretPassword"

--- a/.ci/v0.3_config/hub.yaml
+++ b/.ci/v0.3_config/hub.yaml
@@ -1,0 +1,85 @@
+# An endpoint for miner connections.
+# allowed format is "ip:port" to bind Hub to given IP address
+# or ":port" to bind Hub to all available IPs
+endpoint: ":15011"
+
+# Hub as a gateway settings. Can be omitted indicating that the Hub should not
+# be a gateway.
+# gateway:
+  # Port range allocated for virtual services if any.
+  # ports: [32768, 33768]
+
+# Cluster settings.
+cluster:
+  # An endpoint for client connections using cli
+  # allowed format is "ip:port" to bind Hub to given IP address
+  # or ":port" to bind Hub to all available IPs
+  endpoint: ":15010"
+
+  # An endpoint for hub announcements
+  # This one useful if hub is behind router with DMZ or port forwarding
+  # This endpoint will be used to communicate with hub,
+  # however hub will still bind on "endpoint", not "announce_endpoint"
+  # announce_endpoint: "1.2.3.4:1234"
+
+  # Use automated failover in case of hub death
+  # Requires consul, etcd or zookeeper as a store
+  failover: false
+
+  # Configuration of persistent store
+  store:
+    # Type of the storage to use.
+    # Possible types are: "consul", "zookeeper", "etcd" and "boltdb"
+    # boltDB is a local storage, so it can not be used with failover switched on
+    type: "boltdb"
+
+    # storage specific endpoint. Directory for boltdb, tcp endpoint for other types
+    endpoint: "/tmp/sonm/boltdb"
+
+    # Storage bucket to store all data in
+    bucket: "sonm"
+
+    # TLS key file for stores, supporting it
+    # key_file: "/path/to/key.key
+
+    # Cert file for stores, supporting it
+    # cert_file: "/path/to/cert.crt"
+
+  # Fine tuning
+  leader_key: "sonm/hub/leader"
+  member_list_key: "sonm/hub/list"
+  sync_prefix: "sync_prefix"
+  leader_ttl: "20s"
+  announce_period: "20s"
+  member_gc_period: "20s"
+
+# Logging settings.
+logging:
+  # The desired logging level.
+  # Allowed values in range of -1 (high verbosity) to 3 (most quiet)
+  level: -1
+
+# blockchain-specific settings.
+ethereum:
+  # path to keystore, for example "/home/sonm/keys"
+  key_store: "keystore_path"
+  # passphrase for keystore
+  pass_phrase: "yourSecretPassword"
+
+# Locator service allows nodes to discover each other.
+locator:
+  # Locator gRPC endpoint, required.
+  endpoint: "0xd67749caa651b5f4a056be437f6c6c3725776602@139.59.250.244:15020"
+  # Background announcements period.
+  update_period: "10s"
+
+# Marketplace service settings
+market:
+  # marketplace gRPC endpoint, required
+  endpoint: "0xA99faEeF5559b823B63EB8Fe51CC13E14907C909@188.166.190.188:15021"
+
+whitelist:
+  url: "https://raw.githubusercontent.com/sonm-io/allowed-list/master/general_whitelist.json"
+  enabled: true
+
+metrics_listen_addr: "127.0.0.1:14000"

--- a/.ci/v0.3_config/node.yaml
+++ b/.ci/v0.3_config/node.yaml
@@ -1,0 +1,38 @@
+# Local Node settings
+node:
+  # address to bind Node's gRPC endpoint
+  # required
+  listen_addr: "127.0.0.1:15030"
+
+# Marketplace service settings
+market:
+  # marketplace gRPC endpoint
+  # required
+  endpoint: "0xA99faEeF5559b823B63EB8Fe51CC13E14907C909@188.166.190.188:15021"
+
+# Logging settings.
+log:
+  # The desired logging level.
+  # Allowed values in range of -1 (high verbosity) to 3 (most quiet)
+  level: -1
+
+# locator settings
+locator:
+  # Locator's gRPC endpoint for Eth to IP addr resolution
+  endpoint: "0xd67749caa651b5f4a056be437f6c6c3725776602@139.59.250.244:15020"
+
+
+# Settings for Ethereum keys
+ethereum:
+  # path to keystore, for example "/home/sonm/keys"
+  key_store: "keystore_path"
+  # passphrase for keystore
+  pass_phrase: "yourSecretPassword"
+
+# Hub management settings.
+# Set this if you have your own Hub and want to manage it.
+hub:
+  # endpoint is Hub's monitoring gRPC endpoint for client connections.
+  endpoint: "127.0.0.1:15010"
+
+metrics_listen_addr: "127.0.0.1:14003"

--- a/.ci/v0.3_config/worker.yaml
+++ b/.ci/v0.3_config/worker.yaml
@@ -1,0 +1,68 @@
+# Hub settings.
+hub:
+  eth_addr: "your_Hub_Ether_Address"
+  # Either `resolve_endpoints: true` or `endpoints` should be provided. If `resolve_endpoints`
+  # is set to `true`, hub's addresses will be resolved via locator.
+  resolve_endpoints: false
+  endpoints: ["127.0.0.1:15011", "127.0.0.2:15011"]
+
+#  Resources section is available only on Linux
+#  If configured, all tasks will share this pool of resources.
+#  This pool is a parent control group.
+#  Format is Open Container Initiative Runtime Specification:
+#  resources:
+#    cgroup: insonmnia
+#    resources:
+#      # https://github.com/opencontainers/runtime-spec/blob/master/config-linux.md#memory
+#      memory:
+#        limit: 1000
+#      # https://github.com/opencontainers/runtime-spec/blob/master/config-linux.md#cpu
+#      cpu:
+#        quota: 1024
+#        cpus: "2-3"
+#      # https://github.com/opencontainers/runtime-spec/blob/master/config-linux.md#network
+#      network:
+#        classID: 1048577
+
+# Logging settings.
+logging:
+  # The desired logging level.
+  # Allowed values in range of -1 (high verbosity) to 3 (most quiet)
+  level: -1
+
+# Firewall discovery settings, optional param
+# If enabled the miner tries to discover its own public IP address and the
+# firewall configuration. STUN server can be configured.
+# If disabled it is treated as having public IP address that is determined
+# automatically.
+# firewall:
+#   server: "stun.ekiga.net:3478"
+
+# A list of IPs that can be used to reach the miner, optional param. If not provided, miner's interfaces will
+# be scanned for such IPs (if there's no firewall settings).
+# Ignored if firewall settings are not null.
+# public_ip_addrs: ["46.148.198.134"]
+
+ethereum:
+  # path to keystore, for example "/home/sonm/keys"
+  key_store: "keystore_path"
+  # passphrase for keystore
+  pass_phrase: "yourSecretPassword"
+
+# locator service allows nodes to discover each other
+locator:
+  # locator gRPC endpoint, required
+  endpoint: "0xd67749caa651b5f4a056be437f6c6c3725776602@139.59.250.244:15020"
+
+metrics_listen_addr: "127.0.0.1:14001"
+
+plugins:
+  socket_dir: /run/docker/plugins
+#
+  volume:
+    root: /var/lib/docker-volumes
+    volumes:
+      cifs: {}
+#  gpus:
+#    nvidia: {}
+#    radeon: {}

--- a/Makefile
+++ b/Makefile
@@ -163,3 +163,7 @@ deb:
 
 coverage:
 	.ci/coverage.sh
+
+release:
+	@echo "preparing $(VER) to release..."
+	@ .ci/release.sh $(VER) $(GH_TOKEN)


### PR DESCRIPTION
added:
- Script for cross-compiling release binaries and upload it to the Github.
- Make target that calls the release script.