### PR TITLE
fix: check errors, trim whitespaces

### DIFF
--- a/insonmnia/rendezvous/resolve.go
+++ b/insonmnia/rendezvous/resolve.go
@@ -1,6 +1,7 @@
 package rendezvous
 
 import (
+	"bytes"
 	"fmt"
 	"io/ioutil"
 	"net"
@@ -69,5 +70,9 @@ func (m *externalResolver) resolve() (net.IP, error) {
 	}
 
 	addr, err := ioutil.ReadAll(resp.Body)
-	return net.ParseIP(string(addr)), nil
+	if err != nil {
+		return nil, err
+	}
+
+	return net.ParseIP(string(bytes.TrimSpace(addr))), nil
 }


### PR DESCRIPTION
Fixed:
- No longer eat an error returned while reading body.
- Trim whitespaces in the body response.