### PR TITLE
refactor: make utils great again

### DIFF
--- a/cmd/cli/commands/common.go
+++ b/cmd/cli/commands/common.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/sonm-io/core/accounts"
 	"github.com/sonm-io/core/cmd/cli/config"
 	"github.com/sonm-io/core/insonmnia/auth"
@@ -200,7 +201,7 @@ func loadKeyStoreWrapper(cmd *cobra.Command, _ []string) {
 			os.Exit(1)
 		}
 
-		creds = auth.NewWalletAuthenticator(util.NewTLS(TLSConfig), util.PubKeyToAddr(sessionKey.PublicKey))
+		creds = auth.NewWalletAuthenticator(util.NewTLS(TLSConfig), crypto.PubkeyToAddress(sessionKey.PublicKey))
 	}
 }
 

--- a/cmd/cli/commands/master.go
+++ b/cmd/cli/commands/master.go
@@ -42,7 +42,7 @@ var masterListCmd = &cobra.Command{
 			}
 		} else {
 			key := getDefaultKeyOrDie()
-			master = util.PubKeyToAddr(key.PublicKey)
+			master = crypto.PubkeyToAddress(key.PublicKey)
 		}
 
 		mm, err := newMasterManagementClient(ctx)

--- a/cmd/cli/commands/tasks.go
+++ b/cmd/cli/commands/tasks.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/gosuri/uiprogress"
 	"github.com/sonm-io/core/cmd/cli/task_config"
 	"github.com/sonm-io/core/insonmnia/structs"
@@ -148,7 +149,7 @@ var taskStartCmd = &cobra.Command{
 
 		deal := &pb.Deal{
 			Id:         bigDealID,
-			ConsumerID: pb.NewEthAddress(util.PubKeyToAddr(key.PublicKey)),
+			ConsumerID: pb.NewEthAddress(crypto.PubkeyToAddress(key.PublicKey)),
 		}
 
 		volumes := map[string]*pb.Volume{}

--- a/insonmnia/hardware/hardware.go
+++ b/insonmnia/hardware/hardware.go
@@ -12,7 +12,7 @@ import (
 	"github.com/sonm-io/core/insonmnia/hardware/ram"
 	"github.com/sonm-io/core/insonmnia/worker/gpu"
 	"github.com/sonm-io/core/proto"
-	"github.com/sonm-io/core/util"
+	"github.com/sonm-io/core/util/netutil"
 )
 
 // Hardware accumulates the finest hardware information about system the worker
@@ -100,7 +100,7 @@ func (m *Hardware) GPUIDs(gpuResources *sonm.AskPlanGPU) ([]gpu.GPUID, error) {
 
 func (h *Hardware) SetNetworkIncoming(IPs []string) {
 	for _, ip := range IPs {
-		if !util.IsPrivateIP(net.ParseIP(ip)) {
+		if !netutil.IsPrivateIP(net.ParseIP(ip)) {
 			h.Network.Incoming = true
 			break
 		}

--- a/insonmnia/npp/net.go
+++ b/insonmnia/npp/net.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/libp2p/go-reuseport"
-	"github.com/sonm-io/core/util"
 	"github.com/sonm-io/core/util/netutil"
 )
 
@@ -51,7 +50,7 @@ func privateAddrs(addr net.Addr) ([]net.Addr, error) {
 	// For unspecified bind addresses, actual address set has to be resolved.
 	// In other words, unspecified means every available (but still private)
 	// address for the host.
-	ips, err := util.GetAvailableIPs()
+	ips, err := netutil.GetAvailableIPs()
 	if err != nil {
 		return nil, err
 	}

--- a/insonmnia/worker/options.go
+++ b/insonmnia/worker/options.go
@@ -15,6 +15,7 @@ import (
 	"github.com/sonm-io/core/proto"
 	"github.com/sonm-io/core/util"
 	"github.com/sonm-io/core/util/multierror"
+	"github.com/sonm-io/core/util/netutil"
 	"github.com/sonm-io/core/util/xgrpc"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc/credentials"
@@ -149,7 +150,7 @@ func (m *options) exportKey() error {
 		return err
 	}
 	ks := keystore.NewKeyStore(exportKeystorePath, keystore.LightScryptN, keystore.LightScryptP)
-	if !ks.HasAddress(util.PubKeyToAddr(m.key.PublicKey)) {
+	if !ks.HasAddress(crypto.PubkeyToAddress(m.key.PublicKey)) {
 		_, err := ks.ImportECDSA(m.key, "sonm")
 		return err
 	}
@@ -206,7 +207,7 @@ func (m *options) setupWhitelist() error {
 	if m.whitelist == nil {
 		cfg := m.cfg.Whitelist
 		if len(cfg.PrivilegedAddresses) == 0 {
-			cfg.PrivilegedAddresses = append(cfg.PrivilegedAddresses, util.PubKeyToAddr(m.key.PublicKey).Hex())
+			cfg.PrivilegedAddresses = append(cfg.PrivilegedAddresses, crypto.PubkeyToAddress(m.key.PublicKey).Hex())
 		}
 
 		m.whitelist = NewWhitelist(m.ctx, &cfg)
@@ -255,7 +256,7 @@ func (m *options) setupNetworkOptions() error {
 	}
 
 	// Scan interfaces if there's no config and no NAT.
-	systemIPs, err := util.GetAvailableIPs()
+	systemIPs, err := netutil.GetAvailableIPs()
 	if err != nil {
 		return err
 	}

--- a/insonmnia/worker/server.go
+++ b/insonmnia/worker/server.go
@@ -15,6 +15,7 @@ import (
 	"github.com/docker/docker/pkg/stdcopy"
 	"github.com/docker/go-connections/nat"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/grpc-ecosystem/go-grpc-prometheus"
 	"github.com/mohae/deepcopy"
 	log "github.com/noxiouz/zapctx/ctxlog"
@@ -215,7 +216,7 @@ func (m *Worker) waitMasterApproved() error {
 }
 
 func (m *Worker) ethAddr() common.Address {
-	return util.PubKeyToAddr(m.key.PublicKey)
+	return crypto.PubkeyToAddress(m.key.PublicKey)
 }
 
 func (m *Worker) setupMaster() error {

--- a/insonmnia/worker/server_test.go
+++ b/insonmnia/worker/server_test.go
@@ -11,14 +11,13 @@ import (
 
 	ethcrypto "github.com/ethereum/go-ethereum/crypto"
 	pb "github.com/sonm-io/core/proto"
-	"github.com/sonm-io/core/util"
 	"github.com/stretchr/testify/assert"
 )
 
 var (
 	_    = setupTestResponder()
 	key  = getTestKey()
-	addr = util.PubKeyToAddr(key.PublicKey)
+	addr = ethcrypto.PubkeyToAddress(key.PublicKey)
 )
 
 func getTestKey() *ecdsa.PrivateKey {

--- a/insonmnia/worker/util.go
+++ b/insonmnia/worker/util.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/sonm-io/core/proto"
-	"github.com/sonm-io/core/util"
+	"github.com/sonm-io/core/util/netutil"
 )
 
 // BackoffTimer implementation
@@ -77,7 +77,7 @@ type sortableIPs []net.IP
 func (s sortableIPs) Len() int      { return len(s) }
 func (s sortableIPs) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
 func (s sortableIPs) Less(i, j int) bool {
-	iIsPrivate, jIsPrivate := util.IsPrivateIP(s[i]), util.IsPrivateIP(s[j])
+	iIsPrivate, jIsPrivate := netutil.IsPrivateIP(s[i]), netutil.IsPrivateIP(s[j])
 	if iIsPrivate && !jIsPrivate {
 		return false
 	}

--- a/proto/net.go
+++ b/proto/net.go
@@ -5,7 +5,7 @@ import (
 	"net"
 	"strconv"
 
-	"github.com/sonm-io/core/util"
+	"github.com/sonm-io/core/util/netutil"
 )
 
 func NewAddr(addr net.Addr) (*Addr, error) {
@@ -53,7 +53,7 @@ func NewSocketAddr(endpoint string) (*SocketAddr, error) {
 
 // IsPrivate returns true if this address can't be reached from the Internet directly.
 func (m *SocketAddr) IsPrivate() bool {
-	return util.IsPrivateIP(net.ParseIP(m.Addr))
+	return netutil.IsPrivateIP(net.ParseIP(m.Addr))
 }
 
 func (m *SocketAddr) IntoTCP() (net.Addr, error) {

--- a/util/certs.go
+++ b/util/certs.go
@@ -164,7 +164,7 @@ func GenerateCert(ethpriv *ecdsa.PrivateKey, validPeriod time.Duration) (cert []
 	}
 	issuerCommonName.WriteString(base32.StdEncoding.EncodeToString(signature.Serialize()))
 
-	dnsName := PubKeyToAddr(ethpriv.PublicKey)
+	dnsName := ethcrypto.PubkeyToAddress(ethpriv.PublicKey)
 	template := &x509.Certificate{
 		SerialNumber: big.NewInt(100),
 		Subject: pkix.Name{

--- a/util/netutil/net.go
+++ b/util/netutil/net.go
@@ -1,6 +1,7 @@
 package netutil
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"strconv"
@@ -60,4 +61,57 @@ func (m *TCPAddr) UnmarshalYAML(unmarshal func(interface{}) error) error {
 
 	m.TCPAddr = *tcpAddr
 	return nil
+}
+
+func GetAvailableIPs() (availableIPs []net.IP, err error) {
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		return nil, err
+	}
+
+	for _, i := range ifaces {
+		addrs, err := i.Addrs()
+		if err != nil {
+			return nil, err
+		}
+		for _, addr := range addrs {
+			var ip net.IP
+			switch v := addr.(type) {
+			case *net.IPNet:
+				ip = v.IP
+			case *net.IPAddr:
+				ip = v.IP
+			}
+			if ip != nil && ip.IsGlobalUnicast() {
+				availableIPs = append(availableIPs, ip)
+			}
+		}
+	}
+	if len(availableIPs) == 0 {
+		return nil, errors.New("could not determine a single unicast addr, check networking")
+	}
+
+	return availableIPs, nil
+}
+
+func IsPrivateIP(ip net.IP) bool {
+	return isPrivateIPv4(ip) || isPrivateIPv6(ip)
+}
+
+func isPrivateIPv4(ip net.IP) bool {
+	_, private24BitBlock, _ := net.ParseCIDR("10.0.0.0/8")
+	_, private20BitBlock, _ := net.ParseCIDR("172.16.0.0/12")
+	_, private16BitBlock, _ := net.ParseCIDR("192.168.0.0/16")
+	return private24BitBlock.Contains(ip) ||
+		private20BitBlock.Contains(ip) ||
+		private16BitBlock.Contains(ip) ||
+		ip.IsLoopback() ||
+		ip.IsLinkLocalUnicast() ||
+		ip.IsLinkLocalMulticast()
+}
+
+func isPrivateIPv6(ip net.IP) bool {
+	_, block, _ := net.ParseCIDR("fc00::/7")
+
+	return block.Contains(ip) || ip.IsLoopback() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast()
 }

--- a/util/netutil/net_test.go
+++ b/util/netutil/net_test.go
@@ -1,0 +1,52 @@
+package netutil
+
+import (
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsPrivateIPv4(t *testing.T) {
+	tests := []struct {
+		ip     string
+		isPriv bool
+	}{
+		{ip: "127.0.0.1", isPriv: true},
+		{ip: "127.1.2.3", isPriv: true},
+		{ip: "10.20.30.40", isPriv: true},
+		{ip: "192.168.0.1", isPriv: true},
+		{ip: "172.16.0.1", isPriv: true},
+		{ip: "169.254.0.1", isPriv: true},
+		{ip: "169.254.1.0", isPriv: true},
+		{ip: "169.254.123.222", isPriv: true},
+		{ip: "169.254.255.255", isPriv: true},
+		{ip: "224.0.0.1", isPriv: true},
+
+		{ip: "1.2.3.4", isPriv: false},
+		{ip: "0.0.0.0", isPriv: false},
+	}
+
+	for _, cc := range tests {
+		b := isPrivateIPv4(net.ParseIP(cc.ip))
+		assert.Equal(t, b, cc.isPriv, cc.ip)
+	}
+}
+
+func TestIsPrivateIPv6(t *testing.T) {
+	tests := []struct {
+		ip     string
+		isPriv bool
+	}{
+		{ip: "::", isPriv: false},
+		{ip: "::1", isPriv: true},
+		{ip: "fe80::", isPriv: true},
+		{ip: "feaf::", isPriv: true},
+		{ip: "fc00::", isPriv: true},
+	}
+
+	for _, cc := range tests {
+		b := isPrivateIPv6(net.ParseIP(cc.ip))
+		assert.Equal(t, b, cc.isPriv, cc.ip)
+	}
+}

--- a/util/util.go
+++ b/util/util.go
@@ -2,19 +2,15 @@ package util
 
 import (
 	"context"
-	"crypto/ecdsa"
 	"errors"
 	"fmt"
 	"math/big"
-	"net"
 	"net/http"
 	"os"
 	"os/user"
 	"runtime"
-	"strconv"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/params"
 	log "github.com/noxiouz/zapctx/ctxlog"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -34,30 +30,8 @@ func GetUserHomeDir() (homeDir string, err error) {
 	return usr.HomeDir, nil
 }
 
-func ParseEndpointPort(s string) (string, error) {
-	_, port, err := net.SplitHostPort(s)
-	if err != nil {
-		return "", err
-	}
-
-	intPort, err := strconv.Atoi(port)
-	if err != nil {
-		return "", err
-	}
-
-	if intPort < 1 || intPort > 65535 {
-		return "", errors.New("invalid port value")
-	}
-
-	return port, nil
-}
-
 func GetPlatformName() string {
 	return fmt.Sprintf("%s/%s/%s", runtime.GOOS, runtime.GOARCH, runtime.Version())
-}
-
-func PubKeyToAddr(key ecdsa.PublicKey) common.Address {
-	return crypto.PubkeyToAddress(key)
 }
 
 func FileExists(p string) bool {
@@ -109,59 +83,6 @@ func StringToEtherPrice(s string) (*big.Int, error) {
 	}
 
 	return v, nil
-}
-
-func GetAvailableIPs() (availableIPs []net.IP, err error) {
-	ifaces, err := net.Interfaces()
-	if err != nil {
-		return nil, err
-	}
-
-	for _, i := range ifaces {
-		addrs, err := i.Addrs()
-		if err != nil {
-			return nil, err
-		}
-		for _, addr := range addrs {
-			var ip net.IP
-			switch v := addr.(type) {
-			case *net.IPNet:
-				ip = v.IP
-			case *net.IPAddr:
-				ip = v.IP
-			}
-			if ip != nil && ip.IsGlobalUnicast() {
-				availableIPs = append(availableIPs, ip)
-			}
-		}
-	}
-	if len(availableIPs) == 0 {
-		return nil, errors.New("could not determine a single unicast addr, check networking")
-	}
-
-	return availableIPs, nil
-}
-
-func IsPrivateIP(ip net.IP) bool {
-	return isPrivateIPv4(ip) || isPrivateIPv6(ip)
-}
-
-func isPrivateIPv4(ip net.IP) bool {
-	_, private24BitBlock, _ := net.ParseCIDR("10.0.0.0/8")
-	_, private20BitBlock, _ := net.ParseCIDR("172.16.0.0/12")
-	_, private16BitBlock, _ := net.ParseCIDR("192.168.0.0/16")
-	return private24BitBlock.Contains(ip) ||
-		private20BitBlock.Contains(ip) ||
-		private16BitBlock.Contains(ip) ||
-		ip.IsLoopback() ||
-		ip.IsLinkLocalUnicast() ||
-		ip.IsLinkLocalMulticast()
-}
-
-func isPrivateIPv6(ip net.IP) bool {
-	_, block, _ := net.ParseCIDR("fc00::/7")
-
-	return block.Contains(ip) || ip.IsLoopback() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast()
 }
 
 func StartPrometheus(ctx context.Context, listenAddr string) {

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -3,99 +3,10 @@ package util
 import (
 	"fmt"
 	"math/big"
-	"net"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
-
-func TestParseEndpoint(t *testing.T) {
-	tests := []struct {
-		input    string
-		expected string
-		mustErr  bool
-	}{
-		{
-			input:    "192.168.0.1:10001",
-			expected: "10001",
-			mustErr:  false,
-		},
-		{
-			input:    ":10002",
-			expected: "10002",
-			mustErr:  false,
-		},
-		{
-			input:    "192.168.0.1",
-			expected: "",
-			mustErr:  true,
-		},
-		{
-			input:    "192.168.0.1:qwer",
-			expected: "",
-			mustErr:  true,
-		},
-		{
-			input:    "192.168.0.1:99999",
-			expected: "",
-			mustErr:  true,
-		},
-	}
-
-	for _, tt := range tests {
-		port, err := ParseEndpointPort(tt.input)
-		assert.Equal(t, tt.expected, port)
-		if tt.mustErr {
-			assert.Error(t, err)
-		} else {
-			assert.NoError(t, err)
-		}
-	}
-}
-
-func TestIsPrivateIPv4(t *testing.T) {
-	tests := []struct {
-		ip     string
-		isPriv bool
-	}{
-		{ip: "127.0.0.1", isPriv: true},
-		{ip: "127.1.2.3", isPriv: true},
-		{ip: "10.20.30.40", isPriv: true},
-		{ip: "192.168.0.1", isPriv: true},
-		{ip: "172.16.0.1", isPriv: true},
-		{ip: "169.254.0.1", isPriv: true},
-		{ip: "169.254.1.0", isPriv: true},
-		{ip: "169.254.123.222", isPriv: true},
-		{ip: "169.254.255.255", isPriv: true},
-		{ip: "224.0.0.1", isPriv: true},
-
-		{ip: "1.2.3.4", isPriv: false},
-		{ip: "0.0.0.0", isPriv: false},
-	}
-
-	for _, cc := range tests {
-		b := isPrivateIPv4(net.ParseIP(cc.ip))
-		assert.Equal(t, b, cc.isPriv, cc.ip)
-	}
-}
-
-func TestIsPrivateIPv6(t *testing.T) {
-	tests := []struct {
-		ip     string
-		isPriv bool
-	}{
-		{ip: "::", isPriv: false},
-		{ip: "::1", isPriv: true},
-		{ip: "fe80::", isPriv: true},
-		{ip: "feaf::", isPriv: true},
-		{ip: "fc00::", isPriv: true},
-	}
-
-	for _, cc := range tests {
-		b := isPrivateIPv6(net.ParseIP(cc.ip))
-		assert.Equal(t, b, cc.isPriv, cc.ip)
-	}
-}
 
 func TestStringToEtherPrice(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
Changed:
- Replace `util.PubKeyToAddr` with `crypto.PubkeyToAddress`.
- Drop `ParseEndpointPort`.
- Move all network-related stuff to netutil package.