### PR TITLE
fix: make relay IPv6 ready (not really)

### DIFF
--- a/insonmnia/npp/relay/server.go
+++ b/insonmnia/npp/relay/server.go
@@ -632,7 +632,12 @@ func (m *server) NotifyUpdate(node *memberlist.Node) {
 }
 
 func (m *server) formatEndpoint(ip net.IP) string {
-	return fmt.Sprintf("%s:%d", ip.String(), m.port)
+	addr := net.TCPAddr{
+		IP:   ip,
+		Port: int(m.port),
+	}
+
+	return addr.String()
 }
 
 func mpsc() (chan<- net.Conn, <-chan net.Conn) {


### PR DESCRIPTION
In case of being run on IPv6 it improperly answers to a discover request with address not surrounded with braces.
Now this part is okay.