### PR TITLE
feat: parallel NPP and TCP listening

### DIFF
--- a/insonmnia/npp/options.go
+++ b/insonmnia/npp/options.go
@@ -17,11 +17,13 @@ type options struct {
 	log        *zap.Logger
 	puncher    NATPuncher
 	puncherNew func() (NATPuncher, error)
+	nppBacklog int
 }
 
 func newOptions(ctx context.Context) *options {
 	return &options{
-		ctx: ctx,
+		ctx:        ctx,
+		nppBacklog: 128,
 	}
 }
 
@@ -54,6 +56,14 @@ func WithRendezvous(addrs []auth.Endpoint, credentials credentials.TransportCred
 func WithLogger(log *zap.Logger) Option {
 	return func(o *options) error {
 		o.log = log
+		return nil
+	}
+}
+
+// WithNPPBacklog is an option that specifies NPP backlog size.
+func WithNPPBacklog(backlog int) Option {
+	return func(o *options) error {
+		o.nppBacklog = backlog
 		return nil
 	}
 }

--- a/insonmnia/npp/puncher.go
+++ b/insonmnia/npp/puncher.go
@@ -235,9 +235,9 @@ func (m *natPuncher) punch(ctx context.Context, addrs *sonm.RendezvousReply) (ne
 	for i := 0; i < 1+len(addrs.PrivateAddrs); i++ {
 		conn := <-pending
 
-		if conn.error != nil {
-			m.log.Info("failed to punch", zap.Error(conn.error))
-			errs = append(errs, conn.error)
+		if conn.Error() != nil {
+			m.log.Info("failed to punch", zap.Error(conn.Error()))
+			errs = append(errs, conn.Error())
 			continue
 		}
 


### PR DESCRIPTION
Changed:
- Now NPP listener allows to connect to the rendezvous asynchronously with the default TCP listening. This fixes a bug where Hub server was broken in the case of serving incoming connections.
- NPP has now exponentially backoff timeout to avoids log spamming.

Dev:
- ConnTuple now hides an error, because Zap checks for error interface explicitly.