### PR TITLE
refactor: npp config overhaul

### DIFF
--- a/cmd/relay/main.go
+++ b/cmd/relay/main.go
@@ -18,7 +18,7 @@ var (
 )
 
 func start() {
-	cfg, err := relay.NewConfig(cfgPath)
+	cfg, err := relay.NewServerConfig(cfgPath)
 	if err != nil {
 		fmt.Printf("Failed to load config file: %s\r\n", err)
 		os.Exit(1)

--- a/cmd/rv/main.go
+++ b/cmd/rv/main.go
@@ -22,7 +22,7 @@ var (
 )
 
 func start() {
-	cfg, err := rendezvous.NewConfig(cfgPath)
+	cfg, err := rendezvous.NewServerConfig(cfgPath)
 	if err != nil {
 		fmt.Printf("failed to load config file: %s\r\n", err)
 		os.Exit(1)

--- a/insonmnia/auth/addr.go
+++ b/insonmnia/auth/addr.go
@@ -80,6 +80,21 @@ func (m Addr) String() string {
 	return m.netAddr
 }
 
+func (m *Addr) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var addr string
+	if err := unmarshal(&addr); err != nil {
+		return err
+	}
+
+	value, err := NewAddr(addr)
+	if err != nil {
+		return fmt.Errorf("cannot convert `%s` into an `auth.Addr` address - %s", addr, err)
+	}
+
+	*m = *value
+	return nil
+}
+
 func errInvalidETHAddressFormat() error {
 	return fmt.Errorf("invalid Ethereum address format")
 }

--- a/insonmnia/hub/server.go
+++ b/insonmnia/hub/server.go
@@ -265,19 +265,9 @@ func New(ctx context.Context, cfg *Config, opts ...Option) (*Hub, error) {
 func (h *Hub) Serve() error {
 	h.startTime = time.Now()
 
-	rendezvousEndpoints, err := h.cfg.NPP.Rendezvous.ConvertEndpoints()
-	if err != nil {
-		return err
-	}
-
-	relayEndpoints, err := h.cfg.NPP.Relay.ConvertEndpoints()
-	if err != nil {
-		return err
-	}
-
 	grpcL, err := npp.NewListener(h.ctx, h.cfg.Endpoint,
-		npp.WithRendezvous(rendezvousEndpoints, h.creds),
-		npp.WithRelay(relayEndpoints, h.ethKey),
+		npp.WithRendezvous(h.cfg.NPP.Rendezvous.Endpoints, h.creds),
+		npp.WithRelay(h.cfg.NPP.Relay.Endpoints, h.ethKey),
 		npp.WithLogger(log.G(h.ctx)),
 	)
 	if err != nil {

--- a/insonmnia/node/hub.go
+++ b/insonmnia/node/hub.go
@@ -25,19 +25,12 @@ type hubAPI struct {
 }
 
 func (h *hubAPI) getClient() (pb.HubClient, io.Closer, error) {
-	rendezvousEndpoints, err := h.remotes.conf.NPPConfig().Rendezvous.ConvertEndpoints()
-	if err != nil {
-		return nil, nil, err
-	}
-
-	relayEndpoints, err := h.remotes.conf.NPPConfig().Relay.ConvertEndpoints()
-	if err != nil {
-		return nil, nil, err
-	}
-
 	hubETH := crypto.PubkeyToAddress(h.remotes.key.PublicKey)
 
-	dial, err := npp.NewDialer(h.ctx, npp.WithRendezvous(rendezvousEndpoints, h.remotes.creds), npp.WithRelayClient(relayEndpoints, hubETH))
+	dial, err := npp.NewDialer(h.ctx,
+		npp.WithRendezvous(h.remotes.conf.NPPConfig().Rendezvous.Endpoints, h.remotes.creds),
+		npp.WithRelayClient(h.remotes.conf.NPPConfig().Relay.Endpoints, hubETH),
+	)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/insonmnia/npp/config.go
+++ b/insonmnia/npp/config.go
@@ -1,46 +1,11 @@
 package npp
 
 import (
-	"net"
-
-	"github.com/sonm-io/core/insonmnia/auth"
+	"github.com/sonm-io/core/insonmnia/npp/relay"
+	"github.com/sonm-io/core/insonmnia/rendezvous"
 )
 
-type RendezvousConfig struct {
-	Endpoints []string
-}
-
-func (m *RendezvousConfig) ConvertEndpoints() ([]auth.Addr, error) {
-	var endpoints []auth.Addr
-	for _, endpoint := range m.Endpoints {
-		addr, err := auth.NewAddr(endpoint)
-		if err != nil {
-			return nil, err
-		}
-		endpoints = append(endpoints, *addr)
-	}
-
-	return endpoints, nil
-}
-
-type RelayConfig struct {
-	Endpoints []string
-}
-
-func (m *RelayConfig) ConvertEndpoints() ([]net.Addr, error) {
-	var endpoints []net.Addr
-	for _, endpoint := range m.Endpoints {
-		addr, err := net.ResolveTCPAddr("tcp", endpoint)
-		if err != nil {
-			return nil, err
-		}
-		endpoints = append(endpoints, addr)
-	}
-
-	return endpoints, nil
-}
-
 type Config struct {
-	Rendezvous RendezvousConfig
-	Relay      RelayConfig
+	Rendezvous rendezvous.Config `yaml:"rendezvous"`
+	Relay      relay.Config      `yaml:"relay"`
 }

--- a/insonmnia/npp/options.go
+++ b/insonmnia/npp/options.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/sonm-io/core/insonmnia/auth"
 	"github.com/sonm-io/core/insonmnia/npp/relay"
+	"github.com/sonm-io/core/util/netutil"
 	"go.uber.org/zap"
 	"google.golang.org/grpc/credentials"
 )
@@ -77,7 +78,7 @@ func WithNPPBacklog(backlog int) Option {
 //
 // Without this option no intermediate server will be used for relaying
 // TCP.
-func WithRelay(addrs []net.Addr, key *ecdsa.PrivateKey) Option {
+func WithRelay(addrs []netutil.TCPAddr, key *ecdsa.PrivateKey) Option {
 	return func(o *options) error {
 		signedAddr, err := relay.NewSignedAddr(key)
 		if err != nil {
@@ -86,7 +87,7 @@ func WithRelay(addrs []net.Addr, key *ecdsa.PrivateKey) Option {
 
 		o.relayNew = func() (net.Conn, error) {
 			for _, addr := range addrs {
-				conn, err := relay.Listen(addr, signedAddr)
+				conn, err := relay.Listen(&addr, signedAddr)
 				if err == nil {
 					return conn, nil
 				}
@@ -99,11 +100,11 @@ func WithRelay(addrs []net.Addr, key *ecdsa.PrivateKey) Option {
 	}
 }
 
-func WithRelayClient(addrs []net.Addr, target common.Address) Option {
+func WithRelayClient(addrs []netutil.TCPAddr, target common.Address) Option {
 	return func(o *options) error {
 		o.relayNew = func() (net.Conn, error) {
 			for _, addr := range addrs {
-				conn, err := relay.Dial(addr, target, "")
+				conn, err := relay.Dial(&addr, target, "")
 				if err == nil {
 					return conn, nil
 				}

--- a/insonmnia/npp/relay/server.go
+++ b/insonmnia/npp/relay/server.go
@@ -135,7 +135,7 @@ func (m *connPool) popRandom() *meeting {
 }
 
 type server struct {
-	cfg Config
+	cfg ServerConfig
 
 	port     netutil.Port
 	listener net.Listener
@@ -164,7 +164,7 @@ type server struct {
 
 // NewServer constructs a new relay server using specified config with
 // options.
-func NewServer(cfg Config, options ...Option) (*server, error) {
+func NewServer(cfg ServerConfig, options ...Option) (*server, error) {
 	opts := newOptions()
 
 	for _, o := range options {

--- a/insonmnia/rendezvous/server.go
+++ b/insonmnia/rendezvous/server.go
@@ -105,7 +105,7 @@ func randomPeerCandidate(candidates map[PeerID]peerCandidate) *peerCandidate {
 // This server is responsible for tracking servers and clients to make them
 // meet each other.
 type Server struct {
-	cfg      Config
+	cfg      ServerConfig
 	log      *zap.Logger
 	server   *grpc.Server
 	resolver resolver
@@ -121,7 +121,7 @@ type Server struct {
 // WithCredentials option.
 // Also it is possible to activate logging system by passing a logger using
 // WithLogger function as an option.
-func NewServer(cfg Config, options ...Option) (*Server, error) {
+func NewServer(cfg ServerConfig, options ...Option) (*Server, error) {
 	opts := newOptions()
 	for _, option := range options {
 		option(opts)

--- a/util/netutil/net.go
+++ b/util/netutil/net.go
@@ -1,6 +1,7 @@
 package netutil
 
 import (
+	"fmt"
 	"net"
 	"strconv"
 )
@@ -38,4 +39,25 @@ func ExtractHost(hostport string) (net.IP, error) {
 func ExtractPort(hostport string) (Port, error) {
 	_, port, err := SplitHostPort(hostport)
 	return port, err
+}
+
+// TCPAddr wraps net.TCPAddr allowing to initialize itself using YAML
+// unmarshaller.
+type TCPAddr struct {
+	net.TCPAddr
+}
+
+func (m *TCPAddr) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var addr string
+	if err := unmarshal(&addr); err != nil {
+		return err
+	}
+
+	tcpAddr, err := net.ResolveTCPAddr("tcp", addr)
+	if err != nil {
+		return fmt.Errorf("cannot convert `%s` into a TCP address - %s", addr, err)
+	}
+
+	m.TCPAddr = *tcpAddr
+	return nil
 }


### PR DESCRIPTION
Changed:
- Use self-unpackable structs as a building blocks for configurations. This includes `TCPAddr` and `auth.Addr`.

Removed:
- No longer used convertions.