### PR TITLE
chore: blockchain api naming

### DIFF
--- a/blockchain/addresses.go
+++ b/blockchain/addresses.go
@@ -2,52 +2,45 @@ package blockchain
 
 import "github.com/ethereum/go-ethereum/common"
 
-// private chain
-const SNMSidechainAddress string = "0x26524b1234e361eb4e3ddf7600d41271620fcb0a"
+const (
+	sidechainSNMAddress          = "0x26524b1234e361eb4e3ddf7600d41271620fcb0a"
+	masterchainSNMAddress        = "0x06bda3cf79946e8b32a0bb6a3daa174b577c55b5"
+	blacklistAddress             = "0x9ad1e969ec5842ee5d67414536813e224ceb56b1"
+	marketAddress                = "0x51a1d1d1821b4109eb84edc4ca8ec814b1fe9876"
+	profileRegistryAddress       = "0x1b3a50ee228b040e1b00ef7e7f99058be2684408"
+	oracleUsdAddress             = "0x1f995e52dcbec7c0d00d45b8b1bf43b29dd12b5b"
+	gatekeeperMasterchainAddress = "0xbc29310be3693949094ce452b11829dbccca7d49"
+	gatekeeperSidechainAddress   = "0x9414922e778a0038058e9ea786e9474a89ad1ec0"
+)
 
-const BlacklistAddress string = "0x9ad1e969ec5842ee5d67414536813e224ceb56b1"
+func MasterchainSNMAddr() common.Address {
+	return common.HexToAddress(masterchainSNMAddress)
+}
 
-const MarketAddress string = "0x51a1d1d1821b4109eb84edc4ca8ec814b1fe9876"
-
-const ProfileRegistryAddress string = "0x1b3a50ee228b040e1b00ef7e7f99058be2684408"
-
-const OracleUsdAddress string = "0x1f995e52dcbec7c0d00d45b8b1bf43b29dd12b5b"
-
-const GatekeeperMasterchainAddress string = "0xbc29310be3693949094ce452b11829dbccca7d49"
-
-const GatekeeperSidechainAddress string = "0x9414922e778a0038058e9ea786e9474a89ad1ec0"
-
-// rinkeby
-const SNMAddress string = "0x06bda3cf79946e8b32a0bb6a3daa174b577c55b5"
-
-func SNMAddr() common.Address {
-	return common.HexToAddress(SNMAddress)
+func SidechainSNMAddr() common.Address {
+	return common.HexToAddress(sidechainSNMAddress)
 }
 
 func BlacklistAddr() common.Address {
-	return common.HexToAddress(BlacklistAddress)
+	return common.HexToAddress(blacklistAddress)
 }
 
 func MarketAddr() common.Address {
-	return common.HexToAddress(MarketAddress)
+	return common.HexToAddress(marketAddress)
 }
 
 func ProfileRegistryAddr() common.Address {
-	return common.HexToAddress(ProfileRegistryAddress)
+	return common.HexToAddress(profileRegistryAddress)
 }
 
 func OracleUsdAddr() common.Address {
-	return common.HexToAddress(OracleUsdAddress)
-}
-
-func SNMSidechainAddr() common.Address {
-	return common.HexToAddress(SNMSidechainAddress)
+	return common.HexToAddress(oracleUsdAddress)
 }
 
 func GatekeeperSidechainAddr() common.Address {
-	return common.HexToAddress(GatekeeperSidechainAddress)
+	return common.HexToAddress(gatekeeperSidechainAddress)
 }
 
 func GatekeeperMasterchainAddr() common.Address {
-	return common.HexToAddress(GatekeeperMasterchainAddress)
+	return common.HexToAddress(gatekeeperMasterchainAddress)
 }

--- a/blockchain/api.go
+++ b/blockchain/api.go
@@ -22,8 +22,8 @@ type API interface {
 	Events() EventsAPI
 	Market() MarketAPI
 	Blacklist() BlacklistAPI
-	LiveToken() TokenAPI
-	SideToken() TokenAPI
+	MasterchainToken() TokenAPI
+	SidechainToken() TokenAPI
 	TestToken() TestTokenAPI
 	OracleUSD() OracleAPI
 	MasterchainGate() SimpleGatekeeperAPI
@@ -122,16 +122,16 @@ type SimpleGatekeeperAPI interface {
 }
 
 type BasicAPI struct {
-	market          MarketAPI
-	liveToken       TokenAPI
-	sideToken       TokenAPI
-	testToken       TestTokenAPI
-	blacklist       BlacklistAPI
-	profileRegistry ProfileRegistryAPI
-	events          EventsAPI
-	oracle          OracleAPI
-	masterchainGate SimpleGatekeeperAPI
-	sidechainGate   SimpleGatekeeperAPI
+	market           MarketAPI
+	masterchainToken TokenAPI
+	sidechainToken   TokenAPI
+	testToken        TestTokenAPI
+	blacklist        BlacklistAPI
+	profileRegistry  ProfileRegistryAPI
+	events           EventsAPI
+	oracle           OracleAPI
+	masterchainGate  SimpleGatekeeperAPI
+	sidechainGate    SimpleGatekeeperAPI
 }
 
 func NewAPI(opts ...Option) (API, error) {
@@ -140,12 +140,12 @@ func NewAPI(opts ...Option) (API, error) {
 		o(defaults)
 	}
 
-	liveToken, err := NewStandardToken(SNMAddr(), defaults.masterchain)
+	masterchainToken, err := NewStandardToken(MasterchainSNMAddr(), defaults.masterchain)
 	if err != nil {
 		return nil, err
 	}
 
-	testToken, err := NewTestToken(SNMAddr(), defaults.masterchain)
+	testToken, err := NewTestToken(MasterchainSNMAddr(), defaults.masterchain)
 	if err != nil {
 		return nil, err
 	}
@@ -165,7 +165,7 @@ func NewAPI(opts ...Option) (API, error) {
 		return nil, err
 	}
 
-	sideToken, err := NewStandardToken(SNMSidechainAddr(), defaults.sidechain)
+	sidechainToken, err := NewStandardToken(SidechainSNMAddr(), defaults.sidechain)
 	if err != nil {
 		return nil, err
 	}
@@ -192,16 +192,16 @@ func NewAPI(opts ...Option) (API, error) {
 	}
 
 	return &BasicAPI{
-		market:          marketApi,
-		blacklist:       blacklist,
-		profileRegistry: profileRegistry,
-		liveToken:       liveToken,
-		sideToken:       sideToken,
-		testToken:       testToken,
-		events:          events,
-		oracle:          oracle,
-		masterchainGate: masterchainGate,
-		sidechainGate:   sidechainGate,
+		market:           marketApi,
+		blacklist:        blacklist,
+		profileRegistry:  profileRegistry,
+		masterchainToken: masterchainToken,
+		sidechainToken:   sidechainToken,
+		testToken:        testToken,
+		events:           events,
+		oracle:           oracle,
+		masterchainGate:  masterchainGate,
+		sidechainGate:    sidechainGate,
 	}, nil
 }
 
@@ -209,12 +209,12 @@ func (api *BasicAPI) Market() MarketAPI {
 	return api.market
 }
 
-func (api *BasicAPI) LiveToken() TokenAPI {
-	return api.liveToken
+func (api *BasicAPI) MasterchainToken() TokenAPI {
+	return api.masterchainToken
 }
 
-func (api *BasicAPI) SideToken() TokenAPI {
-	return api.sideToken
+func (api *BasicAPI) SidechainToken() TokenAPI {
+	return api.sidechainToken
 }
 
 func (api *BasicAPI) TestToken() TestTokenAPI {

--- a/blockchain/config.go
+++ b/blockchain/config.go
@@ -13,23 +13,23 @@ type Config struct {
 
 func (m *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	var cfg struct {
-		Endpoint          string `yaml:"endpoint"`
-		SidechainEndpoint string `yaml:"sidechain_endpoint"`
+		MasterchainEndpoint string `yaml:"endpoint"`
+		SidechainEndpoint   string `yaml:"sidechain_endpoint"`
 	}
 
 	if err := unmarshal(&cfg); err != nil {
 		return err
 	}
 
-	if len(cfg.Endpoint) == 0 {
-		cfg.Endpoint = defaultMasterchainEndpoint
+	if len(cfg.MasterchainEndpoint) == 0 {
+		cfg.MasterchainEndpoint = defaultMasterchainEndpoint
 	}
 
 	if len(cfg.SidechainEndpoint) == 0 {
 		cfg.SidechainEndpoint = defaultSidechainEndpoint
 	}
 
-	endpoint, err := url.Parse(cfg.Endpoint)
+	endpoint, err := url.Parse(cfg.MasterchainEndpoint)
 	if err != nil {
 		return err
 	}

--- a/blockchain/examples/placeOrder/placeOrder.go
+++ b/blockchain/examples/placeOrder/placeOrder.go
@@ -29,7 +29,7 @@ func main() {
 		return
 	}
 
-	balance, err := api.SideToken().BalanceOf(context.Background(), crypto.PubkeyToAddress(prv.PublicKey))
+	balance, err := api.SidechainToken().BalanceOf(context.Background(), crypto.PubkeyToAddress(prv.PublicKey))
 	if err != nil {
 		log.Fatalln(err)
 		return
@@ -37,7 +37,7 @@ func main() {
 
 	log.Println("Balance: ", balance)
 
-	allowance, err := api.SideToken().AllowanceOf(context.Background(), crypto.PubkeyToAddress(prv.PublicKey), blockchain.MarketAddr())
+	allowance, err := api.SidechainToken().AllowanceOf(context.Background(), crypto.PubkeyToAddress(prv.PublicKey), blockchain.MarketAddr())
 	if err != nil {
 		log.Fatalln(err)
 		return

--- a/insonmnia/node/tokens.go
+++ b/insonmnia/node/tokens.go
@@ -22,12 +22,12 @@ func (t *tokenAPI) TestTokens(ctx context.Context, _ *sonm.Empty) (*sonm.Empty, 
 func (t *tokenAPI) Balance(ctx context.Context, _ *sonm.Empty) (*sonm.BalanceReply, error) {
 	addr := crypto.PubkeyToAddress(t.remotes.key.PublicKey)
 
-	live, err := t.remotes.eth.LiveToken().BalanceOf(ctx, addr)
+	live, err := t.remotes.eth.MasterchainToken().BalanceOf(ctx, addr)
 	if err != nil {
 		return nil, errors.Wrap(err, "cannot get live token balance")
 	}
 
-	side, err := t.remotes.eth.SideToken().BalanceOf(ctx, addr)
+	side, err := t.remotes.eth.SidechainToken().BalanceOf(ctx, addr)
 	if err != nil {
 		return nil, errors.Wrap(err, "cannot get side token balance")
 	}


### PR DESCRIPTION
Try to use master/side-chain terminology everywhere.