### PR TITLE
feat: debug worker via pprof on demand

### DIFF
--- a/insonmnia/worker/config.go
+++ b/insonmnia/worker/config.go
@@ -13,6 +13,7 @@ import (
 	"github.com/sonm-io/core/insonmnia/state"
 	"github.com/sonm-io/core/insonmnia/worker/plugin"
 	"github.com/sonm-io/core/insonmnia/worker/salesman"
+	"github.com/sonm-io/core/util/debug"
 )
 
 type SSHConfig struct {
@@ -55,6 +56,7 @@ type Config struct {
 	Master            common.Address      `yaml:"master" required:"true"`
 	Development       *DevConfig          `yaml:"development"`
 	Admin             *common.Address     `yaml:"admin"`
+	Debug             *debug.Config       `yaml:"debug"`
 }
 
 // NewConfig creates a new Worker config from the specified YAML file.

--- a/insonmnia/worker/server.go
+++ b/insonmnia/worker/server.go
@@ -28,6 +28,7 @@ import (
 	"github.com/sonm-io/core/insonmnia/worker/gpu"
 	"github.com/sonm-io/core/insonmnia/worker/salesman"
 	"github.com/sonm-io/core/util"
+	"github.com/sonm-io/core/util/debug"
 	"github.com/sonm-io/core/util/multierror"
 	"github.com/sonm-io/core/util/xgrpc"
 
@@ -914,6 +915,11 @@ func (m *Worker) setupServer() error {
 	pb.RegisterWorkerServer(grpcServer, m)
 	pb.RegisterWorkerManagementServer(grpcServer, m)
 	grpc_prometheus.Register(grpcServer)
+
+	if m.cfg.Debug != nil {
+		go debug.ServePProf(m.ctx, *m.cfg.Debug, log.G(m.ctx))
+	}
+
 	return nil
 }
 

--- a/util/debug/pprof.go
+++ b/util/debug/pprof.go
@@ -1,0 +1,53 @@
+package debug
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/pprof"
+
+	"go.uber.org/zap"
+)
+
+const (
+	prefix = "/debug/pprof"
+	ipAddr = "localhost"
+)
+
+type Config struct {
+	Port uint16 `yaml:"port" default:"6060"`
+}
+
+// ServePProf starts pprof HTTP server on the specified port, blocking until
+// the context is done.
+func ServePProf(ctx context.Context, cfg Config, log *zap.Logger) error {
+	addr := fmt.Sprintf("%s:%d", ipAddr, cfg.Port)
+	listener, err := net.Listen("tcp", addr)
+	if err != nil {
+		return err
+	}
+
+	defer listener.Close()
+
+	go func() error {
+		log.Sugar().Infof("starting pprof server on %s", addr)
+		defer log.Sugar().Infof("stopped pprof server on %s", addr)
+
+		return http.Serve(listener, newHandler(prefix))
+	}()
+
+	<-ctx.Done()
+	return ctx.Err()
+}
+
+func newHandler(prefix string) http.Handler {
+	handler := http.NewServeMux()
+	handler.HandleFunc(prefix+"/", pprof.Index)
+	handler.HandleFunc(prefix+"/cmdline", pprof.Cmdline)
+	handler.HandleFunc(prefix+"/profile", pprof.Profile)
+	handler.HandleFunc(prefix+"/symbol", pprof.Symbol)
+	handler.HandleFunc(prefix+"/trace", pprof.Trace)
+
+	return handler
+}


### PR DESCRIPTION
This commit activates debug subsystem in the worker by optionally running a debug HTTP pprof server.