### PR TITLE
refactor: adopt extracted router, fix cycle import issues.

### DIFF
--- a/insonmnia/gateway/router.go
+++ b/insonmnia/gateway/router.go
@@ -2,10 +2,6 @@
 
 package gateway
 
-import (
-	"github.com/sonm-io/core/insonmnia/gateway"
-)
-
 type Route struct {
 	ID          string
 	Protocol    string
@@ -35,7 +31,7 @@ type Router interface {
 	// Deregister deregisters a virtual service specified by the given ID.
 	Deregister(ID string) error
 	// GetMetrics returns gateway-specific metrics.
-	GetMetrics() (*gateway.Metrics, error)
+	GetMetrics() (*Metrics, error)
 	// Close closes the router, freeing all associated resources.
 	Close() error
 }
@@ -55,8 +51,8 @@ func (r *directRouter) Deregister(ID string) error {
 	return nil
 }
 
-func (r *directRouter) GetMetrics() (*gateway.Metrics, error) {
-	return &gateway.Metrics{}, nil
+func (r *directRouter) GetMetrics() (*Metrics, error) {
+	return &Metrics{}, nil
 }
 
 func (r *directRouter) Close() error {

--- a/insonmnia/gateway/router_nonlinux.go
+++ b/insonmnia/gateway/router_nonlinux.go
@@ -4,10 +4,8 @@ package gateway
 
 import (
 	"context"
-
-	"github.com/sonm-io/core/insonmnia/gateway"
 )
 
-func newIPVSRouter(context.Context, *gateway.Gateway, *gateway.PortPool) Router {
+func newIPVSRouter(context.Context, *Gateway, *PortPool) Router {
 	return newDirectRouter()
 }


### PR DESCRIPTION
I'm accidentally found this issue when running `go vet ./...`.