### PR TITLE
refactor: make cli commands more consistent

### DIFF
--- a/cmd/cli/commands/common.go
+++ b/cmd/cli/commands/common.go
@@ -55,8 +55,8 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&outputModeFlag, "out", "", "Output mode: simple or json")
 	rootCmd.PersistentFlags().BoolVar(&insecureFlag, "insecure", false, "Disable TLS for connection")
 
-	rootCmd.AddCommand(workerMgmtCmd, marketRootCmd, nodeDealsRootCmd, taskRootCmd)
-	rootCmd.AddCommand(loginCmd, getTokenCmd, getBalanceCmd, versionCmd, autoCompleteCmd, masterRootCmd)
+	rootCmd.AddCommand(workerMgmtCmd, orderRootCmd, dealRootCmd, taskRootCmd)
+	rootCmd.AddCommand(loginCmd, tokenRootCmd, versionCmd, autoCompleteCmd, masterRootCmd)
 }
 
 // Root configure and return root command

--- a/cmd/cli/commands/deals.go
+++ b/cmd/cli/commands/deals.go
@@ -14,23 +14,23 @@ var (
 )
 
 func init() {
-	dealsListCmd.PersistentFlags().Uint64Var(&dealsSearchCount, "limit", 10, "Deals count to show")
-	dealsFinishCmd.PersistentFlags().BoolVar(&addToBlacklist, "blacklist", false, "Add counterparty to blacklist")
+	dealListCmd.PersistentFlags().Uint64Var(&dealsSearchCount, "limit", 10, "Deals count to show")
+	dealCloseCmd.PersistentFlags().BoolVar(&addToBlacklist, "blacklist", false, "Add counterparty to blacklist")
 
-	nodeDealsRootCmd.AddCommand(
-		dealsListCmd,
-		dealsStatusCmd,
-		dealsOpenCmd,
-		dealsFinishCmd,
+	dealRootCmd.AddCommand(
+		dealListCmd,
+		dealStatusCmd,
+		dealOpenCmd,
+		dealCloseCmd,
 	)
 }
 
-var nodeDealsRootCmd = &cobra.Command{
-	Use:   "deals",
+var dealRootCmd = &cobra.Command{
+	Use:   "deal",
 	Short: "Manage deals",
 }
 
-var dealsListCmd = &cobra.Command{
+var dealListCmd = &cobra.Command{
 	Use:    "list",
 	Short:  "Show your active deals",
 	PreRun: loadKeyStoreWrapper,
@@ -55,9 +55,9 @@ var dealsListCmd = &cobra.Command{
 	},
 }
 
-var dealsStatusCmd = &cobra.Command{
+var dealStatusCmd = &cobra.Command{
 	Use:    "status <deal_id>",
-	Short:  "show deal status",
+	Short:  "Show deal status",
 	Args:   cobra.MinimumNArgs(1),
 	PreRun: loadKeyStoreIfRequired,
 	Run: func(cmd *cobra.Command, args []string) {
@@ -87,9 +87,9 @@ var dealsStatusCmd = &cobra.Command{
 	},
 }
 
-var dealsOpenCmd = &cobra.Command{
+var dealOpenCmd = &cobra.Command{
 	Use:    "open <ask_id> <bid_id>",
-	Short:  "open deal with given orders",
+	Short:  "Open deal with given orders",
 	Args:   cobra.MinimumNArgs(2),
 	PreRun: loadKeyStoreWrapper,
 	Run: func(cmd *cobra.Command, args []string) {
@@ -129,9 +129,9 @@ var dealsOpenCmd = &cobra.Command{
 	},
 }
 
-var dealsFinishCmd = &cobra.Command{
-	Use:    "finish <deal_id>",
-	Short:  "finish deal",
+var dealCloseCmd = &cobra.Command{
+	Use:    "close <deal_id>",
+	Short:  "Close given deal",
 	Args:   cobra.MinimumNArgs(1),
 	PreRun: loadKeyStoreIfRequired,
 	Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/cli/commands/orders.go
+++ b/cmd/cli/commands/orders.go
@@ -13,22 +13,22 @@ var (
 )
 
 func init() {
-	marketSearchCmd.PersistentFlags().Uint64Var(&ordersSearchLimit, "limit", 10, "Orders count to show")
+	orderListCmd.PersistentFlags().Uint64Var(&ordersSearchLimit, "limit", 10, "Orders count to show")
 
-	marketRootCmd.AddCommand(
-		marketSearchCmd,
-		marketShowCmd,
-		marketCreateCmd,
-		marketCancelCmd,
+	orderRootCmd.AddCommand(
+		orderListCmd,
+		orderStatusCmd,
+		orderCreateCmd,
+		orderCancelCmd,
 	)
 }
 
-var marketRootCmd = &cobra.Command{
-	Use:   "market",
-	Short: "Interact with Marketplace",
+var orderRootCmd = &cobra.Command{
+	Use:   "order",
+	Short: "Manage orders",
 }
 
-var marketSearchCmd = &cobra.Command{
+var orderListCmd = &cobra.Command{
 	Use:    "list",
 	Short:  "Show your active orders",
 	PreRun: loadKeyStoreIfRequired,
@@ -53,9 +53,9 @@ var marketSearchCmd = &cobra.Command{
 	},
 }
 
-var marketShowCmd = &cobra.Command{
-	Use:    "show <order_id>",
-	Short:  "Show order details",
+var orderStatusCmd = &cobra.Command{
+	Use:    "status <order_id>",
+	Short:  "Show order stats",
 	Args:   cobra.MinimumNArgs(1),
 	PreRun: loadKeyStoreIfRequired,
 	Run: func(cmd *cobra.Command, args []string) {
@@ -79,10 +79,7 @@ var marketShowCmd = &cobra.Command{
 	},
 }
 
-// Note: here is no processing method at all, we need to move matching code
-// into the separated package, and then reinvent processing from scratch.
-
-var marketCreateCmd = &cobra.Command{
+var orderCreateCmd = &cobra.Command{
 	Use:    "create <bid.yaml>",
 	Short:  "Place new Bid order on Marketplace",
 	Args:   cobra.MinimumNArgs(1),
@@ -115,7 +112,7 @@ var marketCreateCmd = &cobra.Command{
 	},
 }
 
-var marketCancelCmd = &cobra.Command{
+var orderCancelCmd = &cobra.Command{
 	Use:    "cancel <order_id>",
 	Short:  "Cancel order on Marketplace",
 	Args:   cobra.MinimumNArgs(1),

--- a/cmd/cli/commands/tasks.go
+++ b/cmd/cli/commands/tasks.go
@@ -45,7 +45,7 @@ func init() {
 var taskPullOutput string
 
 var taskRootCmd = &cobra.Command{
-	Use:   "tasks",
+	Use:   "task",
 	Short: "Tasks management",
 }
 

--- a/cmd/cli/commands/tokens.go
+++ b/cmd/cli/commands/tokens.go
@@ -7,7 +7,19 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var getTokenCmd = &cobra.Command{
+func init() {
+	tokenRootCmd.AddCommand(
+		tokenGetCmd,
+		tokenBalanceCmd,
+	)
+}
+
+var tokenRootCmd = &cobra.Command{
+	Use:   "token",
+	Short: "Manage tokens",
+}
+
+var tokenGetCmd = &cobra.Command{
 	Use:    "get",
 	Short:  "Get SONM test tokens (ERC20)",
 	PreRun: loadKeyStoreWrapper,
@@ -30,7 +42,7 @@ var getTokenCmd = &cobra.Command{
 	},
 }
 
-var getBalanceCmd = &cobra.Command{
+var tokenBalanceCmd = &cobra.Command{
 	Use:    "balance",
 	Short:  "Show SONM token balance (ERC20)",
 	PreRun: loadKeyStoreWrapper,


### PR DESCRIPTION
This PR changes CLI sub-commands semantic to follow the "entity-action"
commands style.