### PR TITLE
chore: lazy truffle provider

### DIFF
--- a/blockchain/source/truffle.js
+++ b/blockchain/source/truffle.js
@@ -29,7 +29,7 @@ module.exports = {
             gasPrice: 0x01,
         },
         private: {
-            provider: new PrivateKeyProvider(privateKey, privateEndpoint),
+            provider: () => new PrivateKeyProvider(privateKey, privateEndpoint),
             network_id: '444', // eslint-disable-line camelcase
         },
     },


### PR DESCRIPTION
Make provaider init on demand.
If endpoint is unavailable its not broke tests.