### PR TITLE
[WIP] feat: multiple accounts for CLI

### DIFF
--- a/accounts/keys.go
+++ b/accounts/keys.go
@@ -62,7 +62,7 @@ func (o *defaultKeyOpener) OpenKeystore() (bool, error) {
 		}
 	}()
 
-	if !util.DirectoryExists(o.keyDirPath) {
+	if !util.FileExists(o.keyDirPath) {
 		return false, errNoKeystoreDir
 	}
 
@@ -206,7 +206,7 @@ func DefaultKeyOpener(p Printer, keyDir, passPhrase string) (KeyOpener, error) {
 
 	p.Printf("Using %s as KeyStore directory\r\n", keyDir)
 
-	if !util.DirectoryExists(keyDir) {
+	if !util.FileExists(keyDir) {
 		p.Printf("KeyStore directory does not exist, try to create it...\r\n")
 		err = os.MkdirAll(keyDir, 0700)
 		if err != nil {

--- a/accounts/keys.go
+++ b/accounts/keys.go
@@ -12,7 +12,10 @@ import (
 	"github.com/sonm-io/core/util"
 )
 
-const defaultKeystorePath = ".sonm/keystore/"
+const (
+	HomeConfigDir       = ".sonm"
+	DefaultKeystorePath = "keystore"
+)
 
 var (
 	errNoKeystoreDir = errors.New("keystore directory does not exist")
@@ -198,7 +201,7 @@ func DefaultKeyOpener(p Printer, keyDir, passPhrase string) (KeyOpener, error) {
 	var err error
 	// use default key store dir if not specified in config
 	if keyDir == "" {
-		keyDir, err = getDefaultKeyStorePath()
+		keyDir, err = GetDefaultKeyStoreDir()
 		if err != nil {
 			return nil, err
 		}
@@ -226,16 +229,17 @@ func DefaultKeyOpener(p Printer, keyDir, passPhrase string) (KeyOpener, error) {
 	return ko, nil
 }
 
-func getDefaultKeyStorePath() (string, error) {
+func GetDefaultKeyStoreDir() (string, error) {
 	home, err := util.GetUserHomeDir()
 	if err != nil {
 		return "", err
 	}
 
-	keyDir := path.Join(home, defaultKeystorePath)
+	keyDir := path.Join(home, HomeConfigDir, DefaultKeystorePath)
 	return keyDir, nil
 }
 
+// todo: move this code onto (c *EthConfig) LoadKey(options ...Option)
 func LoadKeys(keystore, passphrase string, options ...Option) (*ecdsa.PrivateKey, error) {
 	opts := newOptions()
 	for _, o := range options {

--- a/accounts/multi_keystore.go
+++ b/accounts/multi_keystore.go
@@ -1,0 +1,180 @@
+package accounts
+
+import (
+	"crypto/ecdsa"
+	"io/ioutil"
+	"path"
+
+	"github.com/ethereum/go-ethereum/accounts"
+	"github.com/ethereum/go-ethereum/accounts/keystore"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/pkg/errors"
+	"github.com/sonm-io/core/util"
+)
+
+const (
+	defaultStateFileName = "defaults"
+)
+
+type KeystoreConfig struct {
+	KeyDir      string
+	StateFile   string
+	PassPhrases map[string]string
+}
+
+type multiKeystore struct {
+	keysDir     string
+	stateDir    string
+	keyStore    *keystore.KeyStore
+	passReader  PassPhraser
+	knownPasses map[string]string
+}
+
+func NewMultiKeystore(cfg *KeystoreConfig, pf PassPhraser) (*multiKeystore, error) {
+	ks := keystore.NewKeyStore(
+		cfg.KeyDir,
+		keystore.LightScryptN,
+		keystore.LightScryptP,
+	)
+
+	if cfg.StateFile == "" {
+		home, err := util.GetUserHomeDir()
+		if err != nil {
+			return nil, errors.Wrap(err, "cannot get user's home dir")
+		}
+
+		cfg.StateFile = path.Join(home, ".sonm")
+	}
+
+	return &multiKeystore{
+		knownPasses: cfg.PassPhrases,
+		keysDir:     cfg.KeyDir,
+		stateDir:    cfg.StateFile,
+		keyStore:    ks,
+		passReader:  pf,
+	}, nil
+}
+
+func (m *multiKeystore) List() ([]accounts.Account, error) {
+	return m.keyStore.Accounts(), nil
+}
+
+func (m *multiKeystore) Generate() (*ecdsa.PrivateKey, error) {
+	pass, err := m.passReader.GetPassPhrase()
+	if err != nil {
+		return nil, errors.Wrap(err, "cannot read pass phrase")
+	}
+
+	acc, err := m.keyStore.NewAccount(pass)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(m.keyStore.Accounts()) == 1 {
+		// this is the first account,
+		m.setDefaultAccount(acc.Address)
+	}
+
+	return m.readAccount(acc)
+}
+
+func (m *multiKeystore) GetKeyByAddress(addr common.Address) (*ecdsa.PrivateKey, error) {
+	for _, acc := range m.keyStore.Accounts() {
+		if acc.Address.Big().Cmp(addr.Big()) == 0 {
+			return m.readAccount(acc)
+		}
+	}
+
+	return nil, errors.New("cannot find given address into keystore")
+}
+
+func (m *multiKeystore) GetDefault() (*ecdsa.PrivateKey, error) {
+	if len(m.keyStore.Accounts()) == 0 {
+		return nil, errors.New("no accounts present into keystore")
+	}
+
+	defaultAddr, err := m.getDefaultAddress()
+	if err != nil {
+		// no keys marked as default
+		return nil, errors.Wrap(err, "cannot load default key")
+	}
+
+	if !m.keyStore.HasAddress(defaultAddr) {
+		return nil, errors.New("default address was read but not present into keystore")
+	}
+
+	return m.GetKeyByAddress(defaultAddr)
+}
+
+func (m *multiKeystore) SetDefault(addr common.Address) {
+	m.setDefaultAccount(addr)
+}
+
+func (m *multiKeystore) Import(path string) (common.Address, error) {
+	if !util.DirectoryExists(path) {
+		return common.Address{}, errors.New("key file does not exists")
+	}
+
+	keyData, err := ioutil.ReadFile(path)
+	if err != nil {
+		return common.Address{}, errors.Wrap(err, "cannot read key file")
+	}
+
+	pass, err := m.passReader.GetPassPhrase()
+	if err != nil {
+		return common.Address{}, errors.Wrap(err, "cannot read pass phrase")
+	}
+
+	acc, err := m.keyStore.Import(keyData, pass, pass)
+	if err != nil {
+		return common.Address{}, errors.Wrap(err, "cannot import key file")
+	}
+
+	return acc.Address, nil
+}
+
+func (m *multiKeystore) readAccount(acc accounts.Account) (*ecdsa.PrivateKey, error) {
+	file, err := ioutil.ReadFile(acc.URL.Path)
+	if err != nil {
+		return nil, errors.Wrap(err, "cannot open account file")
+	}
+
+	var pass string
+	pass, ok := m.knownPasses[acc.Address.Hex()]
+	if !ok {
+		pass, err = m.passReader.GetPassPhrase()
+		if err != nil {
+			return nil, errors.Wrap(err, "cannot read pass phrase")
+		}
+	}
+
+	key, err := keystore.DecryptKey(file, pass)
+	if err != nil {
+		return nil, errors.Wrap(err, "cannot decrypt key with given pass phrase")
+	}
+
+	return key.PrivateKey, nil
+}
+
+func (m *multiKeystore) getDefaultAddress() (common.Address, error) {
+	stateFile := path.Join(m.stateDir, defaultStateFileName)
+	if !util.DirectoryExists(stateFile) {
+		return common.Address{}, errors.New("cannot find keystore's state")
+	}
+
+	data, err := ioutil.ReadFile(stateFile)
+	if err != nil {
+		return common.Address{}, errors.New("cannot read state file")
+	}
+
+	if !common.IsHexAddress(string(data)) {
+		return common.Address{}, errors.New("keystore's state data is malformed")
+	}
+
+	return common.HexToAddress(string(data)), nil
+}
+
+func (m *multiKeystore) setDefaultAccount(addr common.Address) {
+	stateFile := path.Join(m.stateDir, defaultStateFileName)
+	ioutil.WriteFile(stateFile, []byte(addr.Hex()), 0600)
+}

--- a/accounts/multi_keystore_test.go
+++ b/accounts/multi_keystore_test.go
@@ -2,6 +2,7 @@ package accounts
 
 import (
 	"os"
+	"path"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/crypto"
@@ -17,7 +18,7 @@ func TestGenerateFirst(t *testing.T) {
 	k, err := NewMultiKeystore(
 		&KeystoreConfig{
 			KeyDir:      testKeystoreDir,
-			StateFile:   os.TempDir(),
+			StateFile:   path.Join(os.TempDir(), "state"),
 			PassPhrases: nil,
 		},
 		NewStaticPassPhraser("test"),
@@ -49,7 +50,7 @@ func TestSetDefault(t *testing.T) {
 	k, err := NewMultiKeystore(
 		&KeystoreConfig{
 			KeyDir:      testKeystoreDir,
-			StateFile:   os.TempDir(),
+			StateFile:   path.Join(os.TempDir(), "state"),
 			PassPhrases: nil,
 		},
 		NewStaticPassPhraser("test"),
@@ -86,7 +87,7 @@ func TestAlreadyKnownPasswords(t *testing.T) {
 	k, err := NewMultiKeystore(
 		&KeystoreConfig{
 			KeyDir:      testKeystoreDir,
-			StateFile:   os.TempDir(),
+			StateFile:   path.Join(os.TempDir(), "state"),
 			PassPhrases: map[string]string{},
 		},
 		NewStaticPassPhraser("test"),
@@ -109,7 +110,7 @@ func TestAlreadyKnownPasswords(t *testing.T) {
 	anotherK, err := NewMultiKeystore(
 		&KeystoreConfig{
 			KeyDir:    testKeystoreDir,
-			StateFile: os.TempDir(),
+			StateFile: path.Join(os.TempDir(), "state"),
 			PassPhrases: map[string]string{
 				addr1.Hex(): "test",
 				addr2.Hex(): "test",
@@ -139,7 +140,7 @@ func TestImportKey(t *testing.T) {
 	k, err := NewMultiKeystore(
 		&KeystoreConfig{
 			KeyDir:      testKeystoreDir,
-			StateFile:   os.TempDir(),
+			StateFile:   path.Join(os.TempDir(), "state"),
 			PassPhrases: map[string]string{},
 		},
 		pf,
@@ -161,7 +162,7 @@ func TestImportKey(t *testing.T) {
 	newKS, err := NewMultiKeystore(
 		&KeystoreConfig{
 			KeyDir:      testKeystoreDir,
-			StateFile:   os.TempDir(),
+			StateFile:   path.Join(os.TempDir(), "state"),
 			PassPhrases: map[string]string{},
 		},
 		pf,

--- a/accounts/multi_keystore_test.go
+++ b/accounts/multi_keystore_test.go
@@ -1,0 +1,174 @@
+package accounts
+
+import (
+	"os"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testKeystoreDir = "/tmp/test/"
+)
+
+func TestGenerateFirst(t *testing.T) {
+	k, err := NewMultiKeystore(
+		&KeystoreConfig{
+			KeyDir:      testKeystoreDir,
+			StateFile:   os.TempDir(),
+			PassPhrases: nil,
+		},
+		NewStaticPassPhraser("test"),
+	)
+	require.NoError(t, err)
+
+	defer func() {
+		os.RemoveAll(testKeystoreDir)
+	}()
+
+	first, err := k.Generate()
+	require.NoError(t, err)
+	assert.NotNil(t, first)
+
+	defaultKey, err := k.GetDefault()
+	require.NoError(t, err)
+	assert.Equal(t, defaultKey, first)
+
+	randomKey, err := k.Generate()
+	require.NoError(t, err)
+	assert.NotNil(t, randomKey)
+
+	yetAnotherDefault, err := k.GetDefault()
+	require.NoError(t, err)
+	assert.NotEqual(t, randomKey, yetAnotherDefault)
+}
+
+func TestSetDefault(t *testing.T) {
+	k, err := NewMultiKeystore(
+		&KeystoreConfig{
+			KeyDir:      testKeystoreDir,
+			StateFile:   os.TempDir(),
+			PassPhrases: nil,
+		},
+		NewStaticPassPhraser("test"),
+	)
+	require.NoError(t, err)
+
+	defer func() {
+		os.RemoveAll(testKeystoreDir)
+	}()
+
+	for i := 0; i < 5; i++ {
+		_, err := k.Generate()
+		require.NoError(t, err)
+	}
+
+	ls, err := k.List()
+	require.NoError(t, err)
+	assert.Len(t, ls, 5)
+
+	defaultAddr := ls[3].Address
+	k.SetDefault(defaultAddr)
+
+	priv, err := k.GetDefault()
+	require.NoError(t, err)
+
+	assert.Equal(t, crypto.PubkeyToAddress(priv.PublicKey), defaultAddr)
+}
+
+type panicPassphrase struct{}
+
+func (panicPassphrase) GetPassPhrase() (string, error) { panic("test failed") }
+
+func TestAlreadyKnownPasswords(t *testing.T) {
+	k, err := NewMultiKeystore(
+		&KeystoreConfig{
+			KeyDir:      testKeystoreDir,
+			StateFile:   os.TempDir(),
+			PassPhrases: map[string]string{},
+		},
+		NewStaticPassPhraser("test"),
+	)
+	require.NoError(t, err)
+
+	defer func() {
+		os.RemoveAll(testKeystoreDir)
+	}()
+
+	key1, err := k.Generate()
+	require.NoError(t, err)
+	key2, err := k.Generate()
+	require.NoError(t, err)
+	key3, err := k.Generate()
+	require.NoError(t, err)
+
+	addr1, addr2, addr3 := crypto.PubkeyToAddress(key1.PublicKey), crypto.PubkeyToAddress(key2.PublicKey), crypto.PubkeyToAddress(key3.PublicKey)
+
+	anotherK, err := NewMultiKeystore(
+		&KeystoreConfig{
+			KeyDir:    testKeystoreDir,
+			StateFile: os.TempDir(),
+			PassPhrases: map[string]string{
+				addr1.Hex(): "test",
+				addr2.Hex(): "test",
+				addr3.Hex(): "test",
+			},
+		},
+		// panicPassphrase panics if called, should never happens.
+		panicPassphrase{},
+	)
+	require.NoError(t, err)
+
+	res1, err := anotherK.GetKeyByAddress(addr1)
+	require.NoError(t, err)
+	assert.Equal(t, res1, key1)
+
+	res2, err := anotherK.GetKeyByAddress(addr2)
+	require.NoError(t, err)
+	assert.Equal(t, res2, key2)
+
+	res3, err := anotherK.GetKeyByAddress(addr3)
+	require.NoError(t, err)
+	assert.Equal(t, res3, key3)
+}
+
+func TestImportKey(t *testing.T) {
+	pf := NewStaticPassPhraser("test")
+	k, err := NewMultiKeystore(
+		&KeystoreConfig{
+			KeyDir:      testKeystoreDir,
+			StateFile:   os.TempDir(),
+			PassPhrases: map[string]string{},
+		},
+		pf,
+	)
+	require.NoError(t, err)
+
+	defer func() {
+		os.RemoveAll(testKeystoreDir)
+	}()
+
+	created, err := k.Generate()
+	require.NoError(t, err)
+	createdAddr := crypto.PubkeyToAddress(created.PublicKey).Hex()
+
+	ls, err := k.List()
+	require.NoError(t, err)
+	keyPath := ls[0].URL.Path
+
+	newKS, err := NewMultiKeystore(
+		&KeystoreConfig{
+			KeyDir:      testKeystoreDir,
+			StateFile:   os.TempDir(),
+			PassPhrases: map[string]string{},
+		},
+		pf,
+	)
+	require.NoError(t, err)
+
+	addr, err := newKS.Import(keyPath)
+	require.NoError(t, err)
+	assert.Equal(t, addr.Hex(), createdAddr)
+}

--- a/accounts/multi_keystore_test.go
+++ b/accounts/multi_keystore_test.go
@@ -2,7 +2,6 @@ package accounts
 
 import (
 	"os"
-	"path"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/crypto"
@@ -18,7 +17,6 @@ func TestGenerateFirst(t *testing.T) {
 	k, err := NewMultiKeystore(
 		&KeystoreConfig{
 			KeyDir:      testKeystoreDir,
-			StateFile:   path.Join(os.TempDir(), "state"),
 			PassPhrases: nil,
 		},
 		NewStaticPassPhraser("test"),
@@ -50,7 +48,6 @@ func TestSetDefault(t *testing.T) {
 	k, err := NewMultiKeystore(
 		&KeystoreConfig{
 			KeyDir:      testKeystoreDir,
-			StateFile:   path.Join(os.TempDir(), "state"),
 			PassPhrases: nil,
 		},
 		NewStaticPassPhraser("test"),
@@ -87,7 +84,6 @@ func TestAlreadyKnownPasswords(t *testing.T) {
 	k, err := NewMultiKeystore(
 		&KeystoreConfig{
 			KeyDir:      testKeystoreDir,
-			StateFile:   path.Join(os.TempDir(), "state"),
 			PassPhrases: map[string]string{},
 		},
 		NewStaticPassPhraser("test"),
@@ -109,8 +105,7 @@ func TestAlreadyKnownPasswords(t *testing.T) {
 
 	anotherK, err := NewMultiKeystore(
 		&KeystoreConfig{
-			KeyDir:    testKeystoreDir,
-			StateFile: path.Join(os.TempDir(), "state"),
+			KeyDir: testKeystoreDir,
 			PassPhrases: map[string]string{
 				addr1.Hex(): "test",
 				addr2.Hex(): "test",
@@ -140,7 +135,6 @@ func TestImportKey(t *testing.T) {
 	k, err := NewMultiKeystore(
 		&KeystoreConfig{
 			KeyDir:      testKeystoreDir,
-			StateFile:   path.Join(os.TempDir(), "state"),
 			PassPhrases: map[string]string{},
 		},
 		pf,
@@ -162,7 +156,6 @@ func TestImportKey(t *testing.T) {
 	newKS, err := NewMultiKeystore(
 		&KeystoreConfig{
 			KeyDir:      testKeystoreDir,
-			StateFile:   path.Join(os.TempDir(), "state"),
 			PassPhrases: map[string]string{},
 		},
 		pf,

--- a/cmd/cli/commands/account.go
+++ b/cmd/cli/commands/account.go
@@ -144,6 +144,7 @@ var accountsSetDefaultCmd = &cobra.Command{
 		addr := common.HexToAddress(args[0])
 		ks := keystore.NewKeyStore(cfg.KeyStore(), keystore.LightScryptN, keystore.LightScryptP)
 		for _, acc := range ks.Accounts() {
+			// use ks.HasAddress()
 			if acc.Address.Big().Cmp(addr.Big()) == 0 {
 				setDefaultKey(acc.Address)
 				cmd.Printf("Using \"%s\" as default account\n", acc.Address.Hex())

--- a/cmd/cli/commands/common.go
+++ b/cmd/cli/commands/common.go
@@ -56,7 +56,7 @@ func init() {
 	rootCmd.PersistentFlags().BoolVar(&insecureFlag, "insecure", false, "Disable TLS for connection")
 
 	rootCmd.AddCommand(workerMgmtCmd, marketRootCmd, nodeDealsRootCmd, taskRootCmd)
-	rootCmd.AddCommand(loginCmd, getTokenCmd, getBalanceCmd, versionCmd, autoCompleteCmd, masterRootCmd)
+	rootCmd.AddCommand(accountsRootCmd, getTokenCmd, getBalanceCmd, versionCmd, autoCompleteCmd, masterRootCmd)
 }
 
 // Root configure and return root command

--- a/cmd/cli/commands/login.go
+++ b/cmd/cli/commands/login.go
@@ -13,7 +13,11 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var setImportAccountAsDefault bool
+
 func init() {
+	accountsImportCmd.PersistentFlags().BoolVar(&setImportAccountAsDefault, "as-default",
+		false, "Set imported account as default")
 	accountsRootCmd.AddCommand(
 		accountsListCmd,
 		accountsCreateCmd,
@@ -116,6 +120,10 @@ var accountsImportCmd = &cobra.Command{
 		if err != nil {
 			showError(cmd, "Cannot import account", err)
 			os.Exit(1)
+		}
+
+		if setImportAccountAsDefault {
+			setDefaultKey("/Users/alex/.sonm", acc.Address)
 		}
 
 		// TODO(sshaman1101): json-friendly

--- a/cmd/cli/commands/login.go
+++ b/cmd/cli/commands/login.go
@@ -1,41 +1,181 @@
 package commands
 
 import (
+	"fmt"
+	"io/ioutil"
 	"os"
+	"path"
 
+	"github.com/ethereum/go-ethereum/accounts/keystore"
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/sonm-io/core/accounts"
 	"github.com/sonm-io/core/util"
 	"github.com/spf13/cobra"
 )
 
-var loginCmd = &cobra.Command{
-	Use:   "login",
-	Short: "Open or generate Etherum keys",
+func init() {
+	accountsRootCmd.AddCommand(
+		accountsListCmd,
+		accountsCreateCmd,
+		accountsImportCmd,
+		accountsSetDefaultCmd,
+	)
+}
+
+var accountsRootCmd = &cobra.Command{
+	Use: "accounts",
+}
+
+var accountsListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "Show Ethereum accounts list",
 	Run: func(cmd *cobra.Command, _ []string) {
-		ko, err := accounts.DefaultKeyOpener(cmd, cfg.KeyStore(), cfg.PassPhrase())
-		if err != nil {
-			showError(cmd, "Cannot init KeyOpener", err)
-			os.Exit(1)
+		defaultAddr := getDefaultKey("/Users/alex/.sonm")
+
+		// TODO(sshaman1101): use `cfg.KeyStore()`
+		dir := "/Users/alex/.sonm/test_keystore"
+		ks := keystore.NewKeyStore(dir, keystore.LightScryptN, keystore.LightScryptP)
+
+		// TODO(sshaman1101): make if JSON-friendly
+		if len(ks.Accounts()) == 0 {
+			cmd.Println("keystore is empty")
+			return
 		}
 
-		created, err := ko.OpenKeystore()
-		if err != nil {
-			showError(cmd, "Cannot open KeyStore", err)
-			os.Exit(1)
+		for idx, acc := range ks.Accounts() {
+			prefix := "  "
+			if acc.Address.Big().Cmp(defaultAddr.Big()) == 0 {
+				prefix = "* "
+			}
+			cmd.Printf("%s%d: %s\n", prefix, idx+1, acc.Address.Hex())
 		}
-
-		if created {
-			cmd.Printf("Keystore successfully created\r\n")
-		} else {
-			cmd.Printf("Keystore successfully opened\r\n")
-		}
-
-		key, err := ko.GetKey()
-		if err != nil {
-			showError(cmd, "Cannot get key from the keystore", err)
-			os.Exit(1)
-		}
-
-		cmd.Printf("Eth address: %s\r\n", util.PubKeyToAddr(key.PublicKey).Hex())
 	},
+}
+
+var accountsCreateCmd = &cobra.Command{
+	Use:   "create",
+	Short: "Create new Ethereum account",
+	Run: func(cmd *cobra.Command, _ []string) {
+		pf := accounts.NewInteractivePassPhraser()
+		pass, err := pf.GetPassPhrase()
+		if err != nil {
+			showError(cmd, "Cannot read pass phrase", err)
+			os.Exit(1)
+		}
+
+		// TODO(sshaman1101): unhardcode path
+		dir := "/Users/alex/.sonm/test_keystore"
+		ks := keystore.NewKeyStore(dir, keystore.LightScryptN, keystore.LightScryptP)
+
+		// set key as default key it is first key in storage
+		setDefault := len(ks.Accounts()) == 0
+		acc, err := ks.NewAccount(pass)
+		if err != nil {
+			showError(cmd, "Cannot create account", err)
+			os.Exit(1)
+		}
+
+		if setDefault {
+			setDefaultKey("/Users/alex/.sonm", acc.Address)
+		}
+
+		// todo: JSON-friendly
+		cmd.Printf("New account address = %s\r\n", acc.Address.Hex())
+	},
+}
+
+var accountsImportCmd = &cobra.Command{
+	Use:   "import <key.json>",
+	Short: "Import exiting Ethereum account",
+	Args:  cobra.MinimumNArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		keyPath := args[0]
+
+		if !util.FileExists(keyPath) {
+			showError(cmd, "File not exists", nil)
+			os.Exit(1)
+		}
+
+		keyData, err := ioutil.ReadFile(keyPath)
+		if err != nil {
+			showError(cmd, "Cannot read key file", err)
+			os.Exit(1)
+		}
+
+		pf := accounts.NewInteractivePassPhraser()
+		pass, err := pf.GetPassPhrase()
+		if err != nil {
+			showError(cmd, "Cannot read pass phrase", err)
+			os.Exit(1)
+		}
+
+		dir := "/Users/alex/.sonm/test_keystore"
+		ks := keystore.NewKeyStore(dir, keystore.LightScryptN, keystore.LightScryptP)
+
+		acc, err := ks.Import(keyData, pass, pass)
+		if err != nil {
+			showError(cmd, "Cannot import account", err)
+			os.Exit(1)
+		}
+
+		// TODO(sshaman1101): json-friendly
+		cmd.Printf("Successfully imported account \"%s\"\n", acc.Address.Hex())
+	},
+}
+
+var accountsSetDefaultCmd = &cobra.Command{
+	Use:   "set-default <addr>",
+	Short: "Set default account for keystore",
+	Args:  cobra.MinimumNArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		if !common.IsHexAddress(args[0]) {
+			showError(cmd, "Given parameter is not an Ethereum address", nil)
+			os.Exit(1)
+		}
+
+		addr := common.HexToAddress(args[0])
+
+		// TODO(sshaman1101): unhardcode path
+		dir := "/Users/alex/.sonm/test_keystore"
+		ks := keystore.NewKeyStore(dir, keystore.LightScryptN, keystore.LightScryptP)
+		for _, acc := range ks.Accounts() {
+			if acc.Address.Big().Cmp(addr.Big()) == 0 {
+				setDefaultKey("/Users/alex/.sonm", acc.Address)
+				cmd.Printf("Using \"%s\" as default account\n", acc.Address.Hex())
+				return
+			}
+		}
+
+		showError(cmd, "Given address does not exists in keystore", nil)
+		os.Exit(1)
+	},
+}
+
+func getDefaultKey(p string) common.Address {
+	stateFile := path.Join(p, "context")
+	if !util.FileExists(stateFile) {
+		fmt.Printf(" >>> context file not exists\n")
+		return common.Address{}
+	}
+
+	data, err := ioutil.ReadFile(stateFile)
+	if err != nil {
+		fmt.Printf(" >>> cannot read file: %v\n", err)
+		return common.Address{}
+	}
+
+	if !common.IsHexAddress(string(data)) {
+		fmt.Printf(" >>> value is not CommonAddress \n")
+		return common.Address{}
+	}
+
+	return common.HexToAddress(string(data))
+}
+
+func setDefaultKey(p string, addr common.Address) {
+	stateFile := path.Join(p, "context")
+	fmt.Printf(" >>> writing state to %s\n", stateFile)
+	if err := ioutil.WriteFile(stateFile, []byte(addr.Hex()), 0600); err != nil {
+		fmt.Printf(" >>> cannot write state %v\n", err)
+	}
 }

--- a/cmd/cli/commands/tasks.go
+++ b/cmd/cli/commands/tasks.go
@@ -144,9 +144,14 @@ var taskStartCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
+		key, err := keystore.GetDefault()
+		if err != nil {
+			showError(cmd, "Cannot read default key", err)
+		}
+
 		deal := &pb.Deal{
 			Id:         bigDealID,
-			ConsumerID: pb.NewEthAddress(util.PubKeyToAddr(sessionKey.PublicKey)),
+			ConsumerID: pb.NewEthAddress(util.PubKeyToAddr(key.PublicKey)),
 		}
 
 		volumes := map[string]*pb.Volume{}

--- a/cmd/cli/config/config.go
+++ b/cmd/cli/config/config.go
@@ -12,7 +12,6 @@ import (
 const (
 	OutputModeSimple = "simple"
 	OutputModeJSON   = "json"
-	homeConfigDir    = ".sonm"
 	configName       = "cli.yaml"
 )
 
@@ -38,16 +37,21 @@ func (cc *cliConfig) PassPhrase() string {
 }
 
 func (cc *cliConfig) KeyStore() string {
+	if cc.Eth.Keystore == "" {
+		d, _ := accounts.GetDefaultKeyStoreDir()
+		return d
+	}
+
 	return cc.Eth.Keystore
 }
 
-func (cc *cliConfig) getDefaultConfigDir() (string, error) {
+func GetDefaultConfigDir() (string, error) {
 	currentUser, err := user.Current()
 	if err != nil {
 		return "", err
 	}
 
-	dir := path.Join(currentUser.HomeDir, homeConfigDir)
+	dir := path.Join(currentUser.HomeDir, accounts.HomeConfigDir)
 	return dir, nil
 }
 
@@ -58,7 +62,7 @@ func (cc *cliConfig) getConfigPath(p ...string) (string, error) {
 	if len(p) > 0 && p[0] != "" {
 		cfgPath = p[0]
 	} else {
-		cfgPath, err = cc.getDefaultConfigDir()
+		cfgPath, err = GetDefaultConfigDir()
 		if err != nil {
 			return "", err
 		}

--- a/util/util.go
+++ b/util/util.go
@@ -99,8 +99,8 @@ func LoadYamlFile(from string, to interface{}) error {
 	return nil
 }
 
-// DirectoryExists returns true if the given directory exists
-func DirectoryExists(p string) bool {
+// FileExists returns true if the given directory or file exists
+func FileExists(p string) bool {
 	if _, err := os.Stat(p); err != nil {
 		return !os.IsNotExist(err)
 	}


### PR DESCRIPTION
Still WIP, but almost completed, reviews are welcome! 

This PR removes `login` method and adds following sub-commands to manipulate ethereum keys:
- `accounts list` - shows all keys into the keystore. The default key is marked by an asterisk sign.
- `accounts create` - generates a new key with given passphrase.
- `accounts import ` - imports existing key by its path. `--as-default` marks just imported key as default.
- `accounts set-default` mark a key from the keystore as default. 



