### PR TITLE
refactor: makefile design

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 0.2.2.{build}
+version: 0.4.0.{build}
 
 platform: x86
 
@@ -18,12 +18,16 @@ install:
 
 build_script:
   - git submodule update --init --recursive
-  - c:\MinGW\bin\mingw32-make.exe build/cli_win32
-  - c:\MinGW\bin\mingw32-make.exe build/node_win32
+  - c:\MinGW\bin\mingw32-make.exe build/cli
+  - c:\MinGW\bin\mingw32-make.exe build/node
+  - c:\MinGW\bin\mingw32-make.exe build/optimus
 
 artifacts:
-  - path: target/sonmcli_win32.exe
+  - path: target/sonmcli_windows_386.exe
     name: CLI
 
-  - path: target/sonmnode_win32.exe
+  - path: target/sonmnode_windows_386.exe
     name: Node
+
+  - path: target/sonmoptimus_windows_386.exe
+    name: Optimus


### PR DESCRIPTION
Now binaries produces by make contain the proper OS and ARCH suffixes even if they are compiled using cross-compilation feature.

Hence, there is no need for `build/*_linux` and `build/*_win32` targets. Now cross-platform binaries can be build using something like this:

`GOOS=windows GOARCH=386 make build/node`

You can read more about supported platforms and architectures: https://github.com/golang/go/wiki/MinimumRequirements.