### PR TITLE
feat: NPP metrics

### DIFF
--- a/insonmnia/npp/metrics.go
+++ b/insonmnia/npp/metrics.go
@@ -1,0 +1,28 @@
+package npp
+
+import (
+	"net"
+
+	"go.uber.org/atomic"
+)
+
+type ListenerMetrics struct {
+	RendezvousAddr       net.Addr
+	NumConnectionsDirect uint64
+	NumConnectionsNAT    uint64
+	NumConnectionsRelay  uint64
+}
+
+type metrics struct {
+	NumConnectionsDirect *atomic.Uint64
+	NumConnectionsNAT    *atomic.Uint64
+	NumConnectionsRelay  *atomic.Uint64
+}
+
+func newMetrics() *metrics {
+	return &metrics{
+		NumConnectionsDirect: atomic.NewUint64(0),
+		NumConnectionsNAT:    atomic.NewUint64(0),
+		NumConnectionsRelay:  atomic.NewUint64(0),
+	}
+}


### PR DESCRIPTION
This commit allows to fetch NPP metrics, where counting of the number of incoming connection occurs.
Also it provides Rendezvous connection status, which is used in `worker status` CLI.