### PR TITLE
fix: default account password

### DIFF
--- a/accounts/multi_keystore.go
+++ b/accounts/multi_keystore.go
@@ -67,6 +67,11 @@ func (m *MultiKeystore) Generate() (*ecdsa.PrivateKey, error) {
 		return nil, errors.Wrap(err, "cannot read pass phrase")
 	}
 
+	return m.GenerateWithPassword(pass)
+}
+
+// GenerateWithPassword generates new key with given pass-phrase
+func (m *MultiKeystore) GenerateWithPassword(pass string) (*ecdsa.PrivateKey, error) {
 	acc, err := m.keyStore.NewAccount(pass)
 	if err != nil {
 		return nil, err

--- a/cmd/cli/commands/common.go
+++ b/cmd/cli/commands/common.go
@@ -51,7 +51,22 @@ var (
 )
 
 func getDefaultKeyOrDie() *ecdsa.PrivateKey {
-	key, err := keystore.GetDefault()
+	defaultAddr, err := keystore.GetDefaultAddress()
+	if err != nil {
+		showError(rootCmd, "cannot read default address from keystore", err)
+		os.Exit(1)
+	}
+
+	var pass = cfg.Eth.Passphrase
+	if pass == "" {
+		pass, err = accounts.NewInteractivePassPhraser().GetPassPhrase()
+		if err != nil {
+			showError(rootCmd, "cannot read pass phrase", err)
+			os.Exit(1)
+		}
+	}
+
+	key, err := keystore.GetKeyWithPass(defaultAddr, pass)
 	if err != nil {
 		showError(rootCmd, "cannot read default key from keystore", err)
 		os.Exit(1)

--- a/cmd/cli/commands/login.go
+++ b/cmd/cli/commands/login.go
@@ -62,13 +62,16 @@ var loginCmd = &cobra.Command{
 			if len(ls) == 0 {
 				// generate new key
 				cmd.Println("Keystore is empty, generating new key...")
-				newKey, err := ks.Generate()
+				// ask for password for default key
+				pass, err := accounts.NewInteractivePassPhraser().GetPassPhrase()
+				newKey, err := ks.GenerateWithPassword(pass)
 				if err != nil {
 					showError(cmd, "Cannot generate new key", err)
 					os.Exit(1)
 				}
-
 				cmd.Printf("Generated key %s set as default\r\n", crypto.PubkeyToAddress(newKey.PublicKey).Hex())
+				cfg.Eth.Passphrase = pass
+				cfg.Save()
 				return
 			}
 


### PR DESCRIPTION
This PR fixes CLI's behaviour in the following way:
- save password for newly generateg keys on `sonmcli login`.
- look for pre-saved key into config, ask interactively if no saved password provied.