### PR TITLE
feat: error-free concurrency for DWH

### DIFF
--- a/insonmnia/dwh/config.go
+++ b/insonmnia/dwh/config.go
@@ -17,7 +17,7 @@ type Config struct {
 	Blockchain        *blockchain.Config `yaml:"blockchain"`
 	MetricsListenAddr string             `yaml:"metrics_listen_addr" default:"127.0.0.1:14004"`
 	ColdStart         *ColdStartConfig   `yaml:"cold_start"`
-	NumWorkers        int                `yaml:"num_workers" default:"16"`
+	NumWorkers        int                `yaml:"num_workers" default:"64"`
 }
 
 type storageConfig struct {

--- a/insonmnia/dwh/storage.go
+++ b/insonmnia/dwh/storage.go
@@ -37,6 +37,7 @@ type storage interface {
 	InsertDealCondition(conn queryConn, condition *pb.DealCondition) error
 	UpdateDealConditionPayout(conn queryConn, dealConditionID uint64, payout *big.Int) error
 	UpdateDealConditionEndTime(conn queryConn, dealConditionID, eventTS uint64) error
+	CheckWorkerExists(conn queryConn, masterID, workerID string) (bool, error)
 	InsertWorker(conn queryConn, masterID, slaveID string) error
 	UpdateWorker(conn queryConn, masterID, slaveID string) error
 	DeleteWorker(conn queryConn, masterID, slaveID string) error


### PR DESCRIPTION
This PR introduces correct parallel processing of blockchain events (the idea is to avoid any errors that are not related to DB/geth node availability).

Entities have a lifetime: `X Created`, `X Modified 1, 2, 3`, `X Deleted`. The algorithm splits events into groups by their type and executes events within a group in parallel. Event groups are ordered so that a situation when, say, `X Modified` event is processed after `X Deleted` is impossible.

Also there's a fix for duplicate Worker entries (was possible because `Market` doesn't check for duplicates).