### PR TITLE
fix: correctly compare an empty timestamps

### DIFF
--- a/cmd/cli/commands/printers.go
+++ b/cmd/cli/commands/printers.go
@@ -308,7 +308,7 @@ func printDealInfo(cmd *cobra.Command, deal *pb.Deal) {
 
 		cmd.Printf("Start at:     %s\r\n", start.Format(time.RFC3339))
 		cmd.Printf("End at:       %s\r\n", end.Format(time.RFC3339))
-		if !lastBill.IsZero() { // fixme: this check is not working o_O
+		if lastBill.Unix() > 0 {
 			cmd.Printf("Last bill:    %s\r\n", lastBill.Format(time.RFC3339))
 		}
 	} else {


### PR DESCRIPTION
As noticed in #686 ( [line](https://github.com/sonm-io/core/pull/686/files#diff-c6365e7cdd271a7c4c9cf1e39f85a62dR311) )