### PR TITLE
fix: proper container cleanup on finished deal

### DIFF
--- a/insonmnia/worker/network/tinc_network.go
+++ b/insonmnia/worker/network/tinc_network.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"net"
 	"strings"
-	"time"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/pkg/stdcopy"
@@ -63,8 +62,7 @@ func (t *TincNetwork) Start(ctx context.Context, addr string) error {
 }
 
 func (t *TincNetwork) Shutdown(ctx context.Context) error {
-	timeout := time.Second * 120
-	t.cli.ContainerStop(ctx, t.TincContainerID, &timeout)
+	t.cli.ContainerKill(ctx, t.TincContainerID, "SIGKILL")
 	return nil
 }
 

--- a/insonmnia/worker/overseer.go
+++ b/insonmnia/worker/overseer.go
@@ -574,6 +574,9 @@ func (o *overseer) OnDealFinish(ctx context.Context, containerID string) error {
 			result = multierror.Append(result, err)
 		}
 	}
+	if err := descriptor.Cleanup(); err != nil {
+		result = multierror.Append(result, err)
+	}
 	if err := descriptor.Remove(ctx); err != nil {
 		result = multierror.Append(result, err)
 	}

--- a/insonmnia/worker/salesman/salesman.go
+++ b/insonmnia/worker/salesman/salesman.go
@@ -170,6 +170,9 @@ func (m *Salesman) maybeShutdownAskPlan(ctx context.Context, plan *sonm.AskPlan)
 		if err != nil {
 			return err
 		}
+		if err := m.checkDeal(ctx, plan, dealInfo); err != nil {
+			return err
+		}
 		if dealInfo.Status == sonm.DealStatus_DEAL_ACCEPTED {
 			if dealInfo.GetDuration() == 0 {
 				m.log.Infof("closing spot deal %s for ask plan %s", dealInfo.GetId(), plan.GetID())
@@ -178,8 +181,7 @@ func (m *Salesman) maybeShutdownAskPlan(ctx context.Context, plan *sonm.AskPlan)
 				}
 			} else {
 				m.log.Debugf("ask plan %s is still bound to deal %s, checking deal", plan.ID, plan.GetDealID().Unwrap().String())
-				// It's not the error - we just need to wait for deal to finish
-				return m.checkDeal(ctx, plan, dealInfo)
+				return nil
 			}
 		}
 	}


### PR DESCRIPTION
This PR: 
  * Fixes situation when worker did not get deal notification when ask-plan was scheduled for deletion.
  * Restores cleanup call on container.
  * Uses sigkill with no regret for tinc as it does not respond to ContainerStop anyway.
This all results in a proper cleanup of the deal containers and resources release.