### PR TITLE
fix: use askplan hasher instead of hardware hasher 

### DIFF
--- a/insonmnia/worker/server.go
+++ b/insonmnia/worker/server.go
@@ -559,7 +559,8 @@ func (m *Worker) StartTask(ctx context.Context, request *pb.StartTaskRequest) (*
 		spec.Resources.GPU = ask.Resources.GPU
 	}
 
-	err = spec.GetResources().GetGPU().Normalize(m.hardware)
+	hasher := &pb.AskPlanHasher{ask.GetResources()}
+	err = spec.GetResources().GetGPU().Normalize(hasher)
 	if err != nil {
 		log.G(ctx).Error("could not normalize GPU resources", zap.Error(err))
 		m.setStatus(&pb.TaskStatusReply{Status: pb.TaskStatusReply_BROKEN}, taskID)

--- a/proto/ask_plan.go
+++ b/proto/ask_plan.go
@@ -213,6 +213,22 @@ type GPUHasher interface {
 	HashGPU(indexes []uint64) (hashes []string, err error)
 }
 
+type AskPlanHasher struct {
+	*AskPlanResources
+}
+
+func (m *AskPlanHasher) HashGPU(indexes []uint64) ([]string, error) {
+	askPlanHashes := m.GetGPU().GetHashes()
+	resultHashes := make([]string, 0, len(indexes))
+	for _, idx := range indexes {
+		if idx >= uint64(len(askPlanHashes)) {
+			return nil, fmt.Errorf("invalid GPU index %d", idx)
+		}
+		resultHashes = append(resultHashes, askPlanHashes[idx])
+	}
+	return resultHashes, nil
+}
+
 func (m *AskPlanGPU) Normalize(hasher GPUHasher) error {
 	if m == nil || m.Normalized() {
 		return nil


### PR DESCRIPTION
Now we use indexes from ask-plan to determine gpu hash instead of hardware. This allows to use GPU indexes as they appear in ask-plan rather then in hardaware