### PR TITLE
feat: worker admin

### DIFF
--- a/etc/worker.yaml
+++ b/etc/worker.yaml
@@ -1,3 +1,8 @@
+# Admin key is a key that allows to use worker management API without
+# configuring master key.
+# Useful for development and/or debugging.
+admin: 0x000000000000000000000000000000000000000f
+
 # An endpoint for client connections using cli
 # allowed format is "ip:port" to bind Worker to given IP address
 # or ":port" to bind Worker to all available IPs

--- a/insonmnia/worker/config.go
+++ b/insonmnia/worker/config.go
@@ -49,6 +49,7 @@ type Config struct {
 	Matcher           *matcher.YAMLConfig `yaml:"matcher"`
 	Salesman          salesman.YAMLConfig `yaml:"salesman"`
 	Master            *common.Address     `yaml:"master"`
+	Admin             *common.Address     `yaml:"admin"`
 }
 
 // NewConfig creates a new Worker config from the specified YAML file.

--- a/insonmnia/worker/server.go
+++ b/insonmnia/worker/server.go
@@ -236,14 +236,17 @@ func (m *Worker) setupMaster() error {
 }
 
 func (m *Worker) setupAuthorization() error {
-	var managementAuth auth.Authorization
-	if m.cfg.Master != nil {
-		managementAuth = newMultiAuth(
-			auth.NewTransportAuthorization(m.ethAddr()),
-			auth.NewTransportAuthorization(*m.cfg.Master))
-	} else {
-		managementAuth = auth.NewTransportAuthorization(m.ethAddr())
+	managementAuthOptions := []auth.Authorization{
+		auth.NewTransportAuthorization(m.ethAddr()),
 	}
+	if m.cfg.Master != nil {
+		managementAuthOptions = append(managementAuthOptions, auth.NewTransportAuthorization(*m.cfg.Master))
+	}
+	if m.cfg.Admin != nil {
+		managementAuthOptions = append(managementAuthOptions, auth.NewTransportAuthorization(*m.cfg.Admin))
+	}
+
+	managementAuth := newMultiAuth(managementAuthOptions...)
 
 	authorization := auth.NewEventAuthorization(m.ctx,
 		auth.WithLog(log.G(m.ctx)),


### PR DESCRIPTION
This commit allows to specify admin ETH key for a worker to be able to have access to worker management tools.