### PR TITLE
chore: add vendor to container's ENV when GPU benchmark starting

### DIFF
--- a/insonmnia/benchmarks/benchmarks.go
+++ b/insonmnia/benchmarks/benchmarks.go
@@ -24,6 +24,7 @@ const (
 
 	BenchIDEnvParamName = "SONM_BENCHMARK_ID"
 	CPUCountBenchParam  = "SONM_CPU_COUNT"
+	GPUVendorParam      = "SONM_GPU_TYPE"
 )
 
 type BenchList interface {

--- a/insonmnia/miner/server.go
+++ b/insonmnia/miner/server.go
@@ -774,8 +774,11 @@ func (m *Miner) runBenchmarkGroup(dev pb.DeviceType, benches []*pb.Benchmark) er
 			} else if len(bench.GetImage()) != 0 {
 				d := getDescriptionForBenchmark(bench)
 				d.Env[bm.CPUCountBenchParam] = fmt.Sprintf("%d", m.hardware.CPU.Device.Cores)
+
 				if gpuDevices != nil {
-					d.GPUDevices = []gpu.GPUID{gpu.GPUID(gpuDevices[idx].GetID())}
+					gpuDev := gpuDevices[idx]
+					d.Env[bm.GPUVendorParam] = gpuDev.VendorType().String()
+					d.GPUDevices = []gpu.GPUID{gpu.GPUID(gpuDev.GetID())}
 				}
 				res, err := m.execBenchmarkContainer(bench, d)
 				if err != nil {


### PR DESCRIPTION
Some of the mining software and other GPU-related stuff exists in two version:
CUDA- and OpenCL- based. We need to know what type of device is connected 
to the container, it allows us to start corresponding software to benchmark GPU properties.