### PR TITLE
fix: convert duration to nanoseconds

### DIFF
--- a/optimus/optimus.go
+++ b/optimus/optimus.go
@@ -269,7 +269,7 @@ func (m *workerControl) Execute(ctx context.Context) {
 
 		plans = append(plans, &sonm.AskPlan{
 			Price:     &sonm.Price{PerSecond: order.Order.Order.Price},
-			Duration:  &sonm.Duration{Nanoseconds: int64(order.Order.Order.Duration)},
+			Duration:  &sonm.Duration{Nanoseconds: 1e9 * int64(order.Order.Order.Duration)},
 			Resources: plan,
 		})
 	}


### PR DESCRIPTION
For some strange reason we use internally duration representation of nanoseconds. At the other side market API uses seconds as a quantum.
This fix converts market representation to worker's one.