### PR TITLE
chore: mailmap

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,8 @@
+Alex Nikonov <alex@sshaman.ru>
+Andrew Zavgorodny <oopcode@yandex.ru> Andrew Zavgorodniy <a.o.zavgorodny@gmail.com>
+Anton Matveenko <antmat@mail.ru> <antmat@me.com>
+Anton Tiurin <noxiouz@yandex.ru> Anton Tyurin
+Antony Shchukin <szwtdy@gmail.com> Anton Shchukin
+DoctorCotic <neonneoxin60@outlook.com> <doctorcotic@MacBook-Pro-Anastasiya.local>
+DoctorCotic <neonneoxin60@outlook.com> <neonnneoxin60@outlook.com>
+DoctorCotic <neonneoxin60@outlook.com> <neonneoxin60@outlook.com>


### PR DESCRIPTION
Used for tools like `git shortlog -se` to work properly.