### PR TITLE
fix: properly forward gRPC REST errors

### DIFF
--- a/util/rest/errors.go
+++ b/util/rest/errors.go
@@ -1,0 +1,51 @@
+package rest
+
+import (
+	"net/http"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func HTTPStatusFromError(err error) int {
+	switch err.(type) {
+	case nil:
+		return http.StatusOK
+	default:
+		s, ok := status.FromError(err)
+		if !ok {
+			return http.StatusInternalServerError
+		}
+
+		return HTTPStatusFromCode(s.Code())
+	}
+}
+
+func HTTPStatusFromCode(code codes.Code) int {
+	switch code {
+	case codes.OK:
+		return http.StatusOK
+	case codes.Canceled:
+		return http.StatusRequestTimeout
+	case codes.InvalidArgument, codes.OutOfRange:
+		return http.StatusBadRequest
+	case codes.DeadlineExceeded:
+		return http.StatusGatewayTimeout
+	case codes.NotFound:
+		return http.StatusNotFound
+	case codes.PermissionDenied:
+		return http.StatusForbidden
+	case codes.Unauthenticated:
+		return http.StatusUnauthorized
+	case codes.ResourceExhausted:
+		return http.StatusTooManyRequests
+	case codes.Unimplemented:
+		return http.StatusNotImplemented
+	case codes.Unavailable:
+		return http.StatusServiceUnavailable
+	case codes.Unknown, codes.DataLoss, codes.Internal:
+		return http.StatusInternalServerError
+	default:
+		return http.StatusInternalServerError
+	}
+}

--- a/util/rest/server.go
+++ b/util/rest/server.go
@@ -10,10 +10,9 @@ import (
 	"reflect"
 	"strings"
 
-	"golang.org/x/net/context"
-
 	"github.com/noxiouz/zapctx/ctxlog"
 	"go.uber.org/zap"
+	"golang.org/x/net/context"
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc"
 )
@@ -200,7 +199,7 @@ func (s *Server) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	}
 
 	if err != nil {
-		rw.WriteHeader(http.StatusInternalServerError)
+		rw.WriteHeader(HTTPStatusFromError(err))
 		rw.Write([]byte(err.Error()))
 	} else {
 		data, err := json.Marshal(result)


### PR DESCRIPTION
This should prevent to seeing errors like HTTP 500 when something not found.