### PR TITLE
fix: asking a version should no longer require config

### DIFF
--- a/cmd/cobra.go
+++ b/cmd/cobra.go
@@ -17,14 +17,13 @@ func NewCmd(name, appVersion string, cfg *string, version *bool, run Runner) *co
 	c := &cobra.Command{
 		Use: appName(name),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
+			if version != nil && *version {
+				fmt.Println(versionString(name, appVersion))
+				os.Exit(0)
+			}
 			return checkRequiredFlags(cmd.PersistentFlags())
 		},
 		Run: func(cmd *cobra.Command, args []string) {
-			if version != nil && *version {
-				fmt.Println(versionString(name, appVersion))
-				return
-			}
-
 			if err := run(); err != nil {
 				fmt.Println(capitalize(err.Error()))
 				os.Exit(1)


### PR DESCRIPTION
Unfortunately merging #744 resulted in a new bug: currently it's impossible to print a version without specifying some configuration file path.

This PR should fix this.