### PR TITLE
fix: do not spam warnings when no rendezvous specified

### DIFF
--- a/insonmnia/npp/options.go
+++ b/insonmnia/npp/options.go
@@ -47,6 +47,10 @@ func newOptions(ctx context.Context) *options {
 // back to the old good plain TCP connection.
 func WithRendezvous(cfg rendezvous.Config, credentials credentials.TransportCredentials) Option {
 	return func(o *options) error {
+		if len(cfg.Endpoints) == 0 {
+			return nil
+		}
+
 		o.puncherNew = func() (NATPuncher, error) {
 			for _, addr := range cfg.Endpoints {
 				client, err := newRendezvousClient(o.ctx, addr, credentials)


### PR DESCRIPTION
This should remove weird warnings like: `failed to construct a puncher	{"error": "failed to connect to []"}` when no rendezvous endpoints specified in the config.