### PR TITLE
fix: possible segfault in FileExists and DirectoryExists

### DIFF
--- a/accounts/keys.go
+++ b/accounts/keys.go
@@ -66,8 +66,8 @@ func (o *defaultKeyOpener) OpenKeystore() (bool, error) {
 		}
 	}()
 
-	if !util.DirectoryExists(o.keyDirPath) {
-		return false, errNoKeystoreDir
+	if err := util.DirectoryExists(o.keyDirPath); err != nil {
+		return false, err
 	}
 
 	passPhrase, err := o.pf.GetPassPhrase()
@@ -215,7 +215,7 @@ func DefaultKeyOpener(p Printer, keyDir, passPhrase string) (KeyOpener, error) {
 
 	p.Printf("Using %s as KeyStore directory\r\n", keyDir)
 
-	if !util.DirectoryExists(keyDir) {
+	if err := util.DirectoryExists(keyDir); err != nil {
 		p.Printf("KeyStore directory does not exist, try to create it...\r\n")
 		err = os.MkdirAll(keyDir, 0700)
 		if err != nil {

--- a/accounts/keys_test.go
+++ b/accounts/keys_test.go
@@ -46,7 +46,7 @@ func TestNewKeyOpener_NoDir(t *testing.T) {
 	K := NewKeyOpener(testKeyStorePath, pf)
 
 	_, err := K.OpenKeystore()
-	assert.EqualError(t, err, errNoKeystoreDir.Error(), "Must not be opened with non-existent dir")
+	assert.Errorf(t, err, "Must not be opened with non-existent dir")
 }
 
 func TestNewKeyOpener_GetKey(t *testing.T) {

--- a/accounts/multi_keystore.go
+++ b/accounts/multi_keystore.go
@@ -2,6 +2,7 @@ package accounts
 
 import (
 	"crypto/ecdsa"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path"
@@ -130,8 +131,9 @@ func (m *MultiKeystore) SetDefault(addr common.Address) error {
 }
 
 func (m *MultiKeystore) GetDefaultAddress() (common.Address, error) {
-	if !util.FileExists(m.cfg.getStateFilePath()) {
-		return common.Address{}, errors.New("cannot find keystore's state")
+	err := util.FileExists(m.cfg.getStateFilePath())
+	if err != nil {
+		return common.Address{}, fmt.Errorf("failed to access keystore's state: %s", err)
 	}
 
 	data, err := ioutil.ReadFile(m.cfg.getStateFilePath())
@@ -186,7 +188,7 @@ func (m *MultiKeystore) readKeyFile(path string, pass string) (*ecdsa.PrivateKey
 }
 
 func (m *MultiKeystore) setDefaultAccount(addr common.Address) error {
-	if !util.DirectoryExists(m.cfg.getStateFileDir()) {
+	if err := util.DirectoryExists(m.cfg.getStateFileDir()); err != nil {
 		if err := os.MkdirAll(m.cfg.getStateFileDir(), 0700); err != nil {
 			return errors.WithMessage(err, "cannot create dir for state")
 		}

--- a/util/util.go
+++ b/util/util.go
@@ -34,23 +34,34 @@ func GetPlatformName() string {
 	return fmt.Sprintf("%s/%s/%s", runtime.GOOS, runtime.GOARCH, runtime.Version())
 }
 
-func FileExists(p string) bool {
+func FileExists(p string) error {
 	f, err := os.Stat(p)
 	if err != nil {
-		return !os.IsNotExist(err) && !f.IsDir()
+		if os.IsNotExist(err) {
+			return fmt.Errorf("%s does not exist", p)
+		}
+		return fmt.Errorf("failed to access %s: %s", p, err)
 	}
-
-	return !f.IsDir()
+	if f.IsDir() {
+		return fmt.Errorf("%s is directory", p)
+	}
+	return nil
 }
 
 // DirectoryExists returns true if the given directory exists
-func DirectoryExists(p string) bool {
+func DirectoryExists(p string) error {
 	f, err := os.Stat(p)
 	if err != nil {
-		return false
+		if os.IsNotExist(err) {
+			return fmt.Errorf("%s does not exist", p)
+		}
+		return fmt.Errorf("failed to access %s: %s", p, err)
 	}
 
-	return f.IsDir()
+	if !f.IsDir() {
+		return fmt.Errorf("%s is not a directory", p)
+	}
+	return nil
 }
 
 // ParseBigInt parses the given string and converts it to *big.Int


### PR DESCRIPTION
In some cases there could be underlying error while determine whether file(dir) exists or not. This PR changes return type to error, which is more descriptive and removes f.IsDir() call on the nil receiver.