### PR TITLE
refactor: make master required, export generated keys

### DIFF
--- a/etc/worker.yaml
+++ b/etc/worker.yaml
@@ -1,20 +1,19 @@
-# Admin key is a key that allows to use worker management API without
-# configuring master key.
-# Useful for development and/or debugging.
-admin: 0x000000000000000000000000000000000000000f
-
 # An endpoint for client connections using cli
 # allowed format is "ip:port" to bind Worker to given IP address
 # or ":port" to bind Worker to all available IPs
 endpoint: ":15010"
 
-# blockchain-specific settings.
-ethereum:
-  # path to keystore
-  key_store: "./keys"
-  # passphrase for keystore
-  pass_phrase: "any"
+# Admin key is a key that allows to use worker management API without
+# configuring master key.
+# Useful for development and/or debugging.
+admin: 0x000000000000000000000000000000000000000f
 
+# Master key is a key that receives all payments for deals
+# This worker should be confirmed by master via sonmcli master confirm,
+# it's eth addr can be found in logs.
+# Private key is also exported in /var/lib/sonm/worker_keystore with "sonm" passphrase
+# This option is required.
+master: 0x0000000000000000000000000000000000000001
 
 # NAT punching settings.
 npp:

--- a/insonmnia/worker/cgroup_test.go
+++ b/insonmnia/worker/cgroup_test.go
@@ -10,6 +10,7 @@ func TestParseResources(t *testing.T) {
 	assertions := assert.New(t)
 	defer deleteTestConfigFile()
 	raw := `
+master: 0x0000000000000000000000000000000000000001
 endpoint: ":0"
 resources:
   cgroup: insonmnia

--- a/insonmnia/worker/config.go
+++ b/insonmnia/worker/config.go
@@ -32,6 +32,10 @@ type WhitelistConfig struct {
 	RefreshPeriod       uint     `yaml:"refresh_period" default:"60"`
 }
 
+type DevConfig struct {
+	DisableMasterApproval bool `yaml:"disable_master_approval"`
+}
+
 type Config struct {
 	Endpoint          string              `yaml:"endpoint" required:"true"`
 	Logging           logging.Config      `yaml:"logging"`
@@ -48,7 +52,8 @@ type Config struct {
 	DWH               dwh.YAMLConfig      `yaml:"dwh"`
 	Matcher           *matcher.YAMLConfig `yaml:"matcher"`
 	Salesman          salesman.YAMLConfig `yaml:"salesman"`
-	Master            *common.Address     `yaml:"master"`
+	Master            common.Address      `yaml:"master" required:"true"`
+	Development       *DevConfig          `yaml:"development"`
 	Admin             *common.Address     `yaml:"admin"`
 }
 

--- a/insonmnia/worker/config_test.go
+++ b/insonmnia/worker/config_test.go
@@ -74,7 +74,7 @@ func TestConfigPlugins(t *testing.T) {
 	defer deleteTestConfigFile()
 	raw := `
 endpoint: "127.0.0.5:15010"
-
+master: 0x0000000000000000000000000000000000000001
 plugins:
   socket_dir: /tmp/run/test-plugins
   volume:


### PR DESCRIPTION
subj
  * master now is required
  * generated keys are exported to sonm folder to ease usage
  * useless keys config section is dropped from config
  * Add ability to start in dev mode without master check