### PR TITLE
feat: Searcher, Matcher and Dealer

### DIFF
--- a/insonmnia/dealer/dealer.go
+++ b/insonmnia/dealer/dealer.go
@@ -1,0 +1,96 @@
+package dealer
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"fmt"
+	"math/big"
+	"time"
+
+	log "github.com/noxiouz/zapctx/ctxlog"
+	"github.com/sonm-io/core/blockchain"
+	"github.com/sonm-io/core/insonmnia/structs"
+	"github.com/sonm-io/core/proto"
+	"github.com/sonm-io/core/util"
+	"go.uber.org/zap"
+)
+
+type Dealer interface {
+	Deal(ctx context.Context, bid, ask *sonm.Order) (*big.Int, error)
+}
+
+type dealer struct {
+	key     *ecdsa.PrivateKey
+	timeout time.Duration
+	bc      blockchain.Blockchainer
+	hub     sonm.HubClient
+}
+
+func NewDealer(key *ecdsa.PrivateKey, hub sonm.HubClient, bc blockchain.Blockchainer, timeout time.Duration) Dealer {
+	return &dealer{
+		key:     key,
+		timeout: timeout,
+		bc:      bc,
+		hub:     hub,
+	}
+}
+
+func (d *dealer) Deal(ctx context.Context, bid, ask *sonm.Order) (*big.Int, error) {
+	log.G(ctx).Info("creating deal on ethereum", zap.String("bidID", bid.GetId()))
+	id, err := d.openDeal(ctx, bid)
+	if err != nil {
+		log.G(ctx).Warn("cannot open deal", zap.Error(err), zap.String("bidID", bid.GetId()))
+		return nil, err
+	}
+
+	log.G(ctx).Info("approving deal on hub",
+		zap.String("dealID", id.String()),
+		zap.String("bidID", bid.GetId()),
+		zap.String("hubID", ask.GetSupplierID()))
+
+	err = d.approveOnHub(ctx, id, bid, ask)
+	if err != nil {
+		log.G(ctx).Warn("cannot approve deal on hub, closing deal",
+			zap.Error(err), zap.String("bidID", bid.GetId()))
+
+		err = d.closeUnapproved(ctx, id)
+		if err != nil {
+			log.G(ctx).Warn("cannot close unapproved deal", zap.Error(err))
+			return nil, err
+
+		}
+		log.G(ctx).Debug("unapproved deal closed")
+		return nil, fmt.Errorf("deal id=%s does not approved by hub", id.String())
+	}
+
+	return id, nil
+}
+
+func (d *dealer) openDeal(ctx context.Context, bid *sonm.Order) (*big.Int, error) {
+	dealRequest := &sonm.Deal{
+		WorkTime:          bid.GetSlot().GetDuration(),
+		BuyerID:           util.PubKeyToAddr(d.key.PublicKey).Hex(),
+		SupplierID:        bid.GetSupplierID(),
+		Price:             sonm.NewBigInt(structs.CalculateTotalPrice(bid)),
+		Status:            sonm.DealStatus_PENDING,
+		SpecificationHash: structs.CalculateSpecHash(bid),
+	}
+
+	return d.bc.OpenDealPending(ctx, d.key, dealRequest, d.timeout)
+
+}
+
+func (d *dealer) approveOnHub(ctx context.Context, id *big.Int, bid, ask *sonm.Order) error {
+	approveRequest := &sonm.ApproveDealRequest{
+		DealID: sonm.NewBigInt(id),
+		AskID:  ask.GetId(),
+		BidID:  bid.GetId(),
+	}
+
+	_, err := d.hub.ApproveDeal(ctx, approveRequest)
+	return err
+}
+
+func (d *dealer) closeUnapproved(ctx context.Context, id *big.Int) error {
+	return d.bc.CloseDealPending(ctx, d.key, id, d.timeout)
+}

--- a/insonmnia/dealer/dealer.go
+++ b/insonmnia/dealer/dealer.go
@@ -15,6 +15,7 @@ import (
 	"go.uber.org/zap"
 )
 
+// Dealer interface describes method to open a deal within two orders.
 type Dealer interface {
 	Deal(ctx context.Context, bid, ask *sonm.Order) (*big.Int, error)
 }
@@ -26,6 +27,8 @@ type dealer struct {
 	hub     sonm.HubClient
 }
 
+// NewDealer returns `Dealer` implementation which can open deal
+// for BID and matched ASK orders.
 func NewDealer(key *ecdsa.PrivateKey, hub sonm.HubClient, bc blockchain.Blockchainer, timeout time.Duration) Dealer {
 	return &dealer{
 		key:     key,

--- a/insonmnia/dealer/dealer_test.go
+++ b/insonmnia/dealer/dealer_test.go
@@ -1,0 +1,95 @@
+package dealer
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"io"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/golang/mock/gomock"
+	"github.com/pkg/errors"
+	"github.com/sonm-io/core/blockchain"
+	"github.com/sonm-io/core/insonmnia/node"
+	"github.com/sonm-io/core/proto"
+	"github.com/stretchr/testify/assert"
+)
+
+func newHubMock(ctrl *gomock.Controller) (sonm.HubClient, io.Closer) {
+	hub := node.NewMockHubClient(ctrl)
+	hub.EXPECT().ProposeDeal(gomock.Any(), gomock.Any()).AnyTimes().Return(&sonm.Empty{}, nil)
+	hub.EXPECT().ApproveDeal(gomock.Any(), gomock.Any()).AnyTimes().Return(&sonm.Empty{}, nil)
+	return hub, &mockConn{}
+}
+
+func newEthKey() *ecdsa.PrivateKey {
+	k, _ := crypto.GenerateKey()
+	return k
+}
+
+func TestDealer_Deal(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ctx := context.Background()
+	key := newEthKey()
+
+	bc := blockchain.NewMockBlockchainer(ctrl)
+	bc.EXPECT().OpenDealPending(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		AnyTimes().Return(big.NewInt(1), nil)
+
+	hub, closr := newHubMock(ctrl)
+	defer closr.Close()
+
+	dlr := NewDealer(key, hub, bc, time.Second)
+
+	ask := &sonm.Order{Id: "askid", SupplierID: "test2"}
+	bid := &sonm.Order{
+		Id:             "bidid",
+		SupplierID:     "test1",
+		PricePerSecond: sonm.NewBigIntFromInt(100),
+		Slot:           &sonm.Slot{Duration: 500},
+	}
+
+	id, err := dlr.Deal(ctx, bid, ask)
+	assert.NoError(t, err)
+	assert.True(t, id.Uint64() > 0)
+}
+
+func TestDealer_DealFailedAndCancelled(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ctx := context.Background()
+	key := newEthKey()
+
+	bc := blockchain.NewMockBlockchainer(ctrl)
+	bc.EXPECT().OpenDealPending(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		AnyTimes().Return(big.NewInt(1), nil)
+	bc.EXPECT().CloseDealPending(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		MinTimes(1).Return(nil)
+
+	hub := node.NewMockHubClient(ctrl)
+	hub.EXPECT().ApproveDeal(gomock.Any(), gomock.Any()).AnyTimes().Return(nil, errors.New("test"))
+
+	dlr := NewDealer(key, hub, bc, time.Second)
+
+	ask := &sonm.Order{Id: "askid", SupplierID: "test2"}
+	bid := &sonm.Order{
+		Id:             "bidid",
+		SupplierID:     "test1",
+		PricePerSecond: sonm.NewBigIntFromInt(100),
+		Slot:           &sonm.Slot{Duration: 500},
+	}
+
+	id, err := dlr.Deal(ctx, bid, ask)
+	assert.Error(t, err)
+	assert.Nil(t, id)
+
+}
+
+type mockConn struct{}
+
+func (c *mockConn) Close() error { return nil }

--- a/insonmnia/dealer/match.go
+++ b/insonmnia/dealer/match.go
@@ -1,0 +1,54 @@
+package dealer
+
+import (
+	"github.com/sonm-io/core/proto"
+)
+
+type Matcher interface {
+	// Match takes orders found on market, returns most profitable order to deal with
+	Match(orders []*sonm.Order) (*sonm.Order, error)
+}
+
+// bidMatcher matches the cheapest order to deal
+type bidMatcher struct{}
+
+func NewBidMatcher() Matcher {
+	return &bidMatcher{}
+}
+
+func (m *bidMatcher) Match(orders []*sonm.Order) (*sonm.Order, error) {
+	if len(orders) == 0 {
+		return nil, nil
+	}
+
+	// var min = &sonm.Order{PricePerSecond: sonm.NewBigIntFromInt(0)}
+	var min = orders[0]
+	for _, o := range orders {
+		if o.PricePerSecond.Cmp(min.PricePerSecond) < 0 {
+			min = o
+		}
+	}
+
+	return min, nil
+}
+
+type askMatcher struct{}
+
+func NewAskMatcher() Matcher {
+	return &askMatcher{}
+}
+
+func (m *askMatcher) Match(orders []*sonm.Order) (*sonm.Order, error) {
+	if len(orders) == 0 {
+		return nil, nil
+	}
+
+	var max = orders[0]
+	for _, o := range orders {
+		if o.PricePerSecond.Cmp(max.PricePerSecond) > 0 {
+			max = o
+		}
+	}
+
+	return max, nil
+}

--- a/insonmnia/dealer/match.go
+++ b/insonmnia/dealer/match.go
@@ -1,28 +1,30 @@
 package dealer
 
 import (
-	"github.com/pkg/errors"
+	"errors"
+
 	"github.com/sonm-io/core/proto"
 )
 
+// Matcher interface describes method to select most profitable order from search results.
 type Matcher interface {
-	// Match takes orders found on market, returns most profitable order to deal with
 	Match(orders []*sonm.Order) (*sonm.Order, error)
 }
 
 // bidMatcher matches the cheapest order to deal
 type bidMatcher struct{}
 
+// NewBidMatcher returns Matcher implementation which
+// matches given BID order with most cheapest ASK.
 func NewBidMatcher() Matcher {
 	return &bidMatcher{}
 }
 
 func (m *bidMatcher) Match(orders []*sonm.Order) (*sonm.Order, error) {
-	if orders == nil || len(orders) == 0 {
+	if len(orders) == 0 {
 		return nil, errors.New("no orders provided")
 	}
 
-	// var min = &sonm.Order{PricePerSecond: sonm.NewBigIntFromInt(0)}
 	var min = orders[0]
 	for _, o := range orders {
 		if o.PricePerSecond.Cmp(min.PricePerSecond) < 0 {
@@ -35,12 +37,14 @@ func (m *bidMatcher) Match(orders []*sonm.Order) (*sonm.Order, error) {
 
 type askMatcher struct{}
 
+// NewAskMatcher returns Matcher implementation which
+// matches given ASK order with most expensive BID.
 func NewAskMatcher() Matcher {
 	return &askMatcher{}
 }
 
 func (m *askMatcher) Match(orders []*sonm.Order) (*sonm.Order, error) {
-	if orders == nil || len(orders) == 0 {
+	if len(orders) == 0 {
 		return nil, errors.New("no orders provided")
 	}
 

--- a/insonmnia/dealer/match.go
+++ b/insonmnia/dealer/match.go
@@ -1,6 +1,7 @@
 package dealer
 
 import (
+	"github.com/pkg/errors"
 	"github.com/sonm-io/core/proto"
 )
 
@@ -17,8 +18,8 @@ func NewBidMatcher() Matcher {
 }
 
 func (m *bidMatcher) Match(orders []*sonm.Order) (*sonm.Order, error) {
-	if len(orders) == 0 {
-		return nil, nil
+	if orders == nil || len(orders) == 0 {
+		return nil, errors.New("no orders provided")
 	}
 
 	// var min = &sonm.Order{PricePerSecond: sonm.NewBigIntFromInt(0)}
@@ -39,8 +40,8 @@ func NewAskMatcher() Matcher {
 }
 
 func (m *askMatcher) Match(orders []*sonm.Order) (*sonm.Order, error) {
-	if len(orders) == 0 {
-		return nil, nil
+	if orders == nil || len(orders) == 0 {
+		return nil, errors.New("no orders provided")
 	}
 
 	var max = orders[0]

--- a/insonmnia/dealer/match_test.go
+++ b/insonmnia/dealer/match_test.go
@@ -1,0 +1,46 @@
+package dealer
+
+import (
+	"testing"
+
+	"github.com/sonm-io/core/proto"
+	"github.com/stretchr/testify/assert"
+)
+
+var input = []*sonm.Order{
+	{PricePerSecond: sonm.NewBigIntFromInt(100)},
+	{PricePerSecond: sonm.NewBigIntFromInt(20)},
+	{PricePerSecond: sonm.NewBigIntFromInt(10)},
+	{PricePerSecond: sonm.NewBigIntFromInt(200)},
+	{PricePerSecond: sonm.NewBigIntFromInt(50)},
+}
+
+func TestBidMatcher_Match(t *testing.T) {
+	m := NewBidMatcher()
+	out, err := m.Match(input)
+
+	assert.NoError(t, err)
+	assert.Equal(t, uint64(10), out.PricePerSecond.Unwrap().Uint64())
+}
+
+func TestBidMatcher_MatchNil(t *testing.T) {
+	m := NewBidMatcher()
+	out, err := m.Match(nil)
+	assert.NoError(t, err)
+	assert.Nil(t, out)
+}
+
+func TestAskMatcher_Match(t *testing.T) {
+	m := NewAskMatcher()
+	out, err := m.Match(input)
+
+	assert.NoError(t, err)
+	assert.Equal(t, uint64(200), out.PricePerSecond.Unwrap().Uint64())
+}
+
+func TestAskMatcher_MatchNil(t *testing.T) {
+	m := NewAskMatcher()
+	out, err := m.Match(nil)
+	assert.NoError(t, err)
+	assert.Nil(t, out)
+}

--- a/insonmnia/dealer/match_test.go
+++ b/insonmnia/dealer/match_test.go
@@ -23,10 +23,15 @@ func TestBidMatcher_Match(t *testing.T) {
 	assert.Equal(t, uint64(10), out.PricePerSecond.Unwrap().Uint64())
 }
 
-func TestBidMatcher_MatchNil(t *testing.T) {
+func TestBidMatcher_MatchNilEmpty(t *testing.T) {
 	m := NewBidMatcher()
+
 	out, err := m.Match(nil)
-	assert.NoError(t, err)
+	assert.EqualError(t, err, "no orders provided")
+	assert.Nil(t, out)
+
+	out, err = m.Match([]*sonm.Order{})
+	assert.EqualError(t, err, "no orders provided")
 	assert.Nil(t, out)
 }
 
@@ -38,9 +43,14 @@ func TestAskMatcher_Match(t *testing.T) {
 	assert.Equal(t, uint64(200), out.PricePerSecond.Unwrap().Uint64())
 }
 
-func TestAskMatcher_MatchNil(t *testing.T) {
+func TestAskMatcher_MatchNilEmpty(t *testing.T) {
 	m := NewAskMatcher()
+
 	out, err := m.Match(nil)
-	assert.NoError(t, err)
+	assert.EqualError(t, err, "no orders provided")
+	assert.Nil(t, out)
+
+	out, err = m.Match([]*sonm.Order{})
+	assert.EqualError(t, err, "no orders provided")
 	assert.Nil(t, out)
 }

--- a/insonmnia/dealer/searcher.go
+++ b/insonmnia/dealer/searcher.go
@@ -1,0 +1,129 @@
+package dealer
+
+import (
+	"context"
+	"math/big"
+
+	"github.com/pkg/errors"
+	"github.com/sonm-io/core/insonmnia/structs"
+	"github.com/sonm-io/core/proto"
+)
+
+type Searcher interface {
+	Search(context.Context, *SearchFilter) ([]*sonm.Order, error)
+}
+
+type askSearcher struct {
+	market sonm.MarketClient
+}
+
+func NewAskSearcher(market sonm.MarketClient) Searcher {
+	return &askSearcher{
+		market: market,
+	}
+}
+
+func (s *askSearcher) filterByPriceAndAllowance(orders []*sonm.Order, balance, allowance *big.Int) ([]*sonm.Order, error) {
+	// disallow unclean input
+	if orders == nil {
+		return nil, errors.New("orders cannot be nil")
+	}
+
+	var err error
+	orders, err = s.filterByPrice(orders, balance)
+	if err != nil {
+		return nil, err
+	}
+
+	orders, err = s.filterByAllowance(orders, allowance)
+	if err != nil {
+		return nil, err
+	}
+
+	return orders, nil
+}
+
+func (s *askSearcher) filterByPrice(orders []*sonm.Order, balance *big.Int) ([]*sonm.Order, error) {
+	var res []*sonm.Order
+	for _, o := range orders {
+		p := structs.CalculateTotalPrice(o)
+		// price < balance, we can handle this order
+		if p.Cmp(balance) == -1 {
+			res = append(res, o)
+		}
+	}
+
+	if len(res) == 0 {
+		return nil, errors.New("no orders fit into available balance")
+	}
+
+	return res, nil
+}
+
+func (s *askSearcher) filterByAllowance(orders []*sonm.Order, allowance *big.Int) ([]*sonm.Order, error) {
+	var res []*sonm.Order
+	for _, o := range orders {
+		p := structs.CalculateTotalPrice(o)
+		// if allowance > price
+		if allowance.Cmp(p) > 0 {
+			res = append(res, o)
+		}
+	}
+
+	if len(res) == 0 {
+		return nil, errors.New("no orders fit into allowance")
+	}
+
+	return res, nil
+}
+
+func (s *askSearcher) Search(ctx context.Context, filter *SearchFilter) ([]*sonm.Order, error) {
+	req := &sonm.GetOrdersRequest{
+		Order: filter.order,
+		Count: 100, // wow, such number, very magic
+	}
+
+	// query market for orders
+	reply, err := s.market.GetOrders(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	// apply extra filter for price and allowance
+	// todo(all): can market/dwh perform filtering by price itself?
+	orders, err := s.filterByPriceAndAllowance(reply.GetOrders(), filter.balance, filter.allowance)
+	if err != nil {
+		return nil, err
+	}
+
+	return orders, nil
+}
+
+// SearchFilter represent params for searching and filtering orders
+// on the marketplace. Accepted by `Searcher` interface.
+type SearchFilter struct {
+	order     *sonm.Order
+	balance   *big.Int
+	allowance *big.Int
+}
+
+// NewSearchFilter validates input data and constructs `SearchFilter`
+func NewSearchFilter(order *sonm.Order, balance, allowance *big.Int) (*SearchFilter, error) {
+	if order == nil {
+		return nil, errors.New("order cannot be nil")
+	}
+
+	if balance == nil {
+		return nil, errors.New("balance cannot be nil")
+	}
+
+	if allowance == nil {
+		return nil, errors.New("allowance cannot be nil")
+	}
+
+	return &SearchFilter{
+		order:     order,
+		balance:   balance,
+		allowance: allowance,
+	}, nil
+}

--- a/insonmnia/dealer/searcher.go
+++ b/insonmnia/dealer/searcher.go
@@ -2,14 +2,16 @@ package dealer
 
 import (
 	"context"
+	"errors"
 	"math/big"
 
-	"github.com/pkg/errors"
 	"github.com/sonm-io/core/insonmnia/structs"
 	"github.com/sonm-io/core/proto"
 )
 
+// Searcher interface describes method for retrieving orders on Market|DWH.
 type Searcher interface {
+	// Search returns orders matching given filter.
 	Search(context.Context, *SearchFilter) ([]*sonm.Order, error)
 }
 
@@ -17,6 +19,8 @@ type askSearcher struct {
 	market sonm.MarketClient
 }
 
+// NewAskSearcher returns `Searcher` implementation which can search
+// for matching ASK orders for given BIDs.
 func NewAskSearcher(market sonm.MarketClient) Searcher {
 	return &askSearcher{
 		market: market,
@@ -80,7 +84,7 @@ func (s *askSearcher) filterByAllowance(orders []*sonm.Order, allowance *big.Int
 func (s *askSearcher) Search(ctx context.Context, filter *SearchFilter) ([]*sonm.Order, error) {
 	req := &sonm.GetOrdersRequest{
 		Order: filter.order,
-		Count: 100, // wow, such number, very magic
+		Count: filter.count,
 	}
 
 	// query market for orders
@@ -105,6 +109,7 @@ type SearchFilter struct {
 	order     *sonm.Order
 	balance   *big.Int
 	allowance *big.Int
+	count     uint64
 }
 
 // NewSearchFilter validates input data and constructs `SearchFilter`
@@ -125,5 +130,6 @@ func NewSearchFilter(order *sonm.Order, balance, allowance *big.Int) (*SearchFil
 		order:     order,
 		balance:   balance,
 		allowance: allowance,
+		count:     100,
 	}, nil
 }

--- a/insonmnia/dealer/searcher_test.go
+++ b/insonmnia/dealer/searcher_test.go
@@ -1,0 +1,80 @@
+package dealer
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/sonm-io/core/proto"
+	"github.com/stretchr/testify/assert"
+)
+
+var ordersForTest = []*sonm.Order{
+	{Id: "1", PricePerSecond: sonm.NewBigIntFromInt(1000), Slot: &sonm.Slot{Duration: 1}},
+	{Id: "2", PricePerSecond: sonm.NewBigIntFromInt(500), Slot: &sonm.Slot{Duration: 1}},
+	{Id: "3", PricePerSecond: sonm.NewBigIntFromInt(200), Slot: &sonm.Slot{Duration: 1}},
+	{Id: "4", PricePerSecond: sonm.NewBigIntFromInt(100), Slot: &sonm.Slot{Duration: 1}},
+}
+
+func TestAskSearcher_filterByPrice(t *testing.T) {
+	s := &askSearcher{}
+	bal := big.NewInt(250)
+
+	out, err := s.filterByPrice(ordersForTest, bal)
+	assert.NoError(t, err)
+	assert.Len(t, out, 2)
+
+	assert.Equal(t, "3", out[0].Id)
+	assert.Equal(t, "4", out[1].Id)
+}
+
+func TestAskSearcher_filterByAllowance(t *testing.T) {
+	s := &askSearcher{}
+	alw := big.NewInt(550)
+
+	out, err := s.filterByAllowance(ordersForTest, alw)
+	assert.NoError(t, err)
+	assert.Len(t, out, 3)
+
+	// first order must be filtered
+	assert.Equal(t, "2", out[0].Id)
+	assert.Equal(t, "3", out[1].Id)
+	assert.Equal(t, "4", out[2].Id)
+}
+
+func TestAskSearcher_filterNil(t *testing.T) {
+	s := &askSearcher{}
+	_, err := s.filterByPriceAndAllowance(nil, nil, nil)
+	assert.Error(t, err)
+}
+
+func TestAskSearcher_filtersChain(t *testing.T) {
+	s := &askSearcher{}
+
+	out, err := s.filterByPriceAndAllowance(ordersForTest, big.NewInt(550), big.NewInt(300))
+	assert.NoError(t, err)
+	assert.Len(t, out, 2)
+
+	out, err = s.filterByPriceAndAllowance(ordersForTest, big.NewInt(220), big.NewInt(9999))
+	assert.NoError(t, err)
+	assert.Len(t, out, 2)
+
+	out, err = s.filterByPriceAndAllowance(ordersForTest, big.NewInt(9999), big.NewInt(50))
+	assert.EqualError(t, err, "no orders fit into allowance")
+
+	out, err = s.filterByPriceAndAllowance(ordersForTest, big.NewInt(50), big.NewInt(9999))
+	assert.EqualError(t, err, "no orders fit into available balance")
+}
+
+func TestNewSearchFilter(t *testing.T) {
+	_, err := NewSearchFilter(nil, big.NewInt(1), big.NewInt(2))
+	assert.EqualError(t, err, "order cannot be nil")
+
+	_, err = NewSearchFilter(&sonm.Order{}, nil, big.NewInt(2))
+	assert.EqualError(t, err, "balance cannot be nil")
+
+	_, err = NewSearchFilter(&sonm.Order{}, big.NewInt(1), nil)
+	assert.EqualError(t, err, "allowance cannot be nil")
+
+	_, err = NewSearchFilter(&sonm.Order{}, big.NewInt(1), big.NewInt(2))
+	assert.NoError(t, err)
+}

--- a/insonmnia/structs/order.go
+++ b/insonmnia/structs/order.go
@@ -5,6 +5,7 @@ import (
 	"math/big"
 	"time"
 
+	"github.com/cnf/structhash"
 	pb "github.com/sonm-io/core/proto"
 )
 
@@ -82,4 +83,11 @@ func CalculateTotalPrice(order *pb.Order) *big.Int {
 	price := big.NewInt(0).Mul(pricePerSecond, durationInSeconds)
 
 	return price
+}
+
+// CalculateSpecHash hashes handler's order and convert hash to big.Int
+func CalculateSpecHash(order *pb.Order) string {
+	s := structhash.Md5(order.GetSlot().GetResources(), 1)
+	result := big.NewInt(0).SetBytes(s).String()
+	return result
 }


### PR DESCRIPTION
Added:
- Searcher interface that hides Market/DWH communication (now for BIDs only).
- Matcher interface that picks up the best order. Split implementations for bid and ask.
- Dealer interface that handles dealing based on two orders. Now can perform full deal cycle from Node's side.
