### PR TITLE
fix: do not null order created timestamp

### DIFF
--- a/optimus/learning.go
+++ b/optimus/learning.go
@@ -57,7 +57,6 @@ func (m *regressionClassifier) Classify(orders []*MarketOrder) ([]WeightedOrder,
 
 		distance := normalizer.Denormalize(normalizedPrice) - expectation[i]
 
-		orders[i].CreatedTS = &sonm.Timestamp{}
 		weightedOrders = append(weightedOrders, WeightedOrder{
 			Order:    orders[i],
 			Distance: distance,

--- a/optimus/learning.go
+++ b/optimus/learning.go
@@ -57,6 +57,9 @@ func (m *regressionClassifier) Classify(orders []*MarketOrder) ([]WeightedOrder,
 
 		distance := normalizer.Denormalize(normalizedPrice) - expectation[i]
 
+		if orders[i].CreatedTS == nil {
+			orders[i].CreatedTS = &sonm.Timestamp{}
+		}
 		weightedOrders = append(weightedOrders, WeightedOrder{
 			Order:    orders[i],
 			Distance: distance,


### PR DESCRIPTION
When DWH was young it was unable to return properly created timestamp, we inited it ourselves.

Now times change, but those empty initialization was forgotten and cause strange autosell bot behaviour.

This commit removes such initialization.