### PR TITLE
feat: configurable timeouts for NPP

### DIFF
--- a/insonmnia/node/server.go
+++ b/insonmnia/node/server.go
@@ -75,7 +75,7 @@ func (re *remoteOptions) getWorkerClientByEthAddr(ctx context.Context, eth strin
 
 func newRemoteOptions(ctx context.Context, key *ecdsa.PrivateKey, cfg *Config, credentials credentials.TransportCredentials) (*remoteOptions, error) {
 	nppDialerOptions := []npp.Option{
-		npp.WithRendezvous(cfg.NPP.Rendezvous.Endpoints, credentials),
+		npp.WithRendezvous(cfg.NPP.Rendezvous, credentials),
 		npp.WithRelayClient(cfg.NPP.Relay.Endpoints),
 	}
 	nppDialer, err := npp.NewDialer(ctx, nppDialerOptions...)

--- a/insonmnia/npp/options.go
+++ b/insonmnia/npp/options.go
@@ -8,8 +8,8 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/sonm-io/core/insonmnia/auth"
 	"github.com/sonm-io/core/insonmnia/npp/relay"
+	"github.com/sonm-io/core/insonmnia/npp/rendezvous"
 	"github.com/sonm-io/core/util/netutil"
 	"go.uber.org/zap"
 	"google.golang.org/grpc/credentials"
@@ -44,17 +44,17 @@ func newOptions(ctx context.Context) *options {
 // Without this option no intermediate server will be used for obtaining
 // peer's endpoints and the entire connection establishment process will fall
 // back to the old good plain TCP connection.
-func WithRendezvous(addrs []auth.Addr, credentials credentials.TransportCredentials) Option {
+func WithRendezvous(cfg rendezvous.Config, credentials credentials.TransportCredentials) Option {
 	return func(o *options) error {
 		o.puncherNew = func() (NATPuncher, error) {
-			for _, addr := range addrs {
+			for _, addr := range cfg.Endpoints {
 				client, err := newRendezvousClient(o.ctx, addr, credentials)
 				if err == nil {
-					return newNATPuncher(o.ctx, client)
+					return newNATPuncher(o.ctx, cfg, client)
 				}
 			}
 
-			return nil, fmt.Errorf("failed to connect to %+v", addrs)
+			return nil, fmt.Errorf("failed to connect to %+v", cfg.Endpoints)
 		}
 
 		return nil

--- a/insonmnia/npp/puncher.go
+++ b/insonmnia/npp/puncher.go
@@ -11,14 +11,10 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/libp2p/go-reuseport"
 	"github.com/noxiouz/zapctx/ctxlog"
+	"github.com/sonm-io/core/insonmnia/npp/rendezvous"
 	"github.com/sonm-io/core/proto"
 	"github.com/sonm-io/core/util/netutil"
 	"go.uber.org/zap"
-)
-
-const (
-	maxConnectAttempts = 5
-	maxConnectTimeout  = 10 * time.Second
 )
 
 // NATPuncher describes an interface of NAT Punching Protocol.
@@ -59,7 +55,7 @@ type natPuncher struct {
 	timeout     time.Duration
 }
 
-func newNATPuncher(ctx context.Context, client *rendezvousClient) (NATPuncher, error) {
+func newNATPuncher(ctx context.Context, cfg rendezvous.Config, client *rendezvousClient) (NATPuncher, error) {
 	// It's important here to reuse the Rendezvous client local address for
 	// successful NAT penetration in the case of cone NAT.
 	listener, err := reuseport.Listen(protocol, client.LocalAddr().String())
@@ -76,8 +72,8 @@ func newNATPuncher(ctx context.Context, client *rendezvousClient) (NATPuncher, e
 		listenerChannel: channel,
 		listener:        listener,
 
-		maxAttempts: maxConnectAttempts,
-		timeout:     maxConnectTimeout,
+		maxAttempts: cfg.MaxConnectionAttempts,
+		timeout:     cfg.Timeout,
 	}
 
 	go m.listen()

--- a/insonmnia/npp/rendezvous/config.go
+++ b/insonmnia/npp/rendezvous/config.go
@@ -3,6 +3,7 @@ package rendezvous
 import (
 	"crypto/ecdsa"
 	"net"
+	"time"
 
 	"github.com/jinzhu/configor"
 	"github.com/sonm-io/core/accounts"
@@ -46,5 +47,7 @@ func NewServerConfig(path string) (*ServerConfig, error) {
 }
 
 type Config struct {
-	Endpoints []auth.Addr
+	Endpoints             []auth.Addr   `yaml:"endpoints"`
+	MaxConnectionAttempts int           `yaml:"max_connection_attempts" default:"5"`
+	Timeout               time.Duration `yaml:"timeout" default:"1s"`
 }

--- a/insonmnia/worker/server.go
+++ b/insonmnia/worker/server.go
@@ -165,7 +165,7 @@ func (m *Worker) Serve() error {
 	listener, err := npp.NewListener(m.ctx, m.cfg.Endpoint,
 		npp.WithNPPBacklog(m.cfg.NPP.Backlog),
 		npp.WithNPPBackoff(m.cfg.NPP.MinBackoffInterval, m.cfg.NPP.MaxBackoffInterval),
-		npp.WithRendezvous(m.cfg.NPP.Rendezvous.Endpoints, m.creds),
+		npp.WithRendezvous(m.cfg.NPP.Rendezvous, m.creds),
 		npp.WithRelay(m.cfg.NPP.Relay.Endpoints, m.key),
 		npp.WithLogger(log.G(m.ctx)),
 	)


### PR DESCRIPTION
This PR allows to configure timeouts and the number of connection attempts for NAT punching.
Also reduced default timeout to 1s.