### PR TITLE
fix: proper sigmoid implementation

### DIFF
--- a/optimus/learning_test.go
+++ b/optimus/learning_test.go
@@ -124,3 +124,23 @@ func TestLearning(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, n, len(weightedOrders))
 }
+
+func TestSigmoid(t *testing.T) {
+	tests := []struct {
+		name string
+		x    float64
+		y    float64
+	}{
+		{"0.0", 0.0, 0.9999546021312976},
+		{"43200.0", 43200.0, 0.5},
+		{"86400.0", 86400.0, 4.5397868702390376e-05},
+	}
+
+	sigmoid := newSigmoid(sigmoidConfig{Alpha: 10.0, Delta: 43200.0})
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.InEpsilon(t, test.y, sigmoid(test.x), 1e-6)
+		})
+	}
+}

--- a/optimus/math.go
+++ b/optimus/math.go
@@ -1,6 +1,8 @@
 package optimus
 
-import "math"
+import (
+	"math"
+)
 
 type sigmoid func(x float64) float64
 
@@ -11,6 +13,6 @@ type sigmoidConfig struct {
 
 func newSigmoid(cfg sigmoidConfig) sigmoid {
 	return func(x float64) float64 {
-		return 1 - (1 / math.Exp(-cfg.Alpha*(x-cfg.Delta)/cfg.Delta))
+		return 1 - (1 / (1 + math.Exp(-cfg.Alpha*(x-cfg.Delta)/cfg.Delta)))
 	}
 }


### PR DESCRIPTION
Autosell bot should no longer fall into millions of NaNs after calculating relative order weights.