### PR TITLE
refactor: attempt to log everything in NPP

### DIFF
--- a/insonmnia/node/server.go
+++ b/insonmnia/node/server.go
@@ -75,7 +75,7 @@ func (re *remoteOptions) getWorkerClientByEthAddr(ctx context.Context, eth strin
 func newRemoteOptions(ctx context.Context, key *ecdsa.PrivateKey, cfg *Config, credentials credentials.TransportCredentials) (*remoteOptions, error) {
 	nppDialerOptions := []npp.Option{
 		npp.WithRendezvous(cfg.NPP.Rendezvous, credentials),
-		npp.WithRelayClient(cfg.NPP.Relay.Endpoints),
+		npp.WithRelayClient(cfg.NPP.Relay.Endpoints, log.G(ctx)),
 		npp.WithLogger(log.G(ctx)),
 	}
 	nppDialer, err := npp.NewDialer(ctx, nppDialerOptions...)

--- a/insonmnia/npp/dial.go
+++ b/insonmnia/npp/dial.go
@@ -88,13 +88,13 @@ func (m *Dialer) DialContext(ctx context.Context, addr auth.Addr) (net.Conn, err
 
 	select {
 	case conn := <-nppChannel:
-		switch err := conn.err; err {
-		case nil:
+		err := conn.Error()
+		if err == nil {
 			log.Debug("successfully connected using NPP", zap.Stringer("remote_peer", conn.RemoteAddr()))
 			return conn.unwrap()
-		default:
-			log.Warn("failed to connect using NPP", zap.Error(err))
 		}
+
+		log.Warn("failed to connect using NPP", zap.Error(err))
 
 		if m.relayDial == nil {
 			log.Debug("no relay configured - returning error", zap.Error(err))
@@ -112,10 +112,10 @@ func (m *Dialer) DialContext(ctx context.Context, addr auth.Addr) (net.Conn, err
 
 	select {
 	case conn := <-channel:
-		switch err := conn.err; err {
-		case nil:
+		err := conn.Error()
+		if err == nil {
 			log.Debug("successfully connected using Relay", zap.Stringer("remote_peer", conn.RemoteAddr()))
-		default:
+		} else {
 			log.Warn("failed to connect using Relay", zap.Error(err))
 		}
 

--- a/insonmnia/npp/dial.go
+++ b/insonmnia/npp/dial.go
@@ -56,6 +56,9 @@ func (m *Dialer) Dial(addr auth.Addr) (net.Conn, error) {
 // connected, any expiration of the context will not affect the
 // connection.
 func (m *Dialer) DialContext(ctx context.Context, addr auth.Addr) (net.Conn, error) {
+	log := m.log.With(zap.Stringer("remote_addr", addr))
+	log.Debug("connecting to remote peer")
+
 	if conn := m.dialDirect(ctx, addr); conn != nil {
 		return conn, nil
 	}
@@ -65,7 +68,10 @@ func (m *Dialer) DialContext(ctx context.Context, addr auth.Addr) (net.Conn, err
 		return nil, err
 	}
 
-	nppCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	timeout := 5 * time.Second
+	log.Debug("connecting using NPP", zap.Duration("timeout", timeout))
+
+	nppCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
 	nppChannel := make(chan connTuple)
@@ -82,15 +88,23 @@ func (m *Dialer) DialContext(ctx context.Context, addr auth.Addr) (net.Conn, err
 
 	select {
 	case conn := <-nppChannel:
-		if conn.err != nil {
-			m.log.Warn("failed to dial via rendezvous", zap.Error(err))
+		switch err := conn.err; err {
+		case nil:
+			log.Debug("successfully connected using NPP", zap.Stringer("remote_peer", conn.RemoteAddr()))
+			return conn.unwrap()
+		default:
+			log.Warn("failed to connect using NPP", zap.Error(err))
 		}
-		if conn.err == nil || m.relayDial == nil {
+
+		if m.relayDial == nil {
+			log.Debug("no relay configured - returning error", zap.Error(err))
 			return conn.unwrap()
 		}
 	case <-nppCtx.Done():
+		log.Warn("failed to connect using NPP", zap.Error(ctx.Err()))
 	}
 
+	log.Debug("connecting using Relay")
 	channel := make(chan connTuple)
 	go func() {
 		channel <- newConnTuple(m.relayDial(ethAddr))
@@ -98,25 +112,40 @@ func (m *Dialer) DialContext(ctx context.Context, addr auth.Addr) (net.Conn, err
 
 	select {
 	case conn := <-channel:
+		switch err := conn.err; err {
+		case nil:
+			log.Debug("successfully connected using Relay", zap.Stringer("remote_peer", conn.RemoteAddr()))
+		default:
+			log.Warn("failed to connect using Relay", zap.Error(err))
+		}
+
 		return conn.unwrap()
 	case <-ctx.Done():
+		log.Warn("failed to connect using Relay", zap.Error(ctx.Err()))
 		return nil, ctx.Err()
 	}
 }
 
+// Note, that this method acts as an optimization.
 func (m *Dialer) dialDirect(ctx context.Context, addr auth.Addr) net.Conn {
-	netAddr, err := addr.Addr()
-	if err == nil {
-		dialer := net.Dialer{}
-		conn, err := dialer.DialContext(ctx, "tcp", netAddr)
-		if err == nil {
-			return conn
-		}
+	log := m.log.With(zap.Stringer("remote_addr", addr))
+	log.Debug("connecting using direct TCP")
 
-		m.log.Warn("failed to dial directly", zap.Error(err), zap.String("remote_peer", netAddr))
+	netAddr, err := addr.Addr()
+	if err != nil {
+		log.Debug("failed to connect using direct TCP", zap.Error(err))
+		return nil
 	}
 
-	return nil
+	dial := net.Dialer{}
+	conn, err := dial.DialContext(ctx, "tcp", netAddr)
+	if err != nil {
+		log.Debug("failed to connect using direct TCP", zap.Error(err))
+		return nil
+	}
+
+	log.Debug("successfully connected using direct TCP")
+	return conn
 }
 
 // Close closes the dialer.

--- a/insonmnia/npp/options.go
+++ b/insonmnia/npp/options.go
@@ -94,7 +94,7 @@ func WithNPPBackoff(min, max time.Duration) Option {
 //
 // Without this option no intermediate server will be used for relaying
 // TCP.
-func WithRelay(addrs []netutil.TCPAddr, key *ecdsa.PrivateKey) Option {
+func WithRelay(addrs []netutil.TCPAddr, key *ecdsa.PrivateKey, log *zap.Logger) Option {
 	return func(o *options) error {
 		signedAddr, err := relay.NewSignedAddr(key)
 		if err != nil {
@@ -103,7 +103,7 @@ func WithRelay(addrs []netutil.TCPAddr, key *ecdsa.PrivateKey) Option {
 
 		o.relayListen = func() (net.Conn, error) {
 			for _, addr := range addrs {
-				conn, err := relay.Listen(&addr, signedAddr)
+				conn, err := relay.ListenWithLog(&addr, signedAddr, log)
 				if err == nil {
 					return conn, nil
 				}
@@ -116,11 +116,11 @@ func WithRelay(addrs []netutil.TCPAddr, key *ecdsa.PrivateKey) Option {
 	}
 }
 
-func WithRelayClient(addrs []netutil.TCPAddr) Option {
+func WithRelayClient(addrs []netutil.TCPAddr, log *zap.Logger) Option {
 	return func(o *options) error {
 		o.relayDial = func(target common.Address) (net.Conn, error) {
 			for _, addr := range addrs {
-				conn, err := relay.Dial(&addr, target, "")
+				conn, err := relay.DialWithLog(&addr, target, "", log)
 				if err == nil {
 					return conn, nil
 				}

--- a/insonmnia/npp/puncher.go
+++ b/insonmnia/npp/puncher.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"sync"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -13,6 +14,7 @@ import (
 	"github.com/noxiouz/zapctx/ctxlog"
 	"github.com/sonm-io/core/insonmnia/npp/rendezvous"
 	"github.com/sonm-io/core/proto"
+	"github.com/sonm-io/core/util/multierror"
 	"github.com/sonm-io/core/util/netutil"
 	"go.uber.org/zap"
 )
@@ -84,8 +86,9 @@ func newNATPuncher(ctx context.Context, cfg rendezvous.Config, client *rendezvou
 func (m *natPuncher) listen() error {
 	for {
 		conn, err := m.listener.Accept()
-		m.listenerChannel <- connTuple{conn, err}
+		m.listenerChannel <- newConnTuple(conn, err)
 		if err != nil {
+			m.log.Error("failed to listen NPP", zap.Error(err))
 			return err
 		}
 	}
@@ -101,7 +104,7 @@ func (m *natPuncher) Dial(addr common.Address) (net.Conn, error) {
 func (m *natPuncher) DialContext(ctx context.Context, addr common.Address) (net.Conn, error) {
 	addrs, err := m.resolve(ctx, addr)
 	if err != nil {
-		m.log.Warn("failed to resolve remote peer via rendezvous", zap.Stringer("remote_peer", addr), zap.Error(err))
+		m.log.Warn("failed to resolve remote peer using rendezvous", zap.Stringer("remote_addr", addr), zap.Error(err))
 		return nil, err
 	}
 
@@ -218,47 +221,60 @@ func (m *natPuncher) punch(ctx context.Context, addrs *sonm.RendezvousReply) (ne
 }
 
 func (m *natPuncher) doPunch(ctx context.Context, addrs *sonm.RendezvousReply, channel chan<- connTuple) {
-	m.log.Debug("punching", zap.Any("addrs", addrs))
+	m.log.Debug("punching", zap.Any("addrs", *addrs))
 
 	pending := make(chan connTuple, 1+len(addrs.PrivateAddrs))
+	wg := sync.WaitGroup{}
+	wg.Add(len(addrs.PrivateAddrs))
 
 	if addrs.PublicAddr.IsValid() {
+		wg.Add(1)
+
 		go func() {
+			defer wg.Done()
+
 			conn, err := m.punchAddr(ctx, addrs.PublicAddr)
-			m.log.Info("using NAT", zap.Any("addr", addrs.PublicAddr), zap.Error(err))
+			m.log.Debug("received NAT", zap.Any("remote_addr", *addrs.PublicAddr), zap.Error(err))
 			pending <- newConnTuple(conn, err)
 		}()
 	}
 
 	for _, addr := range addrs.PrivateAddrs {
 		go func(addr *sonm.Addr) {
+			defer wg.Done()
+
 			conn, err := m.punchAddr(ctx, addr)
-			m.log.Info("using private address", zap.Any("addr", addr), zap.Error(err))
+			m.log.Debug("using private address", zap.Any("remote_addr", *addr), zap.Error(err))
 			pending <- newConnTuple(conn, err)
 		}(addr)
 	}
 
-	var errs []error
+	go func() {
+		wg.Wait()
+		close(pending)
+	}()
+
 	var peer net.Conn
-	for i := 0; i < 1+len(addrs.PrivateAddrs); i++ {
-		conn := <-pending
+	var errs = multierror.NewMultiError()
+	for conn := range pending {
+		m.log.Debug("received NPP connection candidate", zap.Any("remote_addr", conn.RemoteAddr()), zap.Error(conn.err))
 
 		if conn.Error() != nil {
-			m.log.Info("failed to punch", zap.Error(conn.Error()))
-			errs = append(errs, conn.Error())
+			errs = multierror.AppendUnique(errs, conn.Error())
 			continue
 		}
 
 		if peer != nil {
 			conn.Close()
 		} else {
-			peer = conn
+			peer = conn.conn
+			// Do not return here - still need to close possibly successful connections.
 			channel <- newConnTuple(peer, nil)
 		}
 	}
 
 	if peer == nil {
-		channel <- newConnTuple(nil, fmt.Errorf("failed to punch the network: all attempts has failed - %+v", errs))
+		channel <- newConnTuple(nil, fmt.Errorf("failed to punch the network using NPP: all attempts has failed - %s", errs.Error()))
 	}
 }
 
@@ -269,15 +285,17 @@ func (m *natPuncher) punchAddr(ctx context.Context, addr *sonm.Addr) (net.Conn, 
 	}
 
 	var conn net.Conn
+	var errs = multierror.NewMultiError()
 	for i := 0; i < m.maxAttempts; i++ {
 		conn, err = DialContext(ctx, protocol, m.client.LocalAddr().String(), peerAddr.String())
 		if err == nil {
 			return conn, nil
 		}
-		m.log.Debug("failed to punch", zap.Error(err), zap.Int("attempt", i), zap.Stringer("peer_addr", peerAddr))
+
+		errs = multierror.AppendUnique(errs, err)
 	}
 
-	return nil, fmt.Errorf("failed to connect: %s", err)
+	return nil, errs
 }
 
 func (m *natPuncher) RemoteAddr() net.Addr {

--- a/insonmnia/npp/relay/frame.go
+++ b/insonmnia/npp/relay/frame.go
@@ -37,6 +37,10 @@ func NewSignedAddr(key *ecdsa.PrivateKey) (SignedETHAddr, error) {
 	return m, nil
 }
 
+func (m *SignedETHAddr) Addr() common.Address {
+	return m.addr
+}
+
 func newDiscover(addr common.Address) *sonm.HandshakeRequest {
 	return &sonm.HandshakeRequest{
 		PeerType: sonm.PeerType_DISCOVER,

--- a/insonmnia/worker/server.go
+++ b/insonmnia/worker/server.go
@@ -159,7 +159,7 @@ func (m *Worker) Serve() error {
 		npp.WithNPPBacklog(m.cfg.NPP.Backlog),
 		npp.WithNPPBackoff(m.cfg.NPP.MinBackoffInterval, m.cfg.NPP.MaxBackoffInterval),
 		npp.WithRendezvous(m.cfg.NPP.Rendezvous, m.creds),
-		npp.WithRelay(m.cfg.NPP.Relay.Endpoints, m.key),
+		npp.WithRelay(m.cfg.NPP.Relay.Endpoints, m.key, log.G(m.ctx)),
 		npp.WithLogger(log.G(m.ctx)),
 	)
 	if err != nil {


### PR DESCRIPTION
Changed:
- More logs while connecting using NPP.
- Log details in the Puncher.
- Log addresses and protobuf messages as JSON instead of <"\unreadable strings\">.
- Filter duplicate error messages, while attempting to punch a NAT.
- Some typos fixed.

Fixed:
- Possible infinite hanging while punching multiple private addresses.