### PR TITLE
chore: typo SNMD

### DIFF
--- a/blockchain/source/contracts/SNMD.sol
+++ b/blockchain/source/contracts/SNMD.sol
@@ -9,7 +9,7 @@ contract SNMD is StandardToken, Ownable {
 
     using SafeMath for uint256;
 
-    string public name = "SONM Develompent token";
+    string public name = "SONM Development token";
 
     string public symbol = "SNMD";
 


### PR DESCRIPTION
Fix typo `Develompent` => `Development`