### PR TITLE
refactor: proper marshalling for EthAddress

### DIFF
--- a/proto/insonmnia.go
+++ b/proto/insonmnia.go
@@ -1,7 +1,6 @@
 package sonm
 
 import (
-	"errors"
 	"fmt"
 	"math/big"
 	"strings"
@@ -54,25 +53,19 @@ func (m *EthAddress) Unwrap() common.Address {
 	return common.BytesToAddress(m.Address)
 }
 
-func (m *EthAddress) MarshalYAML() (interface{}, error) {
-	if m != nil {
-		return m.Unwrap().Hex(), nil
-	}
-	return nil, nil
+func (m *EthAddress) MarshalText() ([]byte, error) {
+	return []byte(m.Unwrap().Hex()), nil
 }
 
-func (m *EthAddress) UnmarshalYAML(unmarshal func(interface{}) error) error {
-	var v string
-	if err := unmarshal(&v); err != nil {
-		return err
-	}
-
+func (m *EthAddress) UnmarshalText(text []byte) error {
+	v := string(text)
 	if !common.IsHexAddress(v) {
-		return errors.New("invalid ethereum address format")
+		return fmt.Errorf("invalid ethereum address format \"%s\"", v)
 	}
 
 	m.Address = common.HexToAddress(v).Bytes()
 	return nil
+
 }
 
 func (m *EthAddress) IsZero() bool {

--- a/proto/insonmnia.go
+++ b/proto/insonmnia.go
@@ -53,7 +53,7 @@ func (m *EthAddress) Unwrap() common.Address {
 	return common.BytesToAddress(m.Address)
 }
 
-func (m *EthAddress) MarshalText() ([]byte, error) {
+func (m EthAddress) MarshalText() ([]byte, error) {
 	return []byte(m.Unwrap().Hex()), nil
 }
 

--- a/proto/insonmnia_test.go
+++ b/proto/insonmnia_test.go
@@ -54,6 +54,26 @@ func TestEthAddress_MarshalText(t *testing.T) {
 		"JSON marshaller")
 }
 
+func TestEthAddress_MarshalTextByValue(t *testing.T) {
+	in := struct {
+		Addr EthAddress `yaml:"addr" json:"addr"`
+	}{}
+
+	tmp := NewEthAddress(common.HexToAddress("0x123"))
+	in.Addr = *tmp
+
+	ya, err := yaml.Marshal(in)
+	require.NoError(t, err)
+
+	assert.Equal(t, "addr: \"0x0000000000000000000000000000000000000123\"\n", string(ya),
+		"YAML marshaller")
+
+	js, err := json.Marshal(in)
+	require.NoError(t, err)
+	assert.Equal(t, `{"addr":"0x0000000000000000000000000000000000000123"}`, string(js),
+		"JSON marshaller")
+}
+
 func TestEthAddress_UnmarshalText(t *testing.T) {
 	in := []byte(`{"addr":"0x1234567891011121314151617181920212223242"}`)
 	recv := struct {

--- a/proto/insonmnia_test.go
+++ b/proto/insonmnia_test.go
@@ -1,12 +1,15 @@
 package sonm
 
 import (
+	"encoding/json"
 	"math/big"
 	"testing"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v2"
 )
 
 func TestConvertToPrice(t *testing.T) {
@@ -30,4 +33,42 @@ func TestConvertToPrice(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, tt.expected, pr.PerSecond.Unwrap())
 	}
+}
+
+func TestEthAddress_MarshalText(t *testing.T) {
+	in := struct {
+		Addr *EthAddress `yaml:"addr" json:"addr"`
+	}{
+		Addr: NewEthAddress(common.HexToAddress("0x123")),
+	}
+
+	ya, err := yaml.Marshal(in)
+	require.NoError(t, err)
+
+	assert.Equal(t, "addr: \"0x0000000000000000000000000000000000000123\"\n", string(ya),
+		"YAML marshaller")
+
+	js, err := json.Marshal(in)
+	require.NoError(t, err)
+	assert.Equal(t, `{"addr":"0x0000000000000000000000000000000000000123"}`, string(js),
+		"JSON marshaller")
+}
+
+func TestEthAddress_UnmarshalText(t *testing.T) {
+	in := []byte(`{"addr":"0x1234567891011121314151617181920212223242"}`)
+	recv := struct {
+		Addr *EthAddress `json:"addr" yaml:"addr"`
+	}{}
+
+	err := yaml.Unmarshal(in, &recv)
+	require.NoError(t, err)
+	assert.Equal(t, "0x1234567891011121314151617181920212223242", recv.Addr.Unwrap().Hex(),
+		"YAML marshall")
+
+	// reset prev value
+	recv.Addr = nil
+	err = json.Unmarshal(in, &recv)
+	require.NoError(t, err)
+	assert.Equal(t, "0x1234567891011121314151617181920212223242", recv.Addr.Unwrap().Hex(),
+		"JSON marshall")
 }


### PR DESCRIPTION
This PR implements `MarshalText` and `UnmarshalText` methods for the `EthAddress` type.
It allows satisfying both JSON and YAML marshallers requirements.