### PR TITLE
fix: puncher should extract incoming connections

### DIFF
--- a/insonmnia/npp/puncher.go
+++ b/insonmnia/npp/puncher.go
@@ -209,8 +209,12 @@ func (m *natPuncher) punch(ctx context.Context, addrs *sonm.RendezvousReply) (ne
 	channel := make(chan connTuple, 1)
 	go m.doPunch(ctx, addrs, channel)
 
-	conn := <-channel
-	return conn.unwrap()
+	select {
+	case conn := <-channel:
+		return conn.unwrap()
+	case conn := <-m.listenerChannel:
+		return conn.unwrap()
+	}
 }
 
 func (m *natPuncher) doPunch(ctx context.Context, addrs *sonm.RendezvousReply, channel chan<- connTuple) {


### PR DESCRIPTION
For some unknown reasons I forgot to extract incoming connections in the Puncher.
This lead to a situation when one peer succeed to establish a connection, but nothing happened, because the other side accepted that connection and did nothing with it.