### PR TITLE
chore: normalize worker/blacklist api (DWH)

### DIFF
--- a/blockchain/api.go
+++ b/blockchain/api.go
@@ -830,7 +830,6 @@ func (api *BasicEventsAPI) GetEvents(ctx context.Context, fromBlockInitial *big.
 			market.BilledTopic,
 			market.WorkerAnnouncedTopic,
 			market.WorkerConfirmedTopic,
-			market.WorkerConfirmedTopic,
 			market.WorkerRemovedTopic,
 			market.AddedToBlacklistTopic,
 			market.RemovedFromBlacklistTopic,
@@ -989,7 +988,7 @@ func (api *BasicEventsAPI) processLog(log types.Log, eventTS uint64, out chan *E
 			sendErr(out, err, topic)
 			return
 		}
-		sendData(&WorkerAnnouncedData{SlaveID: slaveID, MasterID: masterID})
+		sendData(&WorkerAnnouncedData{WorkerID: slaveID, MasterID: masterID})
 	case market.WorkerConfirmedTopic:
 		slaveID, err := extractAddress(log.Topics, 1)
 		if err != nil {
@@ -1001,7 +1000,7 @@ func (api *BasicEventsAPI) processLog(log types.Log, eventTS uint64, out chan *E
 			sendErr(out, err, topic)
 			return
 		}
-		sendData(&WorkerConfirmedData{SlaveID: slaveID, MasterID: masterID})
+		sendData(&WorkerConfirmedData{WorkerID: slaveID, MasterID: masterID})
 	case market.WorkerRemovedTopic:
 		slaveID, err := extractAddress(log.Topics, 1)
 		if err != nil {
@@ -1013,7 +1012,7 @@ func (api *BasicEventsAPI) processLog(log types.Log, eventTS uint64, out chan *E
 			sendErr(out, err, topic)
 			return
 		}
-		sendData(&WorkerRemovedData{SlaveID: slaveID, MasterID: masterID})
+		sendData(&WorkerRemovedData{WorkerID: slaveID, MasterID: masterID})
 	case market.AddedToBlacklistTopic:
 		adderID, err := extractAddress(log.Topics, 1)
 		if err != nil {

--- a/blockchain/types.go
+++ b/blockchain/types.go
@@ -54,17 +54,17 @@ type BilledData struct {
 }
 
 type WorkerAnnouncedData struct {
-	SlaveID  common.Address
+	WorkerID common.Address
 	MasterID common.Address
 }
 
 type WorkerConfirmedData struct {
-	SlaveID  common.Address
+	WorkerID common.Address
 	MasterID common.Address
 }
 
 type WorkerRemovedData struct {
-	SlaveID  common.Address
+	WorkerID common.Address
 	MasterID common.Address
 }
 

--- a/insonmnia/dwh/server.go
+++ b/insonmnia/dwh/server.go
@@ -471,15 +471,15 @@ func (m *DWH) processEvent(event *blockchain.Event) error {
 	case *blockchain.BilledData:
 		return m.onBilled(event.TS, value.DealID, value.PaidAmount)
 	case *blockchain.WorkerAnnouncedData:
-		return m.onWorkerAnnounced(value.MasterID.Hex(), value.SlaveID.Hex())
+		return m.onWorkerAnnounced(value.MasterID, value.WorkerID)
 	case *blockchain.WorkerConfirmedData:
-		return m.onWorkerConfirmed(value.MasterID.Hex(), value.SlaveID.Hex())
+		return m.onWorkerConfirmed(value.MasterID, value.WorkerID)
 	case *blockchain.WorkerRemovedData:
-		return m.onWorkerRemoved(value.MasterID.Hex(), value.SlaveID.Hex())
+		return m.onWorkerRemoved(value.MasterID, value.WorkerID)
 	case *blockchain.AddedToBlacklistData:
-		return m.onAddedToBlacklist(value.AdderID.Hex(), value.AddeeID.Hex())
+		return m.onAddedToBlacklist(value.AdderID, value.AddeeID)
 	case *blockchain.RemovedFromBlacklistData:
-		m.onRemovedFromBlacklist(value.RemoverID.Hex(), value.RemoveeID.Hex())
+		m.onRemovedFromBlacklist(value.RemoverID, value.RemoveeID)
 	case *blockchain.ValidatorCreatedData:
 		return m.onValidatorCreated(value.ID)
 	case *blockchain.ValidatorDeletedData:
@@ -903,7 +903,7 @@ func (m *DWH) onOrderUpdated(orderID *big.Int) error {
 	return nil
 }
 
-func (m *DWH) onWorkerAnnounced(masterID, slaveID string) error {
+func (m *DWH) onWorkerAnnounced(masterID, slaveID common.Address) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -926,7 +926,7 @@ func (m *DWH) onWorkerAnnounced(masterID, slaveID string) error {
 	return nil
 }
 
-func (m *DWH) onWorkerConfirmed(masterID, slaveID string) error {
+func (m *DWH) onWorkerConfirmed(masterID, slaveID common.Address) error {
 	conn := newSimpleConn(m.db)
 	defer conn.Finish()
 
@@ -937,7 +937,7 @@ func (m *DWH) onWorkerConfirmed(masterID, slaveID string) error {
 	return nil
 }
 
-func (m *DWH) onWorkerRemoved(masterID, slaveID string) error {
+func (m *DWH) onWorkerRemoved(masterID, slaveID common.Address) error {
 	conn := newSimpleConn(m.db)
 	defer conn.Finish()
 
@@ -948,7 +948,7 @@ func (m *DWH) onWorkerRemoved(masterID, slaveID string) error {
 	return nil
 }
 
-func (m *DWH) onAddedToBlacklist(adderID, addeeID string) error {
+func (m *DWH) onAddedToBlacklist(adderID, addeeID common.Address) error {
 	conn := newSimpleConn(m.db)
 	defer conn.Finish()
 
@@ -959,7 +959,7 @@ func (m *DWH) onAddedToBlacklist(adderID, addeeID string) error {
 	return nil
 }
 
-func (m *DWH) onRemovedFromBlacklist(removerID, removeeID string) error {
+func (m *DWH) onRemovedFromBlacklist(removerID, removeeID common.Address) error {
 	conn := newSimpleConn(m.db)
 	defer conn.Finish()
 

--- a/insonmnia/dwh/server_test.go
+++ b/insonmnia/dwh/server_test.go
@@ -589,8 +589,8 @@ func TestDWH_monitor(t *testing.T) {
 
 	monitorDWH.blockchain = mockBlock
 
-	err = monitorDWH.storage.InsertWorker(newSimpleConn(monitorDWH.db), common.Address{}.Hex(),
-		"0x000000000000000000000000000000000000000d")
+	err = monitorDWH.storage.InsertWorker(newSimpleConn(monitorDWH.db), common.Address{},
+		common.HexToAddress("0x000000000000000000000000000000000000000d"))
 	if err != nil {
 		t.Error("failed to insert worker (additional)")
 	}
@@ -615,8 +615,8 @@ func TestDWH_monitor(t *testing.T) {
 		t.Errorf("testOrderUpdated: %s", err)
 		return
 	}
-	err = monitorDWH.storage.DeleteWorker(newSimpleConn(monitorDWH.db), common.Address{}.Hex(),
-		"0x000000000000000000000000000000000000000d")
+	err = monitorDWH.storage.DeleteWorker(newSimpleConn(monitorDWH.db), common.Address{},
+		common.HexToAddress("0x000000000000000000000000000000000000000d"))
 	if err != nil {
 		t.Error("failed to delete worker (additional)")
 	}
@@ -983,8 +983,7 @@ func testDealClosed(deal *pb.Deal, commonID *big.Int) error {
 
 func testWorkerAnnouncedConfirmedRemoved() error {
 	// Check that a worker is added after a WorkerAnnounced event.
-	if err := monitorDWH.onWorkerAnnounced(common.HexToAddress("0xC").Hex(),
-		common.HexToAddress("0xD").Hex()); err != nil {
+	if err := monitorDWH.onWorkerAnnounced(common.HexToAddress("0xC"), common.HexToAddress("0xD")); err != nil {
 		return errors.Wrap(err, "onWorkerAnnounced failed")
 	}
 	if workers, _, err := monitorDWH.storage.GetWorkers(newSimpleConn(monitorDWH.db), &pb.WorkersRequest{}); err != nil {
@@ -999,8 +998,7 @@ func testWorkerAnnouncedConfirmedRemoved() error {
 		}
 	}
 	// Check that a worker is confirmed after a WorkerConfirmed event.
-	if err := monitorDWH.onWorkerConfirmed(common.HexToAddress("0xC").Hex(),
-		common.HexToAddress("0xD").Hex()); err != nil {
+	if err := monitorDWH.onWorkerConfirmed(common.HexToAddress("0xC"), common.HexToAddress("0xD")); err != nil {
 		return errors.Wrap(err, "onWorkerConfirmed failed")
 	}
 	if workers, _, err := monitorDWH.storage.GetWorkers(newSimpleConn(monitorDWH.db), &pb.WorkersRequest{}); err != nil {
@@ -1015,8 +1013,7 @@ func testWorkerAnnouncedConfirmedRemoved() error {
 		}
 	}
 	// Check that a worker is deleted after a WorkerRemoved event.
-	if err := monitorDWH.onWorkerRemoved(common.HexToAddress("0xC").Hex(),
-		common.HexToAddress("0xD").Hex()); err != nil {
+	if err := monitorDWH.onWorkerRemoved(common.HexToAddress("0xC"), common.HexToAddress("0xD")); err != nil {
 		return errors.Wrap(err, "onWorkerRemoved failed")
 	}
 	if workers, _, err := monitorDWH.storage.GetWorkers(newSimpleConn(monitorDWH.db), &pb.WorkersRequest{}); err != nil {
@@ -1031,8 +1028,7 @@ func testWorkerAnnouncedConfirmedRemoved() error {
 
 func testBlacklistAddedRemoved() error {
 	// Check that a Blacklist entry is added after AddedToBlacklist event.
-	if err := monitorDWH.onAddedToBlacklist(common.HexToAddress("0xC").Hex(),
-		common.HexToAddress("0xD").Hex()); err != nil {
+	if err := monitorDWH.onAddedToBlacklist(common.HexToAddress("0xC"), common.HexToAddress("0xD")); err != nil {
 		return errors.Wrap(err, "onAddedToBlacklist failed")
 	}
 	if blacklistReply, err := monitorDWH.storage.GetBlacklist(
@@ -1045,8 +1041,7 @@ func testBlacklistAddedRemoved() error {
 		}
 	}
 	// Check that a Blacklist entry is deleted after RemovedFromBlacklist event.
-	if err := monitorDWH.onRemovedFromBlacklist(common.HexToAddress("0xC").Hex(),
-		common.HexToAddress("0xD").Hex()); err != nil {
+	if err := monitorDWH.onRemovedFromBlacklist(common.HexToAddress("0xC"), common.HexToAddress("0xD")); err != nil {
 		return errors.Wrap(err, "onRemovedFromBlacklist failed")
 	}
 	if repl, err := monitorDWH.storage.GetBlacklist(
@@ -1091,12 +1086,6 @@ func getCertificates(w *DWH) ([]*pb.Certificate, error) {
 	}
 
 	return out, nil
-}
-
-type dealPayment struct {
-	BilledTS   uint64
-	PaidAmount string
-	DealID     string
 }
 
 func setupTestDB(w *DWH) error {

--- a/insonmnia/dwh/sql.go
+++ b/insonmnia/dwh/sql.go
@@ -671,9 +671,9 @@ func (m *sqlStorage) UpdateDealConditionEndTime(conn queryConn, dealConditionID,
 	return err
 }
 
-func (m *sqlStorage) CheckWorkerExists(conn queryConn, masterID, workerID string) (bool, error) {
+func (m *sqlStorage) CheckWorkerExists(conn queryConn, masterID, workerID common.Address) (bool, error) {
 	query, args, _ := m.builder().Select("MasterID").From("Workers").
-		Where("MasterID = ?", masterID).Where("WorkerID = ?", workerID).ToSql()
+		Where("MasterID = ?", masterID.Hex()).Where("WorkerID = ?", workerID.Hex()).ToSql()
 	rows, err := conn.Query(query, args...)
 	if err != nil {
 		return false, errors.Wrap(err, "failed to run CheckWorker query")
@@ -682,22 +682,22 @@ func (m *sqlStorage) CheckWorkerExists(conn queryConn, masterID, workerID string
 	return rows.Next(), nil
 }
 
-func (m *sqlStorage) InsertWorker(conn queryConn, masterID, workerID string) error {
-	query, args, err := m.builder().Insert("Workers").Values(masterID, workerID, false).ToSql()
+func (m *sqlStorage) InsertWorker(conn queryConn, masterID, workerID common.Address) error {
+	query, args, err := m.builder().Insert("Workers").Values(masterID.Hex(), workerID.Hex(), false).ToSql()
 	_, err = conn.Exec(query, args...)
 	return err
 }
 
-func (m *sqlStorage) UpdateWorker(conn queryConn, masterID, workerID string) error {
-	query, args, err := m.builder().Update("Workers").Set("Confirmed", true).Where("MasterID = ?", masterID).
-		Where("WorkerID = ?", workerID).ToSql()
+func (m *sqlStorage) UpdateWorker(conn queryConn, masterID, workerID common.Address) error {
+	query, args, err := m.builder().Update("Workers").Set("Confirmed", true).Where("MasterID = ?", masterID.Hex()).
+		Where("WorkerID = ?", workerID.Hex()).ToSql()
 	_, err = conn.Exec(query, args...)
 	return err
 }
 
-func (m *sqlStorage) DeleteWorker(conn queryConn, masterID, workerID string) error {
-	query, args, err := m.builder().Delete("Workers").Where("MasterID = ?", masterID).
-		Where("WorkerID = ?", workerID).ToSql()
+func (m *sqlStorage) DeleteWorker(conn queryConn, masterID, workerID common.Address) error {
+	query, args, err := m.builder().Delete("Workers").Where("MasterID = ?", masterID.Hex()).
+		Where("WorkerID = ?", workerID.Hex()).ToSql()
 	_, err = conn.Exec(query, args...)
 	return err
 }
@@ -719,15 +719,15 @@ func (m *sqlStorage) GetMasterByWorker(conn queryConn, slaveID common.Address) (
 	return util.HexToAddress(masterID)
 }
 
-func (m *sqlStorage) InsertBlacklistEntry(conn queryConn, adderID, addeeID string) error {
-	query, args, err := m.builder().Insert("Blacklists").Values(adderID, addeeID).ToSql()
+func (m *sqlStorage) InsertBlacklistEntry(conn queryConn, adderID, addeeID common.Address) error {
+	query, args, err := m.builder().Insert("Blacklists").Values(adderID.Hex(), addeeID.Hex()).ToSql()
 	_, err = conn.Exec(query, args...)
 	return err
 }
 
-func (m *sqlStorage) DeleteBlacklistEntry(conn queryConn, removerID, removeeID string) error {
-	query, args, err := m.builder().Delete("Blacklists").Where("AdderID = ?", removerID).
-		Where("AddeeID = ?", removeeID).ToSql()
+func (m *sqlStorage) DeleteBlacklistEntry(conn queryConn, removerID, removeeID common.Address) error {
+	query, args, err := m.builder().Delete("Blacklists").Where("AdderID = ?", removerID.Hex()).
+		Where("AddeeID = ?", removeeID.Hex()).ToSql()
 	_, err = conn.Exec(query, args...)
 	return err
 }

--- a/insonmnia/dwh/storage.go
+++ b/insonmnia/dwh/storage.go
@@ -37,13 +37,13 @@ type storage interface {
 	InsertDealCondition(conn queryConn, condition *pb.DealCondition) error
 	UpdateDealConditionPayout(conn queryConn, dealConditionID uint64, payout *big.Int) error
 	UpdateDealConditionEndTime(conn queryConn, dealConditionID, eventTS uint64) error
-	CheckWorkerExists(conn queryConn, masterID, workerID string) (bool, error)
-	InsertWorker(conn queryConn, masterID, slaveID string) error
-	UpdateWorker(conn queryConn, masterID, slaveID string) error
-	DeleteWorker(conn queryConn, masterID, slaveID string) error
-	GetMasterByWorker(conn queryConn, slaveID common.Address) (common.Address, error)
-	InsertBlacklistEntry(conn queryConn, adderID, addeeID string) error
-	DeleteBlacklistEntry(conn queryConn, removerID, removeeID string) error
+	CheckWorkerExists(conn queryConn, masterID, workerID common.Address) (bool, error)
+	InsertWorker(conn queryConn, masterID, workerID common.Address) error
+	UpdateWorker(conn queryConn, masterID, workerID common.Address) error
+	DeleteWorker(conn queryConn, masterID, workerID common.Address) error
+	GetMasterByWorker(conn queryConn, workerID common.Address) (common.Address, error)
+	InsertBlacklistEntry(conn queryConn, adderID, addeeID common.Address) error
+	DeleteBlacklistEntry(conn queryConn, removerID, removeeID common.Address) error
 	GetBlacklist(conn queryConn, request *pb.BlacklistRequest) (*pb.BlacklistReply, error)
 	InsertValidator(conn queryConn, validator *pb.Validator) error
 	UpdateValidator(conn queryConn, validator *pb.Validator) error


### PR DESCRIPTION
* Renamed `SlaveID` -> `WorkerID` (consistent with blockchain naming);
* Changed `storage` interface to use `common.Address` instead of strings;
* Removed a bit of unused code.