### PR TITLE
chore: drop unused options from Hub

### DIFF
--- a/insonmnia/hub/options.go
+++ b/insonmnia/hub/options.go
@@ -4,10 +4,7 @@ import (
 	"crypto/ecdsa"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/sonm-io/core/blockchain"
 	"github.com/sonm-io/core/insonmnia/miner"
-	"github.com/sonm-io/core/insonmnia/state"
-	pb "github.com/sonm-io/core/proto"
 	"github.com/sonm-io/core/util"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc/credentials"
@@ -19,12 +16,9 @@ type options struct {
 	ctx     context.Context
 	ethKey  *ecdsa.PrivateKey
 	ethAddr common.Address
-	bcr     blockchain.Blockchainer
-	market  pb.MarketClient
 	creds   credentials.TransportCredentials
 	rot     util.HitlessCertRotator
 	worker  *miner.Miner
-	storage *state.Storage
 }
 
 func defaultHubOptions() *options {
@@ -39,18 +33,6 @@ type Option func(options *options)
 func WithContext(ctx context.Context) Option {
 	return func(o *options) {
 		o.ctx = ctx
-	}
-}
-
-func WithBlockchain(bcr blockchain.Blockchainer) Option {
-	return func(o *options) {
-		o.bcr = bcr
-	}
-}
-
-func WithMarket(mp pb.MarketClient) Option {
-	return func(o *options) {
-		o.market = mp
 	}
 }
 

--- a/insonmnia/hub/server.go
+++ b/insonmnia/hub/server.go
@@ -12,7 +12,6 @@ import (
 	log "github.com/noxiouz/zapctx/ctxlog"
 	"github.com/pborman/uuid"
 	"github.com/pkg/errors"
-	"github.com/sonm-io/core/blockchain"
 	"github.com/sonm-io/core/insonmnia/auth"
 	"github.com/sonm-io/core/insonmnia/miner"
 	"github.com/sonm-io/core/insonmnia/npp"
@@ -103,13 +102,6 @@ func New(cfg *miner.Config, opts ...Option) (*Hub, error) {
 			cancel()
 		}
 	}()
-
-	if defaults.bcr == nil {
-		defaults.bcr, err = blockchain.NewAPI_DEPRECATED()
-		if err != nil {
-			return nil, err
-		}
-	}
 
 	if len(cfg.Whitelist.PrivilegedAddresses) == 0 {
 		cfg.Whitelist.PrivilegedAddresses = append(cfg.Whitelist.PrivilegedAddresses, defaults.ethAddr.Hex())

--- a/insonmnia/hub/server_test.go
+++ b/insonmnia/hub/server_test.go
@@ -7,7 +7,6 @@ import (
 
 	ethcrypto "github.com/ethereum/go-ethereum/crypto"
 	"github.com/golang/mock/gomock"
-	"github.com/sonm-io/core/blockchain"
 	"github.com/sonm-io/core/insonmnia/benchmarks"
 	"github.com/sonm-io/core/insonmnia/miner"
 	"github.com/sonm-io/core/insonmnia/miner/plugin"
@@ -55,37 +54,11 @@ func getTestKey() *ecdsa.PrivateKey {
 	return k
 }
 
-func getTestMarket(ctrl *gomock.Controller) pb.MarketClient {
-	m := pb.NewMockMarketClient(ctrl)
-
-	ord := &pb.Order{
-		Id:             "my-order-id",
-		OrderType:      pb.OrderType_BID,
-		PricePerSecond: pb.NewBigIntFromInt(1000),
-		ByuerID:        addr.Hex(),
-		Slot: &pb.Slot{
-			Resources: &pb.Resources{},
-		},
-	}
-	// TODO: fix this - it does not really call create order or cancel order
-	m.EXPECT().CreateOrder(gomock.Any(), gomock.Any()).AnyTimes().
-		Return(ord, nil).AnyTimes()
-	m.EXPECT().CancelOrder(gomock.Any(), gomock.Any()).AnyTimes().
-		Return(&pb.Empty{}, nil).AnyTimes()
-	return m
-}
-
 func buildTestHub(ctrl *gomock.Controller) (*Hub, error) {
-	market := getTestMarket(ctrl)
 	config := defaultMinerMockCfg()
 	worker, _ := getTestMiner(ctrl)
 
-	ctx := context.Background()
-
-	bc := blockchain.NewMockBlockchainer(ctrl)
-	bc.EXPECT().GetDealInfo(ctx, gomock.Any()).AnyTimes().Return(&pb.Deal{}, nil)
-
-	return New(config, WithPrivateKey(key), WithMarket(market), WithBlockchain(bc), WithWorker(worker))
+	return New(config, WithPrivateKey(key), WithWorker(worker))
 }
 
 //TODO: Move this to separate test for AskPlans


### PR DESCRIPTION
This PR removes useless blockchain, marketplace and
state storage clients from the Hub and their options.