### PR TITLE
feat: read memory limit from CGroup

### DIFF
--- a/insonmnia/cgroups/cgroup_linux.go
+++ b/insonmnia/cgroups/cgroup_linux.go
@@ -30,7 +30,6 @@ func (c *cgroup) Stats() (*Stats, error) {
 }
 
 func (c *cgroup) New(name string, resources *specs.LinuxResources) (CGroup, error) {
-	resources.Memory.Swap = new(int64)
 	control, err := c.Cgroup.New(name, resources)
 	if err != nil {
 		return nil, err

--- a/insonmnia/cgroups/cgroup_nonlinux.go
+++ b/insonmnia/cgroups/cgroup_nonlinux.go
@@ -1,6 +1,6 @@
 // +build !linux
 
-package miner
+package cgroups
 
 import (
 	"github.com/opencontainers/runtime-spec/specs-go"
@@ -10,6 +10,6 @@ const (
 	platformSupportCGroups = false
 )
 
-func initializeControlGroup(name string, resources *specs.LinuxResources) (cGroup, error) {
+func initializeControlGroup(name string, resources *specs.LinuxResources) (CGroup, error) {
 	return &nilCgroup{}, nil
 }

--- a/insonmnia/hardware/hardware.go
+++ b/insonmnia/hardware/hardware.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/cnf/structhash"
-	"github.com/sonm-io/core/insonmnia/cgroups"
 	"github.com/sonm-io/core/insonmnia/hardware/cpu"
 	"github.com/sonm-io/core/insonmnia/hardware/mem"
 	"github.com/sonm-io/core/proto"
@@ -47,7 +46,7 @@ type Hardware struct {
 
 // NewHardware returns initial hardware capabilities for Worker's host.
 // Parts of the struct may be filled later by HW-plugins.
-func NewHardware(cg cgroups.CGroup) (*Hardware, error) {
+func NewHardware() (*Hardware, error) {
 	hw := &Hardware{
 		Memory:  &MemoryProperties{Benchmark: make(map[uint64]*sonm.Benchmark)},
 		Network: &NetworkProperties{Benchmark: make(map[uint64]*sonm.Benchmark)},
@@ -66,7 +65,7 @@ func NewHardware(cg cgroups.CGroup) (*Hardware, error) {
 		})
 	}
 
-	vm, err := mem.NewMemoryDevice(cg)
+	vm, err := mem.NewMemoryDevice()
 	if err != nil {
 		return nil, err
 	}

--- a/insonmnia/hardware/marshal.go
+++ b/insonmnia/hardware/marshal.go
@@ -1,8 +1,8 @@
 package hardware
 
 import (
-	"github.com/shirou/gopsutil/mem"
 	"github.com/sonm-io/core/insonmnia/hardware/cpu"
+	"github.com/sonm-io/core/insonmnia/hardware/mem"
 	"github.com/sonm-io/core/proto"
 )
 
@@ -24,7 +24,7 @@ func (h *Hardware) IntoProto() *sonm.Capabilities {
 	}
 }
 
-func MemoryIntoProto(m *mem.VirtualMemoryStat) *sonm.RAMDevice {
+func MemoryIntoProto(m *mem.Device) *sonm.RAMDevice {
 	return &sonm.RAMDevice{
 		Total: m.Total,
 		Used:  m.Used,

--- a/insonmnia/hardware/marshal.go
+++ b/insonmnia/hardware/marshal.go
@@ -27,6 +27,5 @@ func (h *Hardware) IntoProto() *sonm.Capabilities {
 func MemoryIntoProto(m *mem.Device) *sonm.RAMDevice {
 	return &sonm.RAMDevice{
 		Total: m.Total,
-		Used:  m.Used,
 	}
 }

--- a/insonmnia/hardware/mem/device.go
+++ b/insonmnia/hardware/mem/device.go
@@ -2,37 +2,20 @@ package mem
 
 import (
 	"github.com/shirou/gopsutil/mem"
-	"github.com/sonm-io/core/insonmnia/cgroups"
 )
 
 type Device struct {
-	Used  uint64 `json:"used"`
+	// Total is total mem present on the host system
 	Total uint64 `json:"total"`
+	// Available is available mem for tasks scheduling
+	Available uint64 `json:"available"`
 }
 
-func getTotal(m *mem.VirtualMemoryStat, cg cgroups.CGroup) uint64 {
-	hostMem := m.Total
-
-	cgStat, err := cg.Stats()
-	if err != nil {
-		// cannot read mem limit from cGroup,
-		// return amount of memory available for host system
-		return hostMem
-	}
-
-	if hostMem > cgStat.MemoryLimit {
-		return cgStat.MemoryLimit
-	} else {
-		return hostMem
-	}
-}
-
-func NewMemoryDevice(cg cgroups.CGroup) (*Device, error) {
+func NewMemoryDevice() (*Device, error) {
 	m, err := mem.VirtualMemory()
 	if err != nil {
 		return nil, err
 	}
 
-	total := getTotal(m, cg)
-	return &Device{Used: m.Used, Total: total}, err
+	return &Device{Total: m.Total}, err
 }

--- a/insonmnia/hardware/mem/device.go
+++ b/insonmnia/hardware/mem/device.go
@@ -1,18 +1,38 @@
 package mem
 
-type Device interface {
-	// PhysicalId returns device's physical id on the motherboard.
-	PhysicalId() int
-	// DeviceName returns device name for example "DIMM DDR3 1333 MHz (0.8 ns)".
-	DeviceName() string
-	// Vendor returns vendor name.
-	VendorName() string
-	// MemorySize returns memory size in bytes.
-	MemorySize() uint64
-	// Width returns device's bus width in bits.
-	Width() uint64
-	// ClockFrequency returns a memory device clock frequency in Hz.
-	ClockFrequency() uint64
+import (
+	"github.com/shirou/gopsutil/mem"
+	"github.com/sonm-io/core/insonmnia/cgroups"
+)
+
+type Device struct {
+	Used  uint64 `json:"used"`
+	Total uint64 `json:"total"`
 }
 
-// On other platforms get just MemorySize
+func getTotal(m *mem.VirtualMemoryStat, cg cgroups.CGroup) uint64 {
+	hostMem := m.Total
+
+	cgStat, err := cg.Stats()
+	if err != nil {
+		// cannot read mem limit from cGroup,
+		// return amount of memory available for host system
+		return hostMem
+	}
+
+	if hostMem > cgStat.MemoryLimit {
+		return cgStat.MemoryLimit
+	} else {
+		return hostMem
+	}
+}
+
+func NewMemoryDevice(cg cgroups.CGroup) (*Device, error) {
+	m, err := mem.VirtualMemory()
+	if err != nil {
+		return nil, err
+	}
+
+	total := getTotal(m, cg)
+	return &Device{Used: m.Used, Total: total}, err
+}

--- a/insonmnia/hub/server.go
+++ b/insonmnia/hub/server.go
@@ -812,6 +812,7 @@ func (h *Hub) Close() {
 	if h.certRotator != nil {
 		h.certRotator.Close()
 	}
+	h.worker.Close()
 	h.waiter.Wait()
 }
 

--- a/insonmnia/miner/options.go
+++ b/insonmnia/miner/options.go
@@ -77,10 +77,3 @@ func WithBenchmarkList(list benchmarks.BenchList) Option {
 	}
 
 }
-
-func makeCgroupManager(cfg *ResourcesConfig) (cGroup, cGroupManager, error) {
-	if !platformSupportCGroups || cfg == nil {
-		return newNilCgroupManager()
-	}
-	return newCgroupManager(cfg.Cgroup, cfg.Resources)
-}

--- a/insonmnia/miner/server.go
+++ b/insonmnia/miner/server.go
@@ -15,7 +15,9 @@ import (
 	"github.com/docker/docker/pkg/stdcopy"
 	"github.com/docker/go-connections/nat"
 	log "github.com/noxiouz/zapctx/ctxlog"
+	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/pkg/errors"
+	"github.com/sonm-io/core/insonmnia/cgroups"
 	"github.com/sonm-io/core/insonmnia/miner/gpu"
 
 	// todo: drop alias
@@ -65,8 +67,8 @@ type Miner struct {
 	containers map[string]*ContainerInfo
 
 	channelCounter int
-	controlGroup   cGroup
-	cGroupManager  cGroupManager
+	controlGroup   cgroups.CGroup
+	cGroupManager  cgroups.CGroupManager
 	ssh            SSH
 	state          *state
 	benchmarkList  bm.BenchList
@@ -97,12 +99,19 @@ func NewMiner(cfg Config, opts ...Option) (m *Miner, err error) {
 		}
 	}
 
-	hardwareInfo, err := hardware.NewHardware()
+	cgName := ""
+	var cgRes *specs.LinuxResources
+	if cfg.HubResources() != nil {
+		cgName = cfg.HubResources().Cgroup
+		cgRes = cfg.HubResources().Resources
+	}
+
+	cgroup, cGroupManager, err := cgroups.NewCgroupManager(cgName, cgRes)
 	if err != nil {
 		return nil, err
 	}
 
-	cgroup, cGroupManager, err := makeCgroupManager(cfg.HubResources())
+	hardwareInfo, err := hardware.NewHardware(cgroup)
 	if err != nil {
 		return nil, err
 	}
@@ -110,10 +119,6 @@ func NewMiner(cfg Config, opts ...Option) (m *Miner, err error) {
 	state, err := NewState(o.ctx, cfg)
 	if err != nil {
 		return nil, err
-	}
-
-	if !platformSupportCGroups && cfg.HubResources() != nil {
-		log.G(o.ctx).Warn("your platform does not support CGroup, but the config has resources section")
 	}
 
 	if err := o.setupNetworkOptions(cfg); err != nil {
@@ -390,7 +395,7 @@ func (m *Miner) Start(ctx context.Context, request *pb.MinerStartRequest) (*pb.M
 		return nil, status.Errorf(codes.Unauthenticated, "invalid public key provided %v", err)
 	}
 
-	cgroup, resourceHandle, err := m.consume(request.GetOrderId(), resources)
+	cGroup, resourceHandle, err := m.consume(request.GetOrderId(), resources)
 	if err != nil {
 		return nil, status.Errorf(codes.ResourceExhausted, "failed to start %v", err)
 	}
@@ -417,7 +422,7 @@ func (m *Miner) Start(ctx context.Context, request *pb.MinerStartRequest) (*pb.M
 		Registry:      request.Container.Registry,
 		Auth:          request.Container.Auth,
 		RestartPolicy: transformRestartPolicy(request.RestartPolicy),
-		Resources:     resources.ToContainerResources(cgroup.Suffix()),
+		Resources:     resources.ToContainerResources(cGroup.Suffix()),
 		DealId:        request.GetOrderId(),
 		TaskId:        request.Id,
 		CommitOnStop:  request.Container.CommitOnStop,
@@ -495,12 +500,13 @@ func (m *Miner) Start(ctx context.Context, request *pb.MinerStartRequest) (*pb.M
 	return &reply, nil
 }
 
-func (m *Miner) consume(orderId string, resources *structs.TaskResources) (cGroup, resourceHandle, error) {
+func (m *Miner) consume(orderId string, resources *structs.TaskResources) (cgroups.CGroup, resourceHandle, error) {
 	cgroup, err := m.cGroupManager.Attach(orderId, resources.ToCgroupResources())
-	if err != nil && err != errCgroupAlreadyExists {
+	if err != nil && err != cgroups.ErrCgroupAlreadyExists {
 		return nil, nil, err
 	}
-	if err != errCgroupAlreadyExists {
+
+	if err != cgroups.ErrCgroupAlreadyExists {
 		return cgroup, &nilResourceHandle{}, nil
 	}
 
@@ -768,7 +774,7 @@ func (m *Miner) runRAMBenchGroup(benches []*pb.Benchmark) error {
 		if ben.GetID() == bm.RamSize {
 			b := &pb.Benchmark{
 				ID:     bm.RamSize,
-				Result: m.hardware.AvailableMemory(),
+				Result: m.hardware.Memory.Device.Total,
 			}
 
 			m.hardware.Memory.Benchmark[bm.RamSize] = b

--- a/insonmnia/miner/server.go
+++ b/insonmnia/miner/server.go
@@ -111,9 +111,18 @@ func NewMiner(cfg Config, opts ...Option) (m *Miner, err error) {
 		return nil, err
 	}
 
-	hardwareInfo, err := hardware.NewHardware(cgroup)
+	hardwareInfo, err := hardware.NewHardware()
 	if err != nil {
 		return nil, err
+	}
+
+	// check if memory is limited into cgroup
+	if s, err := cgroup.Stats(); err == nil {
+		if s.MemoryLimit < hardwareInfo.Memory.Device.Total {
+			hardwareInfo.Memory.Device.Available = s.MemoryLimit
+		}
+	} else {
+		hardwareInfo.Memory.Device.Available = hardwareInfo.Memory.Device.Total
 	}
 
 	state, err := NewState(o.ctx, cfg)

--- a/insonmnia/resource/pool.go
+++ b/insonmnia/resource/pool.go
@@ -89,7 +89,7 @@ func (p *Pool) pollConsume(usage *Resources) error {
 
 	free := NewResources(
 		p.OS.LogicalCPUCount()-p.usage.NumCPUs,
-		int64(p.OS.Memory.Device.Total)-p.usage.Memory,
+		int64(p.OS.Memory.Device.Available)-p.usage.Memory,
 		len(p.OS.GPU)-p.usage.NumGPUs,
 	)
 


### PR DESCRIPTION
Previously we used total amount RAM on the host system as an available memory for scheduling.
But resources for containers may be limited by a parent CGroup settings.

This PR changes how available memory amount is measured.
The lesser value of `total RAM on host, a limit set for CGroup`
is used.

Changed:
- CGroups management code moved into a separated package to prevent cycle imports issue.
- `insonmnia/hardware/mem` package was updated to unify the hardware descriptions.
- CGroup interface extended with `Stats` method, used to get an internal cgroup stats for various resources.