### PR TITLE
refactor: replace math with rational numbers

### DIFF
--- a/optimus/devices.go
+++ b/optimus/devices.go
@@ -50,7 +50,7 @@ func (m *cpuConsumer) DeviceBenchmark(id int) (*sonm.Benchmark, bool) {
 }
 
 func (m *cpuConsumer) Result(criteria Rational) interface{} {
-	return &sonm.AskPlanCPU{CorePercents: uint64(math.Ceil(criteria.Mul(100).Mul(uint64(m.cpu.Device.Cores)).Float64()))}
+	return &sonm.AskPlanCPU{CorePercents: criteria.Mul(100).Mul(uint64(m.cpu.Device.Cores)).Uint64Ceil()}
 }
 
 type ramConsumer struct {
@@ -74,7 +74,7 @@ func (m *ramConsumer) DeviceBenchmark(id int) (*sonm.Benchmark, bool) {
 }
 
 func (m *ramConsumer) Result(criteria Rational) interface{} {
-	return &sonm.AskPlanRAM{Size: &sonm.DataSize{Bytes: uint64(math.Ceil(criteria.Mul(m.ram.Device.Total).Float64()))}}
+	return &sonm.AskPlanRAM{Size: &sonm.DataSize{Bytes: criteria.Mul(m.ram.Device.Total).Uint64Ceil()}}
 }
 
 type storageConsumer struct {
@@ -98,7 +98,7 @@ func (m *storageConsumer) DeviceBenchmark(id int) (*sonm.Benchmark, bool) {
 }
 
 func (m *storageConsumer) Result(criteria Rational) interface{} {
-	return &sonm.AskPlanStorage{Size: &sonm.DataSize{Bytes: uint64(math.Ceil(criteria.Mul(m.dev.Device.BytesAvailable).Float64()))}}
+	return &sonm.AskPlanStorage{Size: &sonm.DataSize{Bytes: criteria.Mul(m.dev.Device.BytesAvailable).Uint64Ceil()}}
 }
 
 type networkInConsumer struct {
@@ -120,7 +120,7 @@ func (m *networkInConsumer) DeviceBenchmark(id int) (*sonm.Benchmark, bool) {
 }
 
 func (m *networkInConsumer) Result(criteria Rational) interface{} {
-	return &sonm.DataSizeRate{BitsPerSecond: uint64(math.Ceil(criteria.Mul(m.dev.In).Float64()))}
+	return &sonm.DataSizeRate{BitsPerSecond: criteria.Mul(m.dev.In).Uint64Ceil()}
 }
 
 type networkOutConsumer struct {
@@ -142,7 +142,7 @@ func (m *networkOutConsumer) DeviceBenchmark(id int) (*sonm.Benchmark, bool) {
 }
 
 func (m *networkOutConsumer) Result(criteria Rational) interface{} {
-	return &sonm.DataSizeRate{BitsPerSecond: uint64(math.Ceil(criteria.Mul(m.dev.Out).Float64()))}
+	return &sonm.DataSizeRate{BitsPerSecond: criteria.Mul(m.dev.Out).Uint64Ceil()}
 }
 
 type DeviceManager struct {
@@ -295,7 +295,7 @@ func (m *DeviceManager) consume(benchmarks []uint64, consumer Consumer) (interfa
 
 	for id := range m.freeBenchmarks {
 		if benchmarkResult, ok := filter(id); ok {
-			if m.freeBenchmarks[id] < uint64(math.Ceil(value.Mul(benchmarkResult).Float64())) {
+			if m.freeBenchmarks[id] < value.Mul(benchmarkResult).Uint64Ceil() {
 				return 0, errExhausted
 			}
 		}
@@ -303,7 +303,7 @@ func (m *DeviceManager) consume(benchmarks []uint64, consumer Consumer) (interfa
 
 	for id := range m.freeBenchmarks {
 		if benchmarkResult, ok := filter(id); ok {
-			m.freeBenchmarks[id] -= uint64(math.Ceil(value.Mul(benchmarkResult).Float64()))
+			m.freeBenchmarks[id] -= value.Mul(benchmarkResult).Uint64Ceil()
 		}
 	}
 

--- a/optimus/devices_test.go
+++ b/optimus/devices_test.go
@@ -576,3 +576,66 @@ func TestConsumeOrder(t *testing.T) {
 		assert.Equal(t, uint64(1), plan.ThroughputOut.BitsPerSecond)
 	}
 }
+
+func TestConsumeOrderDEV000(t *testing.T) {
+	devices := newEmptyDevicesReply()
+	devices.CPU.Device.Cores = 1
+	devices.CPU.Benchmarks = map[uint64]*sonm.Benchmark{
+		0: {Result: 817},
+		1: {Result: 1315},
+		2: {Result: 1},
+	}
+	devices.RAM.Device.Total = 1033342976
+	devices.RAM.Benchmarks = map[uint64]*sonm.Benchmark{
+		3: {
+			Result: 16754622464,
+		},
+	}
+	devices.Network.In = 58801113
+	devices.Network.Out = 20966499
+	devices.Network.BenchmarksIn = map[uint64]*sonm.Benchmark{
+		5: {Result: 58801113},
+	}
+	devices.Network.BenchmarksOut = map[uint64]*sonm.Benchmark{
+		6: {Result: 20966499},
+	}
+
+	freeDevices := newEmptyDevicesReply()
+	freeDevices.CPU.Device.Cores = 1
+	freeDevices.CPU.Benchmarks = map[uint64]*sonm.Benchmark{
+		0: {Result: 817},
+		1: {Result: 1315},
+		2: {Result: 1},
+	}
+	freeDevices.RAM.Device.Total = 1033342976
+	freeDevices.RAM.Benchmarks = map[uint64]*sonm.Benchmark{
+		3: {
+			Result: 16333650944,
+		},
+	}
+	freeDevices.Network.In = 58801113
+	freeDevices.Network.Out = 20966499
+	freeDevices.Network.BenchmarksIn = map[uint64]*sonm.Benchmark{
+		5: {Result: 58801113},
+	}
+	freeDevices.Network.BenchmarksOut = map[uint64]*sonm.Benchmark{
+		6: {Result: 20966499},
+	}
+
+	controller := gomock.NewController(t)
+	defer controller.Finish()
+
+	manager, err := newDeviceManager(devices, freeDevices, newMappingMock(controller))
+	require.NoError(t, err)
+	require.NotNil(t, manager)
+
+	benchmark := [12]uint64{400, 0, 1, 256000000, 0, 1000000, 1000000}
+	{
+		plan, err := manager.consumeNetwork(benchmark[:])
+		require.NoError(t, err)
+		require.NotNil(t, plan)
+
+		assert.Equal(t, uint64(1000000), plan.ThroughputIn.BitsPerSecond)
+		assert.Equal(t, uint64(1000000), plan.ThroughputOut.BitsPerSecond)
+	}
+}

--- a/optimus/rational.go
+++ b/optimus/rational.go
@@ -2,6 +2,7 @@ package optimus
 
 import (
 	"errors"
+	"math"
 	"math/big"
 )
 
@@ -30,6 +31,10 @@ func (m Rational) Div(v uint64) Rational {
 func (m Rational) Float64() float64 {
 	r, _ := m.v.Float64()
 	return r
+}
+
+func (m Rational) Uint64Ceil() uint64 {
+	return uint64(math.Ceil(m.Float64()))
 }
 
 func (m Rational) Cmp(other Rational) int {

--- a/optimus/rational.go
+++ b/optimus/rational.go
@@ -1,0 +1,53 @@
+package optimus
+
+import (
+	"errors"
+	"math/big"
+)
+
+type Rational struct {
+	v *big.Rat
+}
+
+func NewRational(a, b uint64) Rational {
+	return Rational{
+		v: big.NewRat(int64(a), int64(b)),
+	}
+}
+
+func (m Rational) Mul(v uint64) Rational {
+	return Rational{
+		v: big.NewRat(1, 1).Mul(m.v, big.NewRat(int64(v), 1)),
+	}
+}
+
+func (m Rational) Div(v uint64) Rational {
+	return Rational{
+		v: big.NewRat(1, 1).Quo(m.v, big.NewRat(int64(v), 1)),
+	}
+}
+
+func (m Rational) Float64() float64 {
+	r, _ := m.v.Float64()
+	return r
+}
+
+func (m Rational) Cmp(other Rational) int {
+	return m.v.Cmp(other.v)
+}
+
+func Max(v []Rational) (Rational, error) {
+	if len(v) == 0 {
+		return Rational{}, errors.New("empty input")
+	}
+
+	max := v[0]
+
+	for i := 1; i < len(v); i++ {
+		if v[i].Cmp(max) > 0 {
+			max = v[i]
+		}
+	}
+
+	return max, nil
+}


### PR DESCRIPTION
This is required to avoid precision loosing.

I'd rather hold this until we find a real world example where this is strictly required. So - wip.