### PR TITLE
fix: workaround configor weird logging parsing

### DIFF
--- a/cmd/relay/main.go
+++ b/cmd/relay/main.go
@@ -24,7 +24,7 @@ func start() {
 		os.Exit(1)
 	}
 
-	ctx := log.WithLogger(context.Background(), logging.BuildLogger(cfg.Logging.Level))
+	ctx := log.WithLogger(context.Background(), logging.BuildLogger(cfg.Logging.LogLevel()))
 
 	options := []relay.Option{
 		relay.WithLogger(log.G(ctx)),

--- a/cmd/rv/main.go
+++ b/cmd/rv/main.go
@@ -28,7 +28,7 @@ func start() {
 		os.Exit(1)
 	}
 
-	ctx := log.WithLogger(context.Background(), logging.BuildLogger(cfg.Logging.Level))
+	ctx := log.WithLogger(context.Background(), logging.BuildLogger(cfg.Logging.LogLevel()))
 
 	certRotator, TLSConfig, err := util.NewHitlessCertRotator(ctx, cfg.PrivateKey)
 	if err != nil {

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -35,7 +35,7 @@ func run() {
 		os.Exit(1)
 	}
 
-	logger := logging.BuildLogger(cfg.Logging.Level)
+	logger := logging.BuildLogger(cfg.Logging.LogLevel())
 	ctx = log.WithLogger(ctx, logger)
 
 	key, err := cfg.Eth.LoadKey()

--- a/insonmnia/logging/config.go
+++ b/insonmnia/logging/config.go
@@ -2,5 +2,9 @@ package logging
 
 // Config represents a logging config.
 type Config struct {
-	Level Level `yaml:"level" required:"true" default:"info"`
+	Level *Level `yaml:"level" required:"true" default:"info"`
+}
+
+func (m *Config) LogLevel() Level {
+	return *m.Level
 }

--- a/insonmnia/logging/logging.go
+++ b/insonmnia/logging/logging.go
@@ -41,7 +41,7 @@ type Level struct {
 
 // Zap returns the underlying zap logging level.
 func (m Level) Zap() zapcore.Level {
-	return m.level - 1
+	return m.level
 }
 
 func (m *Level) UnmarshalYAML(unmarshal func(interface{}) error) error {
@@ -55,7 +55,7 @@ func (m *Level) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		return err
 	}
 
-	m.level = v + 1
+	m.level = v
 
 	return nil
 }

--- a/insonmnia/node/config.go
+++ b/insonmnia/node/config.go
@@ -40,15 +40,11 @@ type hubConfig struct {
 	Endpoint string `required:"false" yaml:"endpoint"`
 }
 
-type logConfig struct {
-	Level logging.Level `yaml:"level" required:"true" default:"debug"`
-}
-
 type yamlConfig struct {
 	Node                    nodeConfig         `yaml:"node"`
 	NPPCfg                  npp.Config         `yaml:"npp"`
 	Market                  marketConfig       `required:"true" yaml:"market"`
-	Log                     logConfig          `yaml:"log"`
+	Log                     logging.Config     `yaml:"log"`
 	Eth                     accounts.EthConfig `required:"false" yaml:"ethereum"`
 	Hub                     *hubConfig         `required:"false" yaml:"hub"`
 	MetricsListenAddrConfig string             `yaml:"metrics_listen_addr" default:"127.0.0.1:14003"`
@@ -78,7 +74,7 @@ func (y *yamlConfig) HubEndpoint() string {
 }
 
 func (y *yamlConfig) LogLevel() logging.Level {
-	return y.Log.Level
+	return y.Log.LogLevel()
 }
 
 func (y *yamlConfig) KeyStore() string {


### PR DESCRIPTION
Suddenly configor parses the config into each struct twice: once for loading from file, and once while processing tags.

If a field has default value (all types in go has default value, and this is terrible) equaled with the same value specified in the config, and at the same - has required attribute - configor blows up.

To avoid this I specified logging level as a pointer. Now levels should load nicely, but still all this looks weird.