### PR TITLE
feat: auto request/response validation

### DIFF
--- a/insonmnia/hub/server.go
+++ b/insonmnia/hub/server.go
@@ -169,6 +169,7 @@ func New(cfg *miner.Config, opts ...Option) (*Hub, error) {
 		xgrpc.Credentials(h.creds),
 		xgrpc.DefaultTraceInterceptor(),
 		xgrpc.AuthorizationInterceptor(authorization),
+		xgrpc.VerifyInterceptor(),
 	)
 	h.externalGrpc = grpcServer
 

--- a/insonmnia/node/server.go
+++ b/insonmnia/node/server.go
@@ -149,6 +149,7 @@ func New(ctx context.Context, c Config, key *ecdsa.PrivateKey) (*Node, error) {
 		// Intentionally constructing an unencrypted server.
 		xgrpc.DefaultTraceInterceptor(),
 		xgrpc.UnaryServerInterceptor(hub.(*hubAPI).intercept),
+		xgrpc.VerifyInterceptor(),
 	)
 
 	pb.RegisterHubManagementServer(srv, hub)

--- a/insonmnia/npp/relay/monitor.go
+++ b/insonmnia/npp/relay/monitor.go
@@ -36,6 +36,7 @@ func newMonitor(cfg MonitorConfig, cluster *memberlist.Memberlist, metrics *metr
 	server := xgrpc.NewServer(log,
 		xgrpc.Credentials(credentials),
 		xgrpc.DefaultTraceInterceptor(),
+		xgrpc.VerifyInterceptor(),
 	)
 
 	m := &monitor{

--- a/insonmnia/npp/rendezvous/server.go
+++ b/insonmnia/npp/rendezvous/server.go
@@ -134,6 +134,7 @@ func NewServer(cfg ServerConfig, options ...Option) (*Server, error) {
 			opts.log,
 			xgrpc.Credentials(opts.credentials),
 			xgrpc.DefaultTraceInterceptor(),
+			xgrpc.VerifyInterceptor(),
 		),
 		resolver: newExternalResolver(""),
 		rv:       map[string]*meeting{},
@@ -148,10 +149,6 @@ func NewServer(cfg ServerConfig, options ...Option) (*Server, error) {
 }
 
 func (m *Server) Resolve(ctx context.Context, request *sonm.ConnectRequest) (*sonm.RendezvousReply, error) {
-	if err := request.Validate(); err != nil {
-		return nil, err
-	}
-
 	peerInfo, ok := peer.FromContext(ctx)
 	if !ok {
 		return nil, errNoPeerInfo()


### PR DESCRIPTION
This commit activates gRPC request/response auto-validation by injecting an interceptor.
Those requests/responses that require validation can optionally implement an implicit `Validate() error` function that will be called before request starts being processed and before response passed to the gRPC internals.