### PR TITLE
refactor: bind node to ip socket instead of unix socket

### DIFF
--- a/cmd/cli/commands/client.go
+++ b/cmd/cli/commands/client.go
@@ -7,15 +7,15 @@ import (
 	"google.golang.org/grpc"
 )
 
-// newUnixSocketClientConn provides a single point for gPRC's ClientConn configuration.
+// newClientConn provides a single point for gPRC's ClientConn configuration.
 //
 // Note that `timeoutFlag` and `nodeAddressFlag` are set implicitly because it is global for all CLI-related stuff.
-func newUnixSocketClientConn(ctx context.Context) (*grpc.ClientConn, error) {
-	return xgrpc.NewUnencryptedUnixSocketClient(ctx, nodeAddressFlag, timeoutFlag)
+func newClientConn(ctx context.Context) (*grpc.ClientConn, error) {
+	return xgrpc.NewClient(ctx, nodeAddressFlag, nil)
 }
 
 func newHubManagementClient(ctx context.Context) (pb.HubManagementClient, error) {
-	cc, err := newUnixSocketClientConn(ctx)
+	cc, err := newClientConn(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -24,7 +24,7 @@ func newHubManagementClient(ctx context.Context) (pb.HubManagementClient, error)
 }
 
 func newMarketClient(ctx context.Context) (pb.MarketClient, error) {
-	cc, err := newUnixSocketClientConn(ctx)
+	cc, err := newClientConn(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -33,7 +33,7 @@ func newMarketClient(ctx context.Context) (pb.MarketClient, error) {
 }
 
 func newDealsClient(ctx context.Context) (pb.DealManagementClient, error) {
-	cc, err := newUnixSocketClientConn(ctx)
+	cc, err := newClientConn(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -42,7 +42,7 @@ func newDealsClient(ctx context.Context) (pb.DealManagementClient, error) {
 }
 
 func newTaskClient(ctx context.Context) (pb.TaskManagementClient, error) {
-	cc, err := newUnixSocketClientConn(ctx)
+	cc, err := newClientConn(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/cli/commands/common.go
+++ b/cmd/cli/commands/common.go
@@ -49,7 +49,7 @@ var (
 )
 
 func init() {
-	rootCmd.PersistentFlags().StringVar(&nodeAddressFlag, "node", "/var/run/sonm_node.sock", "node socket")
+	rootCmd.PersistentFlags().StringVar(&nodeAddressFlag, "node", "localhost:15030", "node endpoint")
 	rootCmd.PersistentFlags().DurationVar(&timeoutFlag, "timeout", 60*time.Second, "Connection timeout")
 	rootCmd.PersistentFlags().StringVar(&outputModeFlag, "out", "", "Output mode: simple or json")
 

--- a/cmd/node/main.go
+++ b/cmd/node/main.go
@@ -58,7 +58,6 @@ func run() {
 
 	go util.StartPrometheus(ctx, cfg.MetricsListenAddr())
 
-	log.G(ctx).Info("starting node", zap.String("socket_path", cfg.SocketPath()))
 	if err := n.Serve(); err != nil {
 		log.G(ctx).Error("node termination", zap.Error(err))
 		os.Exit(1)

--- a/etc/node.yaml
+++ b/etc/node.yaml
@@ -1,7 +1,7 @@
 # Local Node settings
 node:
-  # socket path to bind Node's gRPC endpoint, required
-  socket_path: "/var/run/sonm_node.sock"
+  # Node's port to listen for client connection
+  bind_port: 15030
 
 # Marketplace service settings
 market:

--- a/insonmnia/node/config.go
+++ b/insonmnia/node/config.go
@@ -9,8 +9,8 @@ import (
 
 // Config is LocalNode config
 type Config interface {
-	// SocketPath is path to socket file that Node binds to
-	SocketPath() string
+	// BindPort is port to listen for client connection at localhost
+	BindPort() uint16
 	// MarketEndpoint is Marketplace gRPC endpoint
 	MarketEndpoint() string
 	// HubEndpoint is Hub's gRPC endpoint (not required)
@@ -27,7 +27,7 @@ type Config interface {
 }
 
 type nodeConfig struct {
-	SocketPath string `yaml:"socket_path" default:"/var/run/sonm_node.sock"`
+	BindPort uint16 `yaml:"bind_port" default:"15030"`
 }
 
 type marketConfig struct {
@@ -57,8 +57,8 @@ type yamlConfig struct {
 	MetricsListenAddrConfig string             `yaml:"metrics_listen_addr" default:"127.0.0.1:14003"`
 }
 
-func (y *yamlConfig) SocketPath() string {
-	return y.Node.SocketPath
+func (y *yamlConfig) BindPort() uint16 {
+	return y.Node.BindPort
 }
 
 func (y *yamlConfig) MarketEndpoint() string {

--- a/util/xgrpc/client.go
+++ b/util/xgrpc/client.go
@@ -1,9 +1,6 @@
 package xgrpc
 
 import (
-	"net"
-	"time"
-
 	"github.com/grpc-ecosystem/go-grpc-middleware/tracing/opentracing"
 	"github.com/opentracing/basictracer-go"
 	"github.com/opentracing/opentracing-go"
@@ -22,7 +19,7 @@ func newTracer() opentracing.Tracer {
 }
 
 // NewClient creates new gRPC client connection on given addr and wraps it
-// with given credentials.
+// with given credentials (if provided).
 func NewClient(ctx context.Context, addr string, creds credentials.TransportCredentials, opts ...grpc.DialOption) (*grpc.ClientConn, error) {
 	var secureOpt = grpc.WithInsecure()
 	if creds != nil {
@@ -40,21 +37,6 @@ func NewClient(ctx context.Context, addr string, creds credentials.TransportCred
 		return nil, err
 	}
 	return cc, err
-}
-
-func NewUnencryptedUnixSocketClient(ctx context.Context, p string, timeout time.Duration) (*grpc.ClientConn, error) {
-	opts := []grpc.DialOption{
-		grpc.WithInsecure(),
-		grpc.WithCompressor(grpc.NewGZIPCompressor()),
-		grpc.WithDecompressor(grpc.NewGZIPDecompressor()),
-		grpc.WithUnaryInterceptor(grpc_opentracing.UnaryClientInterceptor(grpc_opentracing.WithTracer(newTracer()))),
-		grpc.WithStreamInterceptor(grpc_opentracing.StreamClientInterceptor()),
-		grpc.WithDialer(func(_ string, _ time.Duration) (net.Conn, error) {
-			return net.DialTimeout("unix", p, timeout)
-		}),
-	}
-
-	return grpc.DialContext(ctx, p, opts...)
 }
 
 func NewWalletAuthenticatedClient(ctx context.Context, creds credentials.TransportCredentials, endpoint string, opts ...grpc.DialOption) (*grpc.ClientConn, error) {


### PR DESCRIPTION
Changed:
- Node binds to IP socket.
- Node's config accepts only port number, binds always to localhost (ipv6 and ipv4).
- CLI connects to Node via unencrypted gRPC connection.

Removed:
- `NewUnencryptedUnixSocketClient` because it becomes completely useless.