### PR TITLE
fix: proper cli login behaviour

### DIFF
--- a/accounts/multi_keystore.go
+++ b/accounts/multi_keystore.go
@@ -46,13 +46,6 @@ func NewMultiKeystore(cfg *KeystoreConfig, pf PassPhraser) (*MultiKeystore, erro
 		passReader: pf,
 	}
 
-	// We have only one account, mark it as default
-	// for current keystore instance.
-	accs := ks.Accounts()
-	if len(accs) == 1 {
-		m.SetDefault(accs[0].Address)
-	}
-
 	return m, nil
 }
 

--- a/accounts/multi_keystore_test.go
+++ b/accounts/multi_keystore_test.go
@@ -123,35 +123,3 @@ func TestAlreadyKnownPasswords(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, res3, key3)
 }
-
-func TestFirstDefault(t *testing.T) {
-	tmp, err := NewMultiKeystore(
-		&KeystoreConfig{
-			KeyDir:      testKeystoreDir,
-			PassPhrases: map[string]string{},
-		},
-		NewStaticPassPhraser("test"),
-	)
-	require.NoError(t, err)
-	defer func() { os.RemoveAll(testKeystoreDir) }()
-
-	key, err := tmp.Generate()
-	require.NoError(t, err)
-	err = os.RemoveAll(tmp.cfg.getStateFileDir())
-	require.NoError(t, err)
-
-	k, err := NewMultiKeystore(
-		&KeystoreConfig{
-			KeyDir:      testKeystoreDir,
-			PassPhrases: map[string]string{},
-		},
-		NewStaticPassPhraser("test"),
-	)
-	require.NoError(t, err)
-
-	defaultKey, err := k.GetDefault()
-	require.NoError(t, err)
-
-	assert.Equal(t, crypto.PubkeyToAddress(defaultKey.PublicKey).Hex(), crypto.PubkeyToAddress(key.PublicKey).Hex())
-	assert.Equal(t, defaultKey, key)
-}

--- a/cmd/cli/commands/login.go
+++ b/cmd/cli/commands/login.go
@@ -42,15 +42,15 @@ var loginCmd = &cobra.Command{
 				os.Exit(1)
 			}
 
-			// try to decrypt default key with given pass
+			// try to decrypt default key with given pass phrase
 			if _, err := ks.GetKeyWithPass(addr, pass); err != nil {
 				showError(cmd, "Cannot decrypt default key with given pass", err)
 				os.Exit(1)
 			}
 
-			// mark key as default if we can decrypt it with given
+			// mark key as default if we can decrypt it with given pass phrase
 			if err := ks.SetDefault(addr); err != nil {
-				cmd.Printf("Given address is not present into keystore.\r\nAvailable addresses:\r\n")
+				cmd.Printf("Given address is not present in keystore.\r\nAvailable addresses:\r\n")
 				for _, addr := range ks.List() {
 					cmd.Println(addr.Address.Hex())
 				}

--- a/cmd/cli/commands/login.go
+++ b/cmd/cli/commands/login.go
@@ -35,14 +35,6 @@ var loginCmd = &cobra.Command{
 				os.Exit(1)
 			}
 
-			if err := ks.SetDefault(addr); err != nil {
-				cmd.Printf("Given address is not present into keystore.\r\nAvailable addresses:\r\n")
-				for _, addr := range ks.List() {
-					cmd.Println(addr.Address.Hex())
-				}
-				return
-			}
-
 			// ask for password for default key
 			pass, err := accounts.NewInteractivePassPhraser().GetPassPhrase()
 			if err != nil {
@@ -54,6 +46,15 @@ var loginCmd = &cobra.Command{
 			if _, err := ks.GetKeyWithPass(addr, pass); err != nil {
 				showError(cmd, "Cannot decrypt default key with given pass", err)
 				os.Exit(1)
+			}
+
+			// mark key as default if we can decrypt it with given
+			if err := ks.SetDefault(addr); err != nil {
+				cmd.Printf("Given address is not present into keystore.\r\nAvailable addresses:\r\n")
+				for _, addr := range ks.List() {
+					cmd.Println(addr.Address.Hex())
+				}
+				return
 			}
 
 			cfg.Eth.Passphrase = pass


### PR DESCRIPTION
This PR fixes two bugs:
- Now we do not mark the key as default if there is only one key is present into keystore.
- Now `sonmcli login` asking for pass-phrase, then trying to decrypt key and mark it as default only if decryption was successful.