### PR TITLE
fix: move gasLimit into chainopts

### DIFF
--- a/blockchain/addresses.go
+++ b/blockchain/addresses.go
@@ -13,7 +13,7 @@ const ProfileRegistryAddress string = "0x1b3a50ee228b040e1b00ef7e7f99058be268440
 
 const OracleUsdAddress string = "0x1f995e52dcbec7c0d00d45b8b1bf43b29dd12b5b"
 
-const GatekeeperLiveAddress string = "0xbc29310be3693949094ce452b11829dbccca7d49"
+const GatekeeperMasterchainAddress string = "0xbc29310be3693949094ce452b11829dbccca7d49"
 
 const GatekeeperSidechainAddress string = "0x9414922e778a0038058e9ea786e9474a89ad1ec0"
 
@@ -48,6 +48,6 @@ func GatekeeperSidechainAddr() common.Address {
 	return common.HexToAddress(GatekeeperSidechainAddress)
 }
 
-func GatekeeperLiveAddr() common.Address {
-	return common.HexToAddress(GatekeeperLiveAddress)
+func GatekeeperMasterchainAddr() common.Address {
+	return common.HexToAddress(GatekeeperMasterchainAddress)
 }

--- a/blockchain/api.go
+++ b/blockchain/api.go
@@ -113,7 +113,7 @@ type SimpleGatekeeperAPI interface {
 	// On Masterchain ally as `Deposit`
 	// On Sidecain ally as `Withdraw`
 	PayIn(ctx context.Context, key *ecdsa.PrivateKey, value *big.Int) (*types.Transaction, error)
-	// PayOut release payout transaction from mirrored chain.
+	// Payout release payout transaction from mirrored chain.
 	// Accessible only by owner.
 	Payout(ctx context.Context, key *ecdsa.PrivateKey, to common.Address, value *big.Int, txNumber *big.Int) (*types.Transaction, error)
 	// Kill calls contract to suicide, all ether and tokens funds transfer to owner.
@@ -141,11 +141,6 @@ func NewAPI(opts ...Option) (API, error) {
 	}
 
 	liveToken, err := NewStandardToken(SNMAddr(), defaults.masterchain)
-	if err != nil {
-		return nil, err
-	}
-
-	masterchainGate, err := NewSimpleGatekeeper(GatekeeperLiveAddr(), defaults.masterchain)
 	if err != nil {
 		return nil, err
 	}
@@ -182,6 +177,11 @@ func NewAPI(opts ...Option) (API, error) {
 	}
 
 	oracle, err := NewOracleUSDAPI(OracleUsdAddr(), defaults.sidechain)
+	if err != nil {
+		return nil, err
+	}
+
+	masterchainGate, err := NewSimpleGatekeeper(GatekeeperMasterchainAddr(), defaults.masterchain)
 	if err != nil {
 		return nil, err
 	}
@@ -270,12 +270,12 @@ func NewBasicMarket(address common.Address, opts *chainOpts) (MarketAPI, error) 
 }
 
 func (api *BasicMarketAPI) QuickBuy(ctx context.Context, key *ecdsa.PrivateKey, askId *big.Int) (*types.Transaction, error) {
-	opts := api.opts.getTxOpts(ctx, key, defaultGasLimitForSidechain)
+	opts := api.opts.getTxOpts(ctx, key, api.opts.gasLimit)
 	return api.marketContract.QuickBuy(opts, askId)
 }
 
 func (api *BasicMarketAPI) OpenDeal(ctx context.Context, key *ecdsa.PrivateKey, askID, bidID *big.Int) (*pb.Deal, error) {
-	opts := api.opts.getTxOpts(ctx, key, defaultGasLimitForSidechain)
+	opts := api.opts.getTxOpts(ctx, key, api.opts.gasLimit)
 	tx, err := api.marketContract.OpenDeal(opts, askID, bidID)
 	if err != nil {
 		return nil, err
@@ -295,7 +295,7 @@ func (api *BasicMarketAPI) OpenDeal(ctx context.Context, key *ecdsa.PrivateKey, 
 }
 
 func (api *BasicMarketAPI) CloseDeal(ctx context.Context, key *ecdsa.PrivateKey, dealID *big.Int, blacklisted bool) error {
-	opts := api.opts.getTxOpts(ctx, key, defaultGasLimitForSidechain)
+	opts := api.opts.getTxOpts(ctx, key, api.opts.gasLimit)
 	tx, err := api.marketContract.CloseDeal(opts, dealID, blacklisted)
 	if err != nil {
 		return err
@@ -357,7 +357,7 @@ func (api *BasicMarketAPI) GetDealsAmount(ctx context.Context) (*big.Int, error)
 }
 
 func (api *BasicMarketAPI) PlaceOrder(ctx context.Context, key *ecdsa.PrivateKey, order *pb.Order) (*pb.Order, error) {
-	opts := api.opts.getTxOpts(ctx, key, defaultGasLimitForSidechain)
+	opts := api.opts.getTxOpts(ctx, key, api.opts.gasLimit)
 
 	//TODO: Make netflags dynamic
 	fixedNetflags := [pb.MinNetFlagsCount]bool{}
@@ -396,7 +396,7 @@ func (api *BasicMarketAPI) PlaceOrder(ctx context.Context, key *ecdsa.PrivateKey
 }
 
 func (api *BasicMarketAPI) CancelOrder(ctx context.Context, key *ecdsa.PrivateKey, id *big.Int) error {
-	opts := api.opts.getTxOpts(ctx, key, defaultGasLimitForSidechain)
+	opts := api.opts.getTxOpts(ctx, key, api.opts.gasLimit)
 	tx, err := api.marketContract.CancelOrder(opts, id)
 	if err != nil {
 		return err
@@ -460,7 +460,7 @@ func (api *BasicMarketAPI) GetOrdersAmount(ctx context.Context) (*big.Int, error
 }
 
 func (api *BasicMarketAPI) Bill(ctx context.Context, key *ecdsa.PrivateKey, dealID *big.Int) error {
-	opts := api.opts.getTxOpts(ctx, key, defaultGasLimitForSidechain)
+	opts := api.opts.getTxOpts(ctx, key, api.opts.gasLimit)
 	tx, err := api.marketContract.Bill(opts, dealID)
 	if err != nil {
 		return err
@@ -474,7 +474,7 @@ func (api *BasicMarketAPI) Bill(ctx context.Context, key *ecdsa.PrivateKey, deal
 }
 
 func (api *BasicMarketAPI) RegisterWorker(ctx context.Context, key *ecdsa.PrivateKey, master common.Address) error {
-	opts := api.opts.getTxOpts(ctx, key, defaultGasLimitForSidechain)
+	opts := api.opts.getTxOpts(ctx, key, api.opts.gasLimit)
 	tx, err := api.marketContract.RegisterWorker(opts, master)
 	if err != nil {
 		return err
@@ -488,7 +488,7 @@ func (api *BasicMarketAPI) RegisterWorker(ctx context.Context, key *ecdsa.Privat
 }
 
 func (api *BasicMarketAPI) ConfirmWorker(ctx context.Context, key *ecdsa.PrivateKey, slave common.Address) error {
-	opts := api.opts.getTxOpts(ctx, key, defaultGasLimitForSidechain)
+	opts := api.opts.getTxOpts(ctx, key, api.opts.gasLimit)
 	tx, err := api.marketContract.ConfirmWorker(opts, slave)
 	if err != nil {
 		return err
@@ -502,7 +502,7 @@ func (api *BasicMarketAPI) ConfirmWorker(ctx context.Context, key *ecdsa.Private
 }
 
 func (api *BasicMarketAPI) RemoveWorker(ctx context.Context, key *ecdsa.PrivateKey, master, slave common.Address) error {
-	opts := api.opts.getTxOpts(ctx, key, defaultGasLimitForSidechain)
+	opts := api.opts.getTxOpts(ctx, key, api.opts.gasLimit)
 	tx, err := api.marketContract.RemoveWorker(opts, master, slave)
 	if err != nil {
 		return err
@@ -537,7 +537,7 @@ func (api *BasicMarketAPI) GetDealChangeRequestInfo(ctx context.Context, changeR
 
 func (api *BasicMarketAPI) CreateChangeRequest(ctx context.Context, key *ecdsa.PrivateKey, req *pb.DealChangeRequest) (*big.Int, error) {
 	duration := big.NewInt(int64(req.GetDuration()))
-	opts := api.opts.getTxOpts(ctx, key, defaultGasLimitForSidechain)
+	opts := api.opts.getTxOpts(ctx, key, api.opts.gasLimit)
 	tx, err := api.marketContract.CreateChangeRequest(opts, req.GetDealID().Unwrap(), req.GetPrice().Unwrap(), duration)
 	if err != nil {
 		return nil, err
@@ -557,7 +557,7 @@ func (api *BasicMarketAPI) CreateChangeRequest(ctx context.Context, key *ecdsa.P
 }
 
 func (api *BasicMarketAPI) CancelChangeRequest(ctx context.Context, key *ecdsa.PrivateKey, id *big.Int) error {
-	opts := api.opts.getTxOpts(ctx, key, defaultGasLimitForSidechain)
+	opts := api.opts.getTxOpts(ctx, key, api.opts.gasLimit)
 	tx, err := api.marketContract.CancelChangeRequest(opts, id)
 	if err != nil {
 		return err
@@ -606,22 +606,22 @@ func NewProfileRegistry(address common.Address, opts *chainOpts) (ProfileRegistr
 }
 
 func (api *ProfileRegistry) CreateCertificate(ctx context.Context, key *ecdsa.PrivateKey, owner common.Address, attributeType *big.Int, value []byte) (*types.Transaction, error) {
-	opts := api.opts.getTxOpts(ctx, key, defaultGasLimitForSidechain)
+	opts := api.opts.getTxOpts(ctx, key, api.opts.gasLimit)
 	return api.profileRegistryContract.CreateCertificate(opts, owner, attributeType, value)
 }
 
 func (api *ProfileRegistry) RemoveCertificate(ctx context.Context, key *ecdsa.PrivateKey, id *big.Int) (*types.Transaction, error) {
-	opts := api.opts.getTxOpts(ctx, key, defaultGasLimitForSidechain)
+	opts := api.opts.getTxOpts(ctx, key, api.opts.gasLimit)
 	return api.profileRegistryContract.RemoveCertificate(opts, id)
 }
 
 func (api *ProfileRegistry) AddValidator(ctx context.Context, key *ecdsa.PrivateKey, validator common.Address, level int8) (*types.Transaction, error) {
-	opts := api.opts.getTxOpts(ctx, key, defaultGasLimitForSidechain)
+	opts := api.opts.getTxOpts(ctx, key, api.opts.gasLimit)
 	return api.profileRegistryContract.AddValidator(opts, validator, level)
 }
 
 func (api *ProfileRegistry) RemoveValidator(ctx context.Context, key *ecdsa.PrivateKey, validator common.Address) (*types.Transaction, error) {
-	opts := api.opts.getTxOpts(ctx, key, defaultGasLimitForSidechain)
+	opts := api.opts.getTxOpts(ctx, key, api.opts.gasLimit)
 	return api.profileRegistryContract.RemoveValidator(opts, validator)
 }
 
@@ -688,12 +688,12 @@ func (api *BasicBlacklistAPI) Check(ctx context.Context, who, whom common.Addres
 }
 
 func (api *BasicBlacklistAPI) Add(ctx context.Context, key *ecdsa.PrivateKey, who, whom common.Address) (*types.Transaction, error) {
-	opts := api.opts.getTxOpts(ctx, key, defaultGasLimitForSidechain)
+	opts := api.opts.getTxOpts(ctx, key, api.opts.gasLimit)
 	return api.blacklistContract.Add(opts, who, whom)
 }
 
 func (api *BasicBlacklistAPI) Remove(ctx context.Context, key *ecdsa.PrivateKey, whom common.Address) error {
-	opts := api.opts.getTxOpts(ctx, key, defaultGasLimitForSidechain)
+	opts := api.opts.getTxOpts(ctx, key, api.opts.gasLimit)
 	tx, err := api.blacklistContract.Remove(opts, whom)
 	if err != nil {
 		return err
@@ -707,17 +707,17 @@ func (api *BasicBlacklistAPI) Remove(ctx context.Context, key *ecdsa.PrivateKey,
 }
 
 func (api *BasicBlacklistAPI) AddMaster(ctx context.Context, key *ecdsa.PrivateKey, root common.Address) (*types.Transaction, error) {
-	opts := api.opts.getTxOpts(ctx, key, defaultGasLimitForSidechain)
+	opts := api.opts.getTxOpts(ctx, key, api.opts.gasLimit)
 	return api.blacklistContract.AddMaster(opts, root)
 }
 
 func (api *BasicBlacklistAPI) RemoveMaster(ctx context.Context, key *ecdsa.PrivateKey, root common.Address) (*types.Transaction, error) {
-	opts := api.opts.getTxOpts(ctx, key, defaultGasLimitForSidechain)
+	opts := api.opts.getTxOpts(ctx, key, api.opts.gasLimit)
 	return api.blacklistContract.RemoveMaster(opts, root)
 }
 
 func (api *BasicBlacklistAPI) SetMarketAddress(ctx context.Context, key *ecdsa.PrivateKey, market common.Address) (*types.Transaction, error) {
-	opts := api.opts.getTxOpts(ctx, key, defaultGasLimitForSidechain)
+	opts := api.opts.getTxOpts(ctx, key, api.opts.gasLimit)
 	return api.blacklistContract.SetMarketAddress(opts, market)
 }
 
@@ -754,17 +754,17 @@ func (api *StandardTokenApi) AllowanceOf(ctx context.Context, from, to common.Ad
 }
 
 func (api *StandardTokenApi) Approve(ctx context.Context, key *ecdsa.PrivateKey, to common.Address, amount *big.Int) (*types.Transaction, error) {
-	opts := api.opts.getTxOpts(ctx, key, defaultGasLimit)
+	opts := api.opts.getTxOpts(ctx, key, api.opts.gasLimit)
 	return api.tokenContract.Approve(opts, to, amount)
 }
 
 func (api *StandardTokenApi) Transfer(ctx context.Context, key *ecdsa.PrivateKey, to common.Address, amount *big.Int) (*types.Transaction, error) {
-	opts := api.opts.getTxOpts(ctx, key, defaultGasLimit)
+	opts := api.opts.getTxOpts(ctx, key, api.opts.gasLimit)
 	return api.tokenContract.Transfer(opts, to, amount)
 }
 
 func (api *StandardTokenApi) TransferFrom(ctx context.Context, key *ecdsa.PrivateKey, from common.Address, to common.Address, amount *big.Int) (*types.Transaction, error) {
-	opts := api.opts.getTxOpts(ctx, key, defaultGasLimit)
+	opts := api.opts.getTxOpts(ctx, key, api.opts.gasLimit)
 	return api.tokenContract.TransferFrom(opts, from, to, amount)
 }
 
@@ -797,7 +797,7 @@ func NewTestToken(address common.Address, opts *chainOpts) (TestTokenAPI, error)
 }
 
 func (api *TestTokenApi) GetTokens(ctx context.Context, key *ecdsa.PrivateKey) (*types.Transaction, error) {
-	opts := api.opts.getTxOpts(ctx, key, defaultGasLimit)
+	opts := api.opts.getTxOpts(ctx, key, api.opts.gasLimit)
 	return api.tokenContract.GetTokens(opts)
 }
 
@@ -1106,7 +1106,7 @@ func NewOracleUSDAPI(address common.Address, opts *chainOpts) (OracleAPI, error)
 }
 
 func (api *OracleUSDAPI) SetCurrentPrice(ctx context.Context, key *ecdsa.PrivateKey, price *big.Int) (*types.Transaction, error) {
-	opts := api.opts.getTxOpts(ctx, key, defaultGasLimitForSidechain)
+	opts := api.opts.getTxOpts(ctx, key, api.opts.gasLimit)
 	return api.oracleContract.SetCurrentPrice(opts, price)
 }
 
@@ -1139,16 +1139,16 @@ func NewSimpleGatekeeper(address common.Address, opts *chainOpts) (SimpleGatekee
 }
 
 func (api *BasicSimpleGatekeeper) PayIn(ctx context.Context, key *ecdsa.PrivateKey, value *big.Int) (*types.Transaction, error) {
-	opts := api.opts.getTxOpts(ctx, key, defaultGasLimitForSidechain)
+	opts := api.opts.getTxOpts(ctx, key, api.opts.gasLimit)
 	return api.contract.PayIn(opts, value)
 }
 
 func (api *BasicSimpleGatekeeper) Payout(ctx context.Context, key *ecdsa.PrivateKey, to common.Address, value *big.Int, txNumber *big.Int) (*types.Transaction, error) {
-	opts := api.opts.getTxOpts(ctx, key, defaultGasLimitForSidechain)
+	opts := api.opts.getTxOpts(ctx, key, api.opts.gasLimit)
 	return api.contract.Payout(opts, to, value, txNumber)
 }
 
 func (api *BasicSimpleGatekeeper) Kill(ctx context.Context, key *ecdsa.PrivateKey) (*types.Transaction, error) {
-	opts := api.opts.getTxOpts(ctx, key, defaultGasLimitForSidechain)
+	opts := api.opts.getTxOpts(ctx, key, api.opts.gasLimit)
 	return api.contract.Kill(opts)
 }

--- a/blockchain/options.go
+++ b/blockchain/options.go
@@ -16,6 +16,8 @@ const (
 	defaultSidechainGasPrice   = 0
 	defaultBlockConfirmations  = 5
 	defaultLogParsePeriod      = time.Second
+	defaultMasterchainGasLimit = 500000
+	defaultSidechainGasLimit   = 2000000
 )
 
 // chainOpts describes common options
@@ -24,6 +26,7 @@ const (
 // or local geth-node for testing).
 type chainOpts struct {
 	gasPrice           int64
+	gasLimit           uint64
 	endpoint           string
 	logParsePeriod     time.Duration
 	blockConfirmations int64
@@ -58,12 +61,14 @@ func defaultOptions() *options {
 	return &options{
 		masterchain: &chainOpts{
 			gasPrice:           defaultMasterchainGasPrice,
+			gasLimit:           defaultMasterchainGasLimit,
 			endpoint:           defaultMasterchainEndpoint,
 			logParsePeriod:     defaultLogParsePeriod,
 			blockConfirmations: defaultBlockConfirmations,
 		},
 		sidechain: &chainOpts{
 			gasPrice:           defaultSidechainGasPrice,
+			gasLimit:           defaultSidechainGasLimit,
 			endpoint:           defaultSidechainEndpoint,
 			logParsePeriod:     defaultLogParsePeriod,
 			blockConfirmations: defaultBlockConfirmations,

--- a/blockchain/util.go
+++ b/blockchain/util.go
@@ -16,11 +16,6 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 )
 
-const (
-	defaultGasLimit             = 500000
-	defaultGasLimitForSidechain = 2000000
-)
-
 func getCallOptions(ctx context.Context) *bind.CallOpts {
 	return &bind.CallOpts{
 		Pending: false,


### PR DESCRIPTION
This PR adds several files after the #976:
- `gasLimit` param added to chainOpts.
- Replaced constant usage with chainOpts param.
- Constants with defualt gas limit and gatekeeper addresses renamed using Sidechain\Masterchain.