### PR TITLE
Feat: dwh sql updates

### DIFF
--- a/insonmnia/dwh/postgres.go
+++ b/insonmnia/dwh/postgres.go
@@ -68,6 +68,7 @@ func newPostgresStorage(tInfo *tablesInfo, numBenchmarks uint64) *sqlStorage {
 			profileNotInBlacklist:        `AND UserID NOT IN (SELECT AddeeID FROM Blacklists WHERE AdderID = $ AND AddeeID = p.UserID)`,
 			profileInBlacklist:           `AND UserID IN (SELECT AddeeID FROM Blacklists WHERE AdderID = $ AND AddeeID = p.UserID)`,
 			updateProfile:                `UPDATE Profiles SET %s = $1 WHERE UserID = $2`,
+			updateProfileStats:           `UPDATE Profiles SET %s = %s + $1 WHERE UserID = $2`,
 			selectLastKnownBlock:         `SELECT LastKnownBlock FROM Misc WHERE Id = 1`,
 			insertLastKnownBlock:         `INSERT INTO Misc(LastKnownBlock) VALUES ($1)`,
 			updateLastKnownBlock:         `UPDATE Misc SET LastKnownBlock = $1 WHERE Id = 1`,

--- a/insonmnia/dwh/postgres.go
+++ b/insonmnia/dwh/postgres.go
@@ -63,7 +63,7 @@ func newPostgresStorage(tInfo *tablesInfo, numBenchmarks uint64) *sqlStorage {
 			updateValidator:              `UPDATE Validators SET Level = $1 WHERE Id = $2`,
 			insertCertificate:            `INSERT INTO Certificates VALUES ($1, $2, $3, $4, $5)`,
 			selectCertificates:           `SELECT * FROM Certificates WHERE OwnerID = $1`,
-			insertProfileUserID:          `INSERT INTO Profiles (UserID, IdentityLevel, Name, Country, IsCorporation, IsProfessional, Certificates, ActiveAsks, ActiveBids ) VALUES ($1, 0, '', '', FALSE, FALSE, $2, $3, $4)`,
+			insertProfileUserID:          `INSERT INTO Profiles (UserID, IdentityLevel, Name, Country, IsCorporation, IsProfessional, Certificates, ActiveAsks, ActiveBids ) VALUES ($1, 0, '', '', FALSE, FALSE, $2, $3, $4) ON CONFLICT (UserID) DO NOTHING`,
 			selectProfileByID:            `SELECT * FROM Profiles WHERE UserID = $1`,
 			profileNotInBlacklist:        `AND UserID NOT IN (SELECT AddeeID FROM Blacklists WHERE AdderID = $ AND AddeeID = p.UserID)`,
 			profileInBlacklist:           `AND UserID IN (SELECT AddeeID FROM Blacklists WHERE AdderID = $ AND AddeeID = p.UserID)`,
@@ -172,8 +172,7 @@ func newPostgresStorage(tInfo *tablesInfo, numBenchmarks uint64) *sqlStorage {
 		Attribute					INTEGER NOT NULL,
 		AttributeLevel				INTEGER NOT NULL,
 		Value						BYTEA NOT NULL,
-		ValidatorID					TEXT NOT NULL REFERENCES Validators(Id) ON DELETE CASCADE,
-		UNIQUE						(OwnerID, ValidatorID, Attribute, Value)
+		ValidatorID					TEXT NOT NULL REFERENCES Validators(Id) ON DELETE CASCADE
 	)`,
 			createTableProfiles: `
 	CREATE TABLE IF NOT EXISTS Profiles (

--- a/insonmnia/dwh/sql.go
+++ b/insonmnia/dwh/sql.go
@@ -858,6 +858,11 @@ func (c *sqlStorage) UpdateProfile(conn queryConn, userID common.Address, field 
 	return err
 }
 
+func (c *sqlStorage) UpdateProfileStats(conn queryConn, userID common.Address, field string, value interface{}) error {
+	_, err := conn.Exec(fmt.Sprintf(c.commands.updateProfileStats, field, field), value, userID.Hex())
+	return err
+}
+
 func (c *sqlStorage) GetLastKnownBlock(conn queryConn) (uint64, error) {
 	rows, err := conn.Query(c.commands.selectLastKnownBlock)
 	if err != nil {
@@ -1361,6 +1366,7 @@ type sqlCommands struct {
 	profileNotInBlacklist        string
 	profileInBlacklist           string
 	updateProfile                string
+	updateProfileStats           string
 	selectLastKnownBlock         string
 	insertLastKnownBlock         string
 	updateLastKnownBlock         string

--- a/insonmnia/dwh/sqlite.go
+++ b/insonmnia/dwh/sqlite.go
@@ -70,7 +70,7 @@ func newSQLiteStorage(tInfo *tablesInfo, numBenchmarks uint64) *sqlStorage {
 			updateValidator:              `UPDATE Validators SET Level=? WHERE Id=?`,
 			insertCertificate:            `INSERT INTO Certificates VALUES (?, ?, ?, ?, ?)`,
 			selectCertificates:           `SELECT * FROM Certificates WHERE OwnerID=?`,
-			insertProfileUserID:          `INSERT INTO Profiles VALUES (NULL, ?, 0, "", "", 0, 0, ?, ?, ?)`,
+			insertProfileUserID:          `INSERT OR IGNORE INTO Profiles VALUES (NULL, ?, 0, "", "", 0, 0, ?, ?, ?)`,
 			selectProfileByID:            `SELECT * FROM Profiles WHERE UserID=?`,
 			profileNotInBlacklist:        `AND UserID NOT IN (SELECT AddeeID FROM Blacklists WHERE AdderID=? AND AddeeID = p.UserID)`,
 			profileInBlacklist:           `AND UserID IN (SELECT AddeeID FROM Blacklists WHERE AdderID=? AND AddeeID = p.UserID)`,
@@ -185,7 +185,6 @@ func newSQLiteStorage(tInfo *tablesInfo, numBenchmarks uint64) *sqlStorage {
 		AttributeLevel				INTEGER NOT NULL,
 		Value						BLOB NOT NULL,
 		ValidatorID					TEXT NOT NULL,
-		UNIQUE						(OwnerID, ValidatorID, Attribute, Value),
 		FOREIGN KEY (ValidatorID)	REFERENCES Validators(Id) ON DELETE CASCADE
 	)`,
 			createTableProfiles: `

--- a/insonmnia/dwh/sqlite.go
+++ b/insonmnia/dwh/sqlite.go
@@ -75,6 +75,7 @@ func newSQLiteStorage(tInfo *tablesInfo, numBenchmarks uint64) *sqlStorage {
 			profileNotInBlacklist:        `AND UserID NOT IN (SELECT AddeeID FROM Blacklists WHERE AdderID=? AND AddeeID = p.UserID)`,
 			profileInBlacklist:           `AND UserID IN (SELECT AddeeID FROM Blacklists WHERE AdderID=? AND AddeeID = p.UserID)`,
 			updateProfile:                `UPDATE Profiles SET %s=? WHERE UserID=?`,
+			updateProfileStats:           `UPDATE Profiles SET %s=%s+? WHERE UserID=?`,
 			selectLastKnownBlock:         `SELECT LastKnownBlock FROM Misc WHERE Id=1`,
 			insertLastKnownBlock:         `INSERT INTO Misc VALUES (NULL, ?)`,
 			updateLastKnownBlock:         `UPDATE Misc Set LastKnownBlock=? WHERE Id=1`,

--- a/insonmnia/dwh/storage.go
+++ b/insonmnia/dwh/storage.go
@@ -53,6 +53,7 @@ type storage interface {
 	GetValidators(conn queryConn, request *pb.ValidatorsRequest) ([]*pb.Validator, uint64, error)
 	GetWorkers(conn queryConn, request *pb.WorkersRequest) ([]*pb.DWHWorker, uint64, error)
 	UpdateProfile(conn queryConn, userID common.Address, field string, value interface{}) error
+	UpdateProfileStats(conn queryConn, userID common.Address, field string, value interface{}) error
 	GetLastKnownBlock(conn queryConn) (uint64, error)
 	InsertLastKnownBlock(conn queryConn, blockNumber int64) error
 	UpdateLastKnownBlock(conn queryConn, blockNumber int64) error


### PR DESCRIPTION
* [Coordinated with UI team and analysts] DWH used to create blank profiles for orders with previously unknown authors; this PR removes this behavior;
* Profile stats updates are optimized;
* Uniqueness constraint for certificates `(OwnerID, ValidatorID, Attribute, Value)` is removed because analysts and blockchain guys insist that issuing identical certificates is O.K.