### PR TITLE
chore: unify configs

### DIFF
--- a/etc/worker.yaml
+++ b/etc/worker.yaml
@@ -64,6 +64,9 @@ matcher:
   poll_delay: 10s
   query_limit: 100
 
+dwh:
+  endpoint: "8125721C2413d99a33E351e1F6Bb4e56b6b633FD@127.0.0.1:15021"
+
 plugins:
   socket_dir: /run/docker/plugins
 

--- a/insonmnia/dwh/config.go
+++ b/insonmnia/dwh/config.go
@@ -32,6 +32,10 @@ type ColdStartConfig struct {
 	UpToBlock uint64 `yaml:"up_to_block"`
 }
 
+type YAMLConfig struct {
+	Endpoint string `yaml:"endpoint" required:"false"`
+}
+
 func NewConfig(path string) (*Config, error) {
 	cfg := &Config{}
 	err := configor.Load(cfg, path)

--- a/insonmnia/matcher/matcher.go
+++ b/insonmnia/matcher/matcher.go
@@ -24,8 +24,8 @@ type Matcher interface {
 // YAMLConfig is embeddable config that can be integrated with
 // another component's config.
 type YAMLConfig struct {
-	PollDelay  time.Duration `yaml:"poll_delay"`
-	QueryLimit uint64        `yaml:"query_limit"`
+	PollDelay  time.Duration `yaml:"poll_delay" default:"30s"`
+	QueryLimit uint64        `yaml:"query_limit" default:"50"`
 }
 
 type Config struct {

--- a/insonmnia/miner/config.go
+++ b/insonmnia/miner/config.go
@@ -6,6 +6,7 @@ import (
 	"github.com/sonm-io/core/accounts"
 	"github.com/sonm-io/core/blockchain"
 	"github.com/sonm-io/core/insonmnia/benchmarks"
+	"github.com/sonm-io/core/insonmnia/dwh"
 	"github.com/sonm-io/core/insonmnia/logging"
 	"github.com/sonm-io/core/insonmnia/matcher"
 	"github.com/sonm-io/core/insonmnia/miner/plugin"
@@ -44,8 +45,8 @@ type Config struct {
 	Benchmarks        benchmarks.Config   `yaml:"benchmarks"`
 	Whitelist         WhitelistConfig     `yaml:"whitelist"`
 	MetricsListenAddr string              `yaml:"metrics_listen_addr" default:"127.0.0.1:14000"`
-	DWHEndpoint       string              `yaml:"dwh" default:"127.0.0.1:15021"`
-	Matcher           matcher.YAMLConfig  `yaml:"matcher"`
+	DWH               dwh.YAMLConfig      `yaml:"dwh"`
+	Matcher           *matcher.YAMLConfig `yaml:"matcher"`
 }
 
 // NewConfig creates a new Miner config from the specified YAML file.

--- a/insonmnia/node/config.go
+++ b/insonmnia/node/config.go
@@ -5,6 +5,7 @@ import (
 	"github.com/sonm-io/core/accounts"
 	"github.com/sonm-io/core/blockchain"
 	"github.com/sonm-io/core/insonmnia/benchmarks"
+	"github.com/sonm-io/core/insonmnia/dwh"
 	"github.com/sonm-io/core/insonmnia/logging"
 	"github.com/sonm-io/core/insonmnia/matcher"
 	"github.com/sonm-io/core/insonmnia/npp"
@@ -20,10 +21,6 @@ type hubConfig struct {
 	Endpoint string `required:"false" yaml:"endpoint"`
 }
 
-type dwhConfig struct {
-	Endpoint string `required:"false" yaml:"endpoint"`
-}
-
 type Config struct {
 	Node              nodeConfig          `yaml:"node"`
 	NPP               npp.Config          `yaml:"npp"`
@@ -31,7 +28,7 @@ type Config struct {
 	Blockchain        *blockchain.Config  `yaml:"blockchain"`
 	Eth               accounts.EthConfig  `yaml:"ethereum" required:"false"`
 	Hub               hubConfig           `yaml:"hub" required:"false"`
-	DWH               dwhConfig           `yaml:"dwh"`
+	DWH               dwh.YAMLConfig      `yaml:"dwh"`
 	MetricsListenAddr string              `yaml:"metrics_listen_addr" default:"127.0.0.1:14003"`
 	Benchmarks        benchmarks.Config   `yaml:"benchmarks"`
 	Matcher           *matcher.YAMLConfig `yaml:"matcher"`


### PR DESCRIPTION
Changed:
- Disableable matcher into a Worker.
- Extract DWH ClientConfing, reuse it into Worker and Node.