### PR TITLE
aux: control the restart burst with systemd

### DIFF
--- a/debian/sonm-dwh.service
+++ b/debian/sonm-dwh.service
@@ -6,7 +6,10 @@ Description=SONM DWH
 EnvironmentFile=/etc/default/sonm-dwh
 Type=simple
 ExecStart=/usr/bin/sonmdwh --config=${CONFIG_PATH}
+
 Restart=on-failure
+StartLimitIntervalSec=60
+StartLimitBurst=3
 
 
 [Install]

--- a/debian/sonm-node.service
+++ b/debian/sonm-node.service
@@ -7,7 +7,10 @@ EnvironmentFile=/etc/default/sonm-node
 Type=simple
 ExecStart=/usr/bin/sonmnode --config=${CONFIG_PATH}
 User=sonm
+
 Restart=on-failure
+StartLimitIntervalSec=60
+StartLimitBurst=3
 
 
 [Install]

--- a/debian/sonm-optimus.service
+++ b/debian/sonm-optimus.service
@@ -6,7 +6,10 @@ Description=SONM Optimus
 EnvironmentFile=/etc/default/sonm-optimus
 Type=simple
 ExecStart=/usr/bin/sonmoptimus --config=${CONFIG_PATH}
+
 Restart=on-failure
+StartLimitIntervalSec=60
+StartLimitBurst=3
 
 
 [Install]

--- a/debian/sonm-relay.service
+++ b/debian/sonm-relay.service
@@ -8,6 +8,10 @@ Type=simple
 ExecStart=/usr/bin/sonmrelay --config=${CONFIG_PATH}
 Restart=on-failure
 
+Restart=on-failure
+StartLimitIntervalSec=60
+StartLimitBurst=3
+
 
 [Install]
 WantedBy=multi-user.target

--- a/debian/sonm-rendezvous.service
+++ b/debian/sonm-rendezvous.service
@@ -6,7 +6,10 @@ Description=SONM Rendezvous
 EnvironmentFile=/etc/default/sonm-rendezvous
 Type=simple
 ExecStart=/usr/bin/sonmrendezvous --config=${CONFIG_PATH}
+
 Restart=on-failure
+StartLimitIntervalSec=60
+StartLimitBurst=3
 
 
 [Install]

--- a/debian/sonm-worker.service
+++ b/debian/sonm-worker.service
@@ -6,7 +6,10 @@ Description=SONM Worker
 EnvironmentFile=/etc/default/sonm-worker
 Type=simple
 ExecStart=/usr/bin/sonmworker --config=${CONFIG_PATH}
+
 Restart=on-failure
+StartLimitIntervalSec=60
+StartLimitBurst=3
 
 
 [Install]


### PR DESCRIPTION
This PR adds settings that allow systemd to mark units as broken
if the unit cannot successfully start 3 times a row within 60 seconds.
If it happens, systemd will stop infinitely restarting it.
So helpful in case of misconfiguration.