### PR TITLE
feat: load benchmarks list externally

### DIFF
--- a/etc/worker.yaml
+++ b/etc/worker.yaml
@@ -57,6 +57,9 @@ locator:
 store:
   path: "/var/lib/sonm/worker.boltdb"
 
+benchmarks:
+  url: "https://raw.githubusercontent.com/sonm-io/allowed-list/master/benchmarks_list.json"
+
 metrics_listen_addr: "127.0.0.1:14001"
 
 plugins:

--- a/insonmnia/benchmarks/benchmarks.go
+++ b/insonmnia/benchmarks/benchmarks.go
@@ -1,7 +1,14 @@
 package benchmarks
 
 import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/noxiouz/zapctx/ctxlog"
 	pb "github.com/sonm-io/core/proto"
+	"go.uber.org/zap"
 )
 
 const (
@@ -17,29 +24,80 @@ const (
 )
 
 type BenchList interface {
-	List() (map[pb.DeviceType][]*pb.Benchmark, error)
+	List() map[pb.DeviceType][]*pb.Benchmark
 }
 
-type dumbBenchmark struct{}
-
-// NewDumbBenchmarks returns becnhmark list that contains nothing.
-func NewDumbBenchmarks() BenchList {
-	return &dumbBenchmark{}
+type benchmarkList struct {
+	data map[pb.DeviceType][]*pb.Benchmark
 }
 
-func (db *dumbBenchmark) List() (map[pb.DeviceType][]*pb.Benchmark, error) {
-	return map[pb.DeviceType][]*pb.Benchmark{}, nil
+func (bl *benchmarkList) load(ctx context.Context, url string) error {
+	ctxlog.G(ctx).Debug("updating benchmarks list")
+
+	resp, err := http.Get(url)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("failed to download benchmarks list: got %s status", resp.Status)
+	}
+
+	data := make(map[string]*pb.Benchmark)
+
+	decoder := json.NewDecoder(resp.Body)
+	if err := decoder.Decode(&data); err != nil {
+		return fmt.Errorf("cannot decode JSON response: %v", err)
+	}
+
+	for code, bench := range data {
+		key := bench.GetType()
+		bench.Code = code
+
+		_, ok := bl.data[key]
+		if ok {
+			bl.data[key] = append(bl.data[key], bench)
+		} else {
+			bl.data[key] = []*pb.Benchmark{bench}
+		}
+	}
+
+	ctxlog.G(ctx).Debug("received benchmarks list", zap.Any("data", bl.data))
+
+	return nil
+}
+
+// NewBenchmarksList returns benchmark list from external storage.
+func NewBenchmarksList(ctx context.Context, cfg Config) (BenchList, error) {
+	ls := &benchmarkList{
+		data: make(map[pb.DeviceType][]*pb.Benchmark),
+	}
+
+	if err := ls.load(ctx, cfg.URL); err != nil {
+		return nil, err
+	}
+
+	return ls, nil
+}
+
+func (bl *benchmarkList) List() map[pb.DeviceType][]*pb.Benchmark {
+	return bl.data
 }
 
 // ResultJSON describes results of single benchmark.
 type ResultJSON struct {
-	Result      uint64 `json:"result"`
-	DeviceID    string `json:"device_id"`
-	BenchmarkID string `json:"benchmark_id"`
+	Result   uint64 `json:"result"`
+	DeviceID string `json:"device_id"`
 }
 
 // ContainerBenchmarkResultsJSON describes JSON structure which container
 // must return as result of one or many benchmarks.
+// Maps benchmark code to result struct
 type ContainerBenchmarkResultsJSON struct {
-	Results map[uint64]*ResultJSON `json:"results"`
+	Results map[string]*ResultJSON `json:"results"`
+}
+
+type Config struct {
+	URL string `yaml:"url" required:"true"`
 }

--- a/insonmnia/hub/server_test.go
+++ b/insonmnia/hub/server_test.go
@@ -43,7 +43,7 @@ func getTestMiner(mock *gomock.Controller) (*miner.Miner, error) {
 	ovs.EXPECT().Info(gomock.Any()).AnyTimes().Return(map[string]miner.ContainerMetrics{}, nil)
 
 	bl := benchmarks.NewMockBenchList(mock)
-	bl.EXPECT().List().AnyTimes().Return(map[pb.DeviceType][]*pb.Benchmark{}, nil)
+	bl.EXPECT().List().AnyTimes().Return(map[pb.DeviceType][]*pb.Benchmark{})
 
 	return miner.NewMiner(
 		cfg,

--- a/insonmnia/miner/cgroup_test.go
+++ b/insonmnia/miner/cgroup_test.go
@@ -26,6 +26,8 @@ locator:
   endpoint: "8125721C2413d99a33E351e1F6Bb4e56b6b633FD@127.0.0.1:9090"
 logging:
   level: debug
+benchmarks:
+  url: "http://localhost.dev/list.json"
 `
 	err := createTestConfigFile(raw)
 	assertions.NoError(err)

--- a/insonmnia/miner/config.go
+++ b/insonmnia/miner/config.go
@@ -5,6 +5,7 @@ import (
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/pkg/errors"
 	"github.com/sonm-io/core/accounts"
+	"github.com/sonm-io/core/insonmnia/benchmarks"
 	"github.com/sonm-io/core/insonmnia/logging"
 	"github.com/sonm-io/core/insonmnia/miner/plugin"
 	"go.uber.org/zap/zapcore"
@@ -63,6 +64,7 @@ type config struct {
 	MetricsListenAddrConfig string              `yaml:"metrics_listen_addr" default:"127.0.0.1:14001"`
 	PluginsConfig           plugin.Config       `yaml:"plugins"`
 	StoreConfig             storeConfig         `yaml:"store"`
+	BenchConfig             benchmarks.Config   `yaml:"benchmarks"`
 	DevConfig               *DevConfig          `yaml:"yes_i_want_to_use_dev-only_features"`
 }
 
@@ -120,6 +122,10 @@ func (c *config) StorePath() string {
 
 func (c *config) StoreBucket() string {
 	return c.StoreConfig.Bucket
+}
+
+func (c *config) Benchmarks() benchmarks.Config {
+	return c.BenchConfig
 }
 
 func (c *config) validate() error {
@@ -189,6 +195,8 @@ type Config interface {
 	MetricsListenAddr() string
 	// Plugins returns plugins settings.
 	Plugins() plugin.Config
+	// Benchmarks returns benchmarking settings.
+	Benchmarks() benchmarks.Config
 	// DevAddr to listen on. For dev purposes only!
 	Dev() *DevConfig
 }

--- a/insonmnia/miner/config_test.go
+++ b/insonmnia/miner/config_test.go
@@ -31,6 +31,8 @@ locator:
   endpoint: "8125721C2413d99a33E351e1F6Bb4e56b6b633FD@127.0.0.1:9090"
 logging:
   level: warn
+benchmarks:
+  url: "http://localhost.dev/list.json"
 `
 	err := createTestConfigFile(raw)
 	assert.Nil(t, err)
@@ -52,6 +54,8 @@ hub:
   endpoints: ["127.0.0.1:10002"]
 locator:
   endpoint: "8125721C2413d99a33E351e1F6Bb4e56b6b633FD@127.0.0.1:9090"
+benchmarks:
+  url: "http://localhost.dev/list.json"
 `
 	err := createTestConfigFile(raw)
 	assert.Nil(t, err)
@@ -71,9 +75,11 @@ hub:
   endpoints: ["127.0.0.1:10002"]
 locator:
   endpoint: "8125721C2413d99a33E351e1F6Bb4e56b6b633FD@127.0.0.1:9090"
+benchmarks:
+  url: "http://localhost.dev/list.json"
+
 plugins:
   socket_dir: /tmp/run/test-plugins
-
   volume:
     root: /my/random/dir
     volumes:

--- a/insonmnia/miner/server_test.go
+++ b/insonmnia/miner/server_test.go
@@ -12,6 +12,7 @@ import (
 	ethcrypto "github.com/ethereum/go-ethereum/crypto"
 	"github.com/golang/mock/gomock"
 	accounts "github.com/sonm-io/core/accounts"
+	"github.com/sonm-io/core/insonmnia/benchmarks"
 	"github.com/sonm-io/core/insonmnia/miner/plugin"
 	pb "github.com/sonm-io/core/proto"
 	"github.com/sonm-io/core/util"
@@ -54,7 +55,14 @@ func defaultMockCfg(mock *gomock.Controller) *MockConfig {
 	cfg.EXPECT().Plugins().AnyTimes().Return(plugin.Config{})
 	cfg.EXPECT().StorePath().AnyTimes().Return("/tmp/sonm/worker_test.boltdb")
 	cfg.EXPECT().StoreBucket().AnyTimes().Return("sonm")
+	cfg.EXPECT().Benchmarks().AnyTimes().Return(benchmarks.Config{})
 	return cfg
+}
+
+func newMockBench(ctrl *gomock.Controller) benchmarks.BenchList {
+	ls := benchmarks.NewMockBenchList(ctrl)
+	ls.EXPECT().List().AnyTimes().Return(map[pb.DeviceType][]*pb.Benchmark{})
+	return ls
 }
 
 func TestMinerInfo(t *testing.T) {
@@ -68,7 +76,7 @@ func TestMinerInfo(t *testing.T) {
 	info["id1"] = ContainerMetrics{mem: types.MemoryStats{Usage: 42, MaxUsage: 43}}
 	ovs.EXPECT().Info(gomock.Any()).AnyTimes().Return(info, nil)
 
-	m, err := NewMiner(cfg, WithKey(key), WithOverseer(ovs))
+	m, err := NewMiner(cfg, WithKey(key), WithOverseer(ovs), WithBenchmarkList(newMockBench(mock)))
 	t.Log(err)
 	require.NotNil(t, m)
 	require.Nil(t, err)


### PR DESCRIPTION
Added:
- Able to configure URL for list loading.
- `BenchList` now have an implementation that loads it from external storage.

Changed:
- Container result's JSON now identified by the `code` field, not an ID (go cannot use numbers as map keys for JSON).