### PR TITLE
refactor: logging configuration

### DIFF
--- a/cmd/hub/main.go
+++ b/cmd/hub/main.go
@@ -72,7 +72,7 @@ func run() {
 		os.Exit(1)
 	}
 
-	h, err := hub.New(ctx, cfg, hub.WithVersion(appVersion), hub.WithContext(ctx),
+	h, err := hub.New(cfg, hub.WithVersion(appVersion), hub.WithContext(ctx),
 		hub.WithPrivateKey(key), hub.WithCreds(creds), hub.WithCertRotator(certRotator), hub.WithWorker(w))
 	if err != nil {
 		log.G(ctx).Error("failed to create a new Hub", zap.Error(err))

--- a/cmd/relay/main.go
+++ b/cmd/relay/main.go
@@ -24,7 +24,7 @@ func start() {
 		os.Exit(1)
 	}
 
-	ctx := log.WithLogger(context.Background(), logging.BuildLogger(cfg.LogLevel()))
+	ctx := log.WithLogger(context.Background(), logging.BuildLogger(cfg.Logging.Level))
 
 	options := []relay.Option{
 		relay.WithLogger(log.G(ctx)),

--- a/cmd/rv/main.go
+++ b/cmd/rv/main.go
@@ -28,7 +28,7 @@ func start() {
 		os.Exit(1)
 	}
 
-	ctx := log.WithLogger(context.Background(), logging.BuildLogger(cfg.LogLevel()))
+	ctx := log.WithLogger(context.Background(), logging.BuildLogger(cfg.Logging.Level))
 
 	certRotator, TLSConfig, err := util.NewHitlessCertRotator(ctx, cfg.PrivateKey)
 	if err != nil {

--- a/etc/worker.yaml
+++ b/etc/worker.yaml
@@ -17,12 +17,6 @@
 #    network:
 #      classID: 1048577
 
-# Logging settings.
-logging:
-  # The desired logging level.
-  # Allowed values are "debug", "info", "warn", "error", "panic" and "fatal"
-  level: debug
-
 # A list of IPs that can be used to reach the miner, optional param. If not provided, miner's interfaces will
 # be scanned for such IPs (if there's no firewall settings).
 # Ignored if firewall settings are not null.

--- a/insonmnia/hub/config.go
+++ b/insonmnia/hub/config.go
@@ -7,12 +7,10 @@ import (
 	"github.com/sonm-io/core/accounts"
 	"github.com/sonm-io/core/insonmnia/logging"
 	"github.com/sonm-io/core/insonmnia/npp"
-	"go.uber.org/zap/zapcore"
 )
 
 type LoggingConfig struct {
-	Level       string `required:"true" default:"debug"`
-	parsedLevel zapcore.Level
+	Level logging.Level `yaml:"level" required:"true" default:"debug"`
 }
 
 type WhitelistConfig struct {
@@ -31,8 +29,8 @@ type Config struct {
 	NPP               npp.Config
 }
 
-func (c *Config) LogLevel() zapcore.Level {
-	return c.Logging.parsedLevel
+func (c *Config) LogLevel() logging.Level {
+	return c.Logging.Level
 }
 
 // NewConfig loads a hub config from the specified YAML file.
@@ -42,12 +40,6 @@ func NewConfig(path string) (*Config, error) {
 	if err != nil {
 		return nil, err
 	}
-
-	lvl, err := logging.ParseLogLevel(conf.Logging.Level)
-	if err != nil {
-		return nil, err
-	}
-	conf.Logging.parsedLevel = lvl
 
 	return conf, nil
 }

--- a/insonmnia/hub/config_test.go
+++ b/insonmnia/hub/config_test.go
@@ -78,7 +78,7 @@ market:
 	conf, err := NewConfig(testHubConfigPath)
 	assert.Nil(t, err)
 
-	assert.Equal(t, zapcore.InfoLevel, conf.LogLevel())
+	assert.Equal(t, zapcore.InfoLevel, conf.LogLevel().Zap())
 }
 
 func TestLoadConfigInvalidLogLevel(t *testing.T) {

--- a/insonmnia/hub/server.go
+++ b/insonmnia/hub/server.go
@@ -78,7 +78,7 @@ type Hub struct {
 }
 
 // New returns new Hub.
-func New(ctx context.Context, cfg *Config, opts ...Option) (*Hub, error) {
+func New(cfg *Config, opts ...Option) (*Hub, error) {
 	defaults := defaultHubOptions()
 	for _, o := range opts {
 		o(defaults)

--- a/insonmnia/hub/server_test.go
+++ b/insonmnia/hub/server_test.go
@@ -92,7 +92,7 @@ func buildTestHub(ctrl *gomock.Controller) (*Hub, error) {
 	bc := blockchain.NewMockBlockchainer(ctrl)
 	bc.EXPECT().GetDealInfo(ctx, gomock.Any()).AnyTimes().Return(&pb.Deal{}, nil)
 
-	return New(ctx, config, WithPrivateKey(key), WithMarket(market), WithBlockchain(bc), WithWorker(worker))
+	return New(config, WithPrivateKey(key), WithMarket(market), WithBlockchain(bc), WithWorker(worker))
 }
 
 //TODO: Move this to separate test for AskPlans

--- a/insonmnia/logging/logging_test.go
+++ b/insonmnia/logging/logging_test.go
@@ -24,7 +24,7 @@ func TestParseLogLevel(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		out, err := ParseLogLevel(tt.in)
+		out, err := parseLogLevel(tt.in)
 		if tt.mustFail {
 			assert.Error(t, err)
 		} else {

--- a/insonmnia/miner/config.go
+++ b/insonmnia/miner/config.go
@@ -7,7 +7,6 @@ import (
 	"github.com/sonm-io/core/insonmnia/logging"
 	"github.com/sonm-io/core/insonmnia/miner/plugin"
 	"github.com/sonm-io/core/insonmnia/state"
-	"go.uber.org/zap/zapcore"
 )
 
 type SSHConfig struct {
@@ -16,8 +15,7 @@ type SSHConfig struct {
 }
 
 type LoggingConfig struct {
-	Level       string `required:"true" default:"debug"`
-	parsedLevel zapcore.Level
+	Level logging.Level `required:"true" default:"debug"`
 }
 
 type ResourcesConfig struct {
@@ -33,10 +31,6 @@ type config struct {
 	PluginsConfig   plugin.Config       `yaml:"plugins"`
 	StoreConfig     state.StorageConfig `yaml:"store"`
 	BenchConfig     benchmarks.Config   `yaml:"benchmarks"`
-}
-
-func (c *config) LogLevel() zapcore.Level {
-	return c.LoggingConfig.parsedLevel
 }
 
 func (c *config) HubResources() *ResourcesConfig {
@@ -72,19 +66,11 @@ func NewConfig(path string) (Config, error) {
 		return nil, err
 	}
 
-	lvl, err := logging.ParseLogLevel(cfg.LoggingConfig.Level)
-	if err != nil {
-		return nil, err
-	}
-	cfg.LoggingConfig.parsedLevel = lvl
-
 	return cfg, nil
 }
 
 // Config represents a Miner configuration interface.
 type Config interface {
-	logging.Leveler
-
 	// HubResources returns resources allocated for a Hub.
 	HubResources() *ResourcesConfig
 	// PublicIPs returns all IPs that can be used to communicate with the miner.

--- a/insonmnia/miner/config_test.go
+++ b/insonmnia/miner/config_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"go.uber.org/zap/zapcore"
 )
 
 const (
@@ -27,8 +26,6 @@ func TestLoadConfig(t *testing.T) {
 hub:
   eth_addr: "8125721C2413d99a33E351e1F6Bb4e56b6b633FD"
   endpoints: ["127.0.0.1:10002"]
-logging:
-  level: warn
 benchmarks:
   url: "http://localhost.dev/list.json"
 `
@@ -38,7 +35,6 @@ benchmarks:
 	conf, err := NewConfig(testMinerConfigPath)
 	assert.Nil(t, err)
 
-	assert.Equal(t, zapcore.WarnLevel, conf.LogLevel())
 	assert.Equal(t, "/var/lib/sonm/worker.boltdb", conf.Storage().Endpoint)
 	assert.Equal(t, "sonm", conf.Storage().Bucket)
 }

--- a/insonmnia/node/config.go
+++ b/insonmnia/node/config.go
@@ -5,7 +5,6 @@ import (
 	"github.com/sonm-io/core/accounts"
 	"github.com/sonm-io/core/insonmnia/logging"
 	"github.com/sonm-io/core/insonmnia/npp"
-	"go.uber.org/zap/zapcore"
 )
 
 // Config is LocalNode config
@@ -42,8 +41,7 @@ type hubConfig struct {
 }
 
 type logConfig struct {
-	Level       string `required:"true" default:"debug" yaml:"level"`
-	parsedLevel zapcore.Level
+	Level logging.Level `yaml:"level" required:"true" default:"debug"`
 }
 
 type yamlConfig struct {
@@ -79,8 +77,8 @@ func (y *yamlConfig) HubEndpoint() string {
 	return ""
 }
 
-func (y *yamlConfig) LogLevel() zapcore.Level {
-	return y.Log.parsedLevel
+func (y *yamlConfig) LogLevel() logging.Level {
+	return y.Log.Level
 }
 
 func (y *yamlConfig) KeyStore() string {
@@ -104,11 +102,5 @@ func NewConfig(path string) (Config, error) {
 		return nil, err
 	}
 
-	lvl, err := logging.ParseLogLevel(cfg.Log.Level)
-	if err != nil {
-		return nil, err
-	}
-
-	cfg.Log.parsedLevel = lvl
 	return cfg, nil
 }

--- a/insonmnia/npp/relay/config.go
+++ b/insonmnia/npp/relay/config.go
@@ -10,7 +10,6 @@ import (
 	"github.com/sonm-io/core/accounts"
 	"github.com/sonm-io/core/insonmnia/logging"
 	"github.com/sonm-io/core/util/netutil"
-	"go.uber.org/zap/zapcore"
 )
 
 // ClusterConfig represents a cluster membership config.
@@ -24,8 +23,7 @@ type ClusterConfig struct {
 
 // LoggingConfig represents a logging config.
 type LoggingConfig struct {
-	Level string `required:"true" default:"debug"`
-	level zapcore.Level
+	Level logging.Level `required:"true" default:"debug"`
 }
 
 type MonitorConfig struct {
@@ -61,12 +59,6 @@ func NewServerConfig(path string) (*ServerConfig, error) {
 		return nil, err
 	}
 
-	lvl, err := logging.ParseLogLevel(cfg.Logging.Level)
-	if err != nil {
-		return nil, err
-	}
-	cfg.Logging.level = lvl
-
 	if len(cfg.Cluster.Name) == 0 {
 		hostname, err := os.Hostname()
 		if err != nil {
@@ -90,11 +82,6 @@ func NewServerConfig(path string) (*ServerConfig, error) {
 			PrivateKey: privateKey,
 		},
 	}, nil
-}
-
-// LogLevel returns the minimum logging level configured.
-func (c *ServerConfig) LogLevel() zapcore.Level {
-	return c.Logging.level
 }
 
 // Config represents a client-side relay configuration.

--- a/insonmnia/npp/rendezvous/config.go
+++ b/insonmnia/npp/rendezvous/config.go
@@ -9,13 +9,11 @@ import (
 	"github.com/sonm-io/core/insonmnia/auth"
 	"github.com/sonm-io/core/insonmnia/logging"
 	"github.com/sonm-io/core/util/netutil"
-	"go.uber.org/zap/zapcore"
 )
 
 // LoggingConfig represents a logging config.
 type LoggingConfig struct {
-	Level string `required:"true" default:"debug"`
-	level zapcore.Level
+	Level logging.Level
 }
 
 // ServerConfig represents a Rendezvous server configuration.
@@ -24,11 +22,6 @@ type ServerConfig struct {
 	Addr       net.Addr
 	PrivateKey *ecdsa.PrivateKey
 	Logging    LoggingConfig
-}
-
-// LogLevel returns the minimum logging level configured.
-func (c *ServerConfig) LogLevel() zapcore.Level {
-	return c.Logging.level
 }
 
 type serverConfig struct {
@@ -49,12 +42,6 @@ func NewServerConfig(path string) (*ServerConfig, error) {
 	if err != nil {
 		return nil, err
 	}
-
-	lvl, err := logging.ParseLogLevel(cfg.Logging.Level)
-	if err != nil {
-		return nil, err
-	}
-	cfg.Logging.level = lvl
 
 	return &ServerConfig{
 		Addr:       &cfg.Addr,


### PR DESCRIPTION
Added:
- Explicit log level configuration struct that can be used as a building block for constructing configurations. It is parsable from YAML and throws errors at the parsing stage, avoiding doing additional checks.

Changed:
- Constructing a new Hub no longer requires a context parameter, because it was anyway ignored.
- Remove logging section from worker config. Hub's and Worker configs should be merged in the nearest future.