### PR TITLE
chore: drop pkg/errors, wrap errors using fmt.Errorf

### DIFF
--- a/accounts/identity.go
+++ b/accounts/identity.go
@@ -2,11 +2,11 @@ package accounts
 
 import (
 	"crypto/ecdsa"
+	"errors"
 	"io/ioutil"
 
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/accounts/keystore"
-	"github.com/pkg/errors"
 )
 
 var (

--- a/blockchain/api.go
+++ b/blockchain/api.go
@@ -3,6 +3,7 @@ package blockchain
 import (
 	"context"
 	"crypto/ecdsa"
+	"errors"
 	"fmt"
 	"math/big"
 	"time"
@@ -12,7 +13,6 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/noxiouz/zapctx/ctxlog"
-	"github.com/pkg/errors"
 	marketAPI "github.com/sonm-io/core/blockchain/source/api"
 	pb "github.com/sonm-io/core/proto"
 	"go.uber.org/zap"
@@ -569,7 +569,7 @@ func (api *BasicMarketAPI) CreateChangeRequest(ctx context.Context, key *ecdsa.P
 
 	id, err := extractBig(logs.Topics, 1)
 	if err != nil {
-		return nil, errors.WithMessage(err, "cannot extract change request id from transaction logs")
+		return nil, fmt.Errorf("cannot extract change request id from transaction logs: %v", err)
 	}
 
 	return id, nil
@@ -988,7 +988,7 @@ func (api *BasicEventsAPI) GetEvents(ctx context.Context, fromBlockInitial *big.
 
 				if err != nil {
 					out <- &Event{
-						Data:        &ErrorData{Err: errors.Wrap(err, "failed to FilterLogs")},
+						Data:        &ErrorData{Err: fmt.Errorf("failed to FilterLogs: %v", err)},
 						BlockNumber: fromBlock,
 					}
 				}

--- a/blockchain/util.go
+++ b/blockchain/util.go
@@ -7,8 +7,8 @@ import (
 	"math/big"
 	"time"
 
+	"errors"
 	"github.com/ethereum/go-ethereum"
-	"github.com/pkg/errors"
 	"github.com/sonm-io/core/util"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"

--- a/insonmnia/dwh/config.go
+++ b/insonmnia/dwh/config.go
@@ -1,8 +1,9 @@
 package dwh
 
 import (
+	"errors"
+
 	"github.com/jinzhu/configor"
-	"github.com/pkg/errors"
 	"github.com/sonm-io/core/accounts"
 	"github.com/sonm-io/core/blockchain"
 	"github.com/sonm-io/core/insonmnia/logging"

--- a/insonmnia/dwh/server.go
+++ b/insonmnia/dwh/server.go
@@ -4,6 +4,8 @@ import (
 	"crypto/ecdsa"
 	"database/sql"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"math/big"
 	"net"
 	"reflect"
@@ -14,7 +16,6 @@ import (
 	"github.com/grpc-ecosystem/go-grpc-prometheus"
 	_ "github.com/mattn/go-sqlite3"
 	log "github.com/noxiouz/zapctx/ctxlog"
-	"github.com/pkg/errors"
 	"github.com/sonm-io/core/blockchain"
 	pb "github.com/sonm-io/core/proto"
 	"github.com/sonm-io/core/util"
@@ -71,24 +72,24 @@ func (m *DWH) Serve() error {
 	bch, err := blockchain.NewAPI(blockchain.WithConfig(m.cfg.Blockchain))
 	if err != nil {
 		m.Stop()
-		return errors.Wrap(err, "failed to create NewAPI")
+		return fmt.Errorf("failed to create NewAPI: %v", err)
 	}
 	m.blockchain = bch
 
 	if err := m.setupDB(); err != nil {
 		m.Stop()
-		return errors.WithMessage(err, "failed to setupDB")
+		return fmt.Errorf("failed to setupDB: %v", err)
 	}
 
 	go m.monitorBlockchain()
 	if m.cfg.ColdStart {
 		if err := m.coldStart(); err != nil {
 			m.Stop()
-			return errors.Wrap(err, "failed to coldStart")
+			return fmt.Errorf("failed to coldStart: %v", err)
 		}
 	} else {
 		if err := m.storage.CreateIndices(m.db); err != nil {
-			return errors.WithMessage(err, "failed to CreateIndices (Serve)")
+			return fmt.Errorf("failed to CreateIndices (Serve): %v", err)
 		}
 	}
 
@@ -125,7 +126,7 @@ func (m *DWH) setupDB() error {
 	numBenchmarks, err := m.blockchain.Market().GetNumBenchmarks(m.ctx)
 	if err != nil {
 		m.stop()
-		return errors.Wrap(err, "failed to GetNumBenchmarks")
+		return fmt.Errorf("failed to GetNumBenchmarks: %v", err)
 	}
 	if numBenchmarks >= NumMaxBenchmarks {
 		m.stop()
@@ -137,17 +138,17 @@ func (m *DWH) setupDB() error {
 	case "sqlite3":
 		_, err := m.db.Exec(`PRAGMA foreign_keys=ON`)
 		if err != nil {
-			return errors.Wrapf(err, "failed to enable foreign key support (%s)", m.cfg.Storage.Backend)
+			return fmt.Errorf("failed to enable foreign key support (%s): %v", m.cfg.Storage.Backend, err)
 		}
 		storage = newSQLiteStorage(numBenchmarks)
 	case "postgres":
 		storage = newPostgresStorage(numBenchmarks)
 	default:
-		return errors.Errorf("unsupported backend: %s", m.cfg.Storage.Backend)
+		return fmt.Errorf("unsupported backend: %s", m.cfg.Storage.Backend)
 	}
 
 	if err := storage.Setup(m.db); err != nil {
-		return errors.Wrap(err, "failed to setup storage")
+		return fmt.Errorf("failed to setup storage: %v", err)
 	}
 
 	m.storage = storage
@@ -176,7 +177,7 @@ func (m *DWH) serveGRPC() error {
 	lis, err := net.Listen("tcp", m.cfg.GRPCListenAddr)
 	if err != nil {
 		m.mu.Unlock()
-		return errors.Wrapf(err, "failed to listen on %s", m.cfg.GRPCListenAddr)
+		return fmt.Errorf("failed to listen on %s: %v", m.cfg.GRPCListenAddr, err)
 	}
 
 	m.mu.Unlock()
@@ -198,20 +199,20 @@ func (m *DWH) serveHTTP() error {
 	lis, err := net.Listen("tcp", m.cfg.HTTPListenAddr)
 	if err != nil {
 		m.mu.Unlock()
-		return errors.WithMessage(err, "failed to create http listener")
+		return fmt.Errorf("failed to create http listener: %v", err)
 	}
 
 	options = append(options, rest.WithListener(lis))
 	srv, err := rest.NewServer(options...)
 	if err != nil {
 		m.mu.Unlock()
-		return errors.WithMessage(err, "failed to create rest server")
+		return fmt.Errorf("failed to create rest server: %v", err)
 	}
 
 	err = srv.RegisterService((*pb.DWHServer)(nil), m)
 	if err != nil {
 		m.mu.Unlock()
-		return errors.WithMessage(err, "failed to RegisterService")
+		return fmt.Errorf("failed to RegisterService: %v", err)
 	}
 
 	m.http = srv
@@ -291,7 +292,7 @@ func (m *DWH) GetOrderDetails(ctx context.Context, request *pb.BigInt) (*pb.DWHO
 	out, err := m.storage.GetOrderByID(conn, request.Unwrap())
 	if err != nil {
 		m.logger.Warn("failed to GetOrderDetails", util.LaconicError(err), zap.Any("request", *request))
-		return nil, errors.Wrap(err, "failed to GetOrderDetails")
+		return nil, fmt.Errorf("failed to GetOrderDetails: %v", err)
 	}
 
 	return out, nil
@@ -554,11 +555,11 @@ func (m *DWH) onNumBenchmarksUpdated(newNumBenchmarks uint64) error {
 	defer m.mu.Unlock()
 
 	if err := m.setupDB(); err != nil {
-		return errors.WithMessage(err, "failed to setupDB after NumBenchmarksUpdated event")
+		return fmt.Errorf("failed to setupDB after NumBenchmarksUpdated event: %v", err)
 	}
 
 	if err := m.storage.CreateIndices(m.db); err != nil {
-		return errors.WithMessage(err, "failed to CreateIndices (onNumBenchmarksUpdated)")
+		return fmt.Errorf("failed to CreateIndices (onNumBenchmarksUpdated): %v", err)
 	}
 
 	return nil
@@ -567,18 +568,18 @@ func (m *DWH) onNumBenchmarksUpdated(newNumBenchmarks uint64) error {
 func (m *DWH) onDealOpened(dealID *big.Int) error {
 	deal, err := m.blockchain.Market().GetDealInfo(m.ctx, dealID)
 	if err != nil {
-		return errors.Wrapf(err, "failed to GetDealInfo")
+		return fmt.Errorf("failed to GetDealInfo: %v", err)
 	}
 
 	conn, err := newTxConn(m.db, m.logger)
 	if err != nil {
-		return errors.Wrap(err, "failed to begin transaction")
+		return fmt.Errorf("failed to begin transaction: %v", err)
 	}
 	defer conn.Finish()
 
 	if deal.Status == pb.DealStatus_DEAL_CLOSED {
 		if err := m.storage.StoreStaleID(newSimpleConn(m.db), dealID, "Deal"); err != nil {
-			return errors.Wrap(err, "failed to StoreStaleID")
+			return fmt.Errorf("failed to StoreStaleID: %v", err)
 		}
 		m.logger.Debug("skipping inactive deal", zap.String("deal_id", dealID.String()))
 		return nil
@@ -586,7 +587,7 @@ func (m *DWH) onDealOpened(dealID *big.Int) error {
 
 	err = m.storage.InsertDeal(conn, deal)
 	if err != nil {
-		return errors.Wrapf(err, "failed to insertDeal")
+		return fmt.Errorf("failed to insertDeal: %v", err)
 	}
 
 	err = m.storage.InsertDealCondition(conn,
@@ -603,7 +604,7 @@ func (m *DWH) onDealOpened(dealID *big.Int) error {
 		},
 	)
 	if err != nil {
-		return errors.Wrapf(err, "onDealOpened: failed to insertDealCondition")
+		return fmt.Errorf("onDealOpened: failed to insertDealCondition: %v", err)
 	}
 
 	return nil
@@ -612,18 +613,18 @@ func (m *DWH) onDealOpened(dealID *big.Int) error {
 func (m *DWH) onDealUpdated(dealID *big.Int) error {
 	deal, err := m.blockchain.Market().GetDealInfo(m.ctx, dealID)
 	if err != nil {
-		return errors.Wrapf(err, "failed to GetDealInfo")
+		return fmt.Errorf("failed to GetDealInfo: %v", err)
 	}
 
 	conn, err := newTxConn(m.db, m.logger)
 	if err != nil {
-		return errors.Wrap(err, "failed to begin transaction")
+		return fmt.Errorf("failed to begin transaction: %v", err)
 	}
 	defer conn.Finish()
 
 	// If deal is known to be stale:
 	if ok, err := m.storage.CheckStaleID(conn, dealID, "Deal"); err != nil {
-		return errors.Wrap(err, "failed to CheckStaleID")
+		return fmt.Errorf("failed to CheckStaleID: %v", err)
 	} else {
 		if ok {
 			m.removeStaleEntityID(dealID, "Deal")
@@ -634,21 +635,21 @@ func (m *DWH) onDealUpdated(dealID *big.Int) error {
 	if deal.Status == pb.DealStatus_DEAL_CLOSED {
 		err = m.storage.DeleteDeal(conn, deal.Id.Unwrap())
 		if err != nil {
-			return errors.Wrap(err, "failed to delete deal (possibly old log entry)")
+			return fmt.Errorf("failed to delete deal (possibly old log entry): %v", err)
 		}
 
 		if err := m.storage.DeleteOrder(conn, deal.AskID.Unwrap()); err != nil {
-			return errors.Wrap(err, "failed to deleteOrder")
+			return fmt.Errorf("failed to deleteOrder: %v", err)
 		}
 		if err := m.storage.DeleteOrder(conn, deal.BidID.Unwrap()); err != nil {
-			return errors.Wrap(err, "failed to deleteOrder")
+			return fmt.Errorf("failed to deleteOrder: %v", err)
 		}
 
 		return nil
 	}
 
 	if err := m.storage.UpdateDeal(conn, deal); err != nil {
-		return errors.Wrapf(err, "failed to UpdateDeal")
+		return fmt.Errorf("failed to UpdateDeal: %v", err)
 	}
 
 	return nil
@@ -662,13 +663,13 @@ func (m *DWH) onDealChangeRequestSent(eventTS uint64, changeRequestID *big.Int) 
 
 	conn, err := newTxConn(m.db, m.logger)
 	if err != nil {
-		return errors.Wrap(err, "failed to begin transaction")
+		return fmt.Errorf("failed to begin transaction: %v", err)
 	}
 	defer conn.Finish()
 
 	// If deal is known to be stale, skip.
 	if ok, err := m.storage.CheckStaleID(conn, changeRequest.DealID.Unwrap(), "Deal"); err != nil {
-		return errors.Wrap(err, "failed to CheckStaleID")
+		return fmt.Errorf("failed to CheckStaleID: %v", err)
 	} else {
 		if ok {
 			m.logger.Debug("skipping DealChangeRequestSent event for inactive deal")
@@ -691,7 +692,7 @@ func (m *DWH) onDealChangeRequestSent(eventTS uint64, changeRequestID *big.Int) 
 	for _, expiredChangeRequest := range expiredChangeRequests {
 		err := m.storage.DeleteDealChangeRequest(conn, expiredChangeRequest.Id.Unwrap())
 		if err != nil {
-			return errors.Wrap(err, "failed to deleteDealChangeRequest")
+			return fmt.Errorf("failed to deleteDealChangeRequest: %v", err)
 		} else {
 			m.logger.Warn("deleted expired DealChangeRequest",
 				zap.String("id", expiredChangeRequest.Id.Unwrap().String()))
@@ -700,7 +701,7 @@ func (m *DWH) onDealChangeRequestSent(eventTS uint64, changeRequestID *big.Int) 
 
 	changeRequest.CreatedTS = &pb.Timestamp{Seconds: int64(eventTS)}
 	if err := m.storage.InsertDealChangeRequest(conn, changeRequest); err != nil {
-		return errors.Wrapf(err, "failed to InsertDealChangeRequest (%s)", changeRequest.Id.Unwrap().String())
+		return fmt.Errorf("failed to InsertDealChangeRequest (%s): %v", changeRequest.Id.Unwrap().String(), err)
 	}
 
 	return err
@@ -714,13 +715,13 @@ func (m *DWH) onDealChangeRequestUpdated(eventTS uint64, changeRequestID *big.In
 
 	conn, err := newTxConn(m.db, m.logger)
 	if err != nil {
-		return errors.Wrap(err, "failed to begin transaction")
+		return fmt.Errorf("failed to begin transaction: %v", err)
 	}
 	defer conn.Finish()
 
 	// If deal is known to be stale, skip.
 	if ok, err := m.storage.CheckStaleID(conn, changeRequest.DealID.Unwrap(), "Deal"); err != nil {
-		return errors.Wrap(err, "failed to CheckStaleID")
+		return fmt.Errorf("failed to CheckStaleID: %v", err)
 	} else {
 		if ok {
 			m.logger.Debug("skipping DealChangeRequestUpdated event for inactive deal")
@@ -732,22 +733,22 @@ func (m *DWH) onDealChangeRequestUpdated(eventTS uint64, changeRequestID *big.In
 	case pb.ChangeRequestStatus_REQUEST_REJECTED:
 		err := m.storage.UpdateDealChangeRequest(conn, changeRequest)
 		if err != nil {
-			return errors.Wrapf(err, "failed to update DealChangeRequest %s", changeRequest.Id.Unwrap().String())
+			return fmt.Errorf("failed to update DealChangeRequest %s: %v", changeRequest.Id.Unwrap().String(), err)
 		}
 	case pb.ChangeRequestStatus_REQUEST_ACCEPTED:
 		deal, err := m.storage.GetDealByID(conn, changeRequest.DealID.Unwrap())
 		if err != nil {
-			return errors.Wrap(err, "failed to storage.GetDealByID")
+			return fmt.Errorf("failed to storage.GetDealByID: %v", err)
 		}
 
 		deal.Deal.Duration = changeRequest.Duration
 		deal.Deal.Price = changeRequest.Price
 		if err := m.storage.UpdateDeal(conn, deal.Deal); err != nil {
-			return errors.WithMessage(err, "failed to UpdateDeal")
+			return fmt.Errorf("failed to UpdateDeal: %v", err)
 		}
 
 		if err := m.updateDealConditionEndTime(conn, deal.GetDeal().Id, eventTS); err != nil {
-			return errors.Wrap(err, "failed to updateDealConditionEndTime")
+			return fmt.Errorf("failed to updateDealConditionEndTime: %v", err)
 		}
 
 		err = m.storage.InsertDealCondition(conn,
@@ -764,17 +765,17 @@ func (m *DWH) onDealChangeRequestUpdated(eventTS uint64, changeRequestID *big.In
 			},
 		)
 		if err != nil {
-			return errors.Wrap(err, "failed to insertDealCondition")
+			return fmt.Errorf("failed to insertDealCondition: %v", err)
 		}
 
 		err = m.storage.DeleteDealChangeRequest(conn, changeRequest.Id.Unwrap())
 		if err != nil {
-			return errors.Wrapf(err, "failed to delete DealChangeRequest %s", changeRequest.Id.Unwrap().String())
+			return fmt.Errorf("failed to delete DealChangeRequest %s: %v", changeRequest.Id.Unwrap().String(), err)
 		}
 	default:
 		err := m.storage.DeleteDealChangeRequest(conn, changeRequest.Id.Unwrap())
 		if err != nil {
-			return errors.Wrapf(err, "failed to delete DealChangeRequest %s", changeRequest.Id.Unwrap().String())
+			return fmt.Errorf("failed to delete DealChangeRequest %s: %v", changeRequest.Id.Unwrap().String(), err)
 		}
 	}
 
@@ -784,13 +785,13 @@ func (m *DWH) onDealChangeRequestUpdated(eventTS uint64, changeRequestID *big.In
 func (m *DWH) onBilled(eventTS uint64, dealID, payedAmount *big.Int) error {
 	conn, err := newTxConn(m.db, m.logger)
 	if err != nil {
-		return errors.Wrap(err, "failed to begin transaction")
+		return fmt.Errorf("failed to begin transaction: %v", err)
 	}
 	defer conn.Finish()
 
 	// If deal is known to be stale, skip.
 	if ok, err := m.storage.CheckStaleID(conn, dealID, "Deal"); err != nil {
-		return errors.Wrap(err, "failed to CheckStaleID")
+		return fmt.Errorf("failed to CheckStaleID: %v", err)
 	} else {
 		if ok {
 			m.logger.Debug("skipping Billed event for inactive deal")
@@ -799,26 +800,26 @@ func (m *DWH) onBilled(eventTS uint64, dealID, payedAmount *big.Int) error {
 	}
 
 	if err := m.updateDealPayout(conn, dealID, payedAmount, eventTS); err != nil {
-		return errors.Wrap(err, "failed to updateDealPayout")
+		return fmt.Errorf("failed to updateDealPayout: %v", err)
 	}
 
 	dealConditions, _, err := m.storage.GetDealConditions(conn, &pb.DealConditionsRequest{DealID: pb.NewBigInt(dealID)})
 	if err != nil {
-		return errors.Wrap(err, "failed to GetDealConditions (last)")
+		return fmt.Errorf("failed to GetDealConditions (last): %v", err)
 	}
 
 	if len(dealConditions) < 1 {
-		return errors.Errorf("no deal conditions found for deal `%s`", dealID.String())
+		return fmt.Errorf("no deal conditions found for deal `%s`: %v", dealID.String(), err)
 	}
 
 	err = m.storage.UpdateDealConditionPayout(conn, dealConditions[0].Id,
 		big.NewInt(0).Add(dealConditions[0].TotalPayout.Unwrap(), payedAmount))
 	if err != nil {
-		return errors.Wrap(err, "failed to UpdateDealConditionPayout")
+		return fmt.Errorf("failed to UpdateDealConditionPayout: %v", err)
 	}
 
 	if err != nil {
-		return errors.Wrap(err, "insertDealPayment failed")
+		return fmt.Errorf("insertDealPayment failed: %v", err)
 	}
 
 	return nil
@@ -827,13 +828,13 @@ func (m *DWH) onBilled(eventTS uint64, dealID, payedAmount *big.Int) error {
 func (m *DWH) updateDealPayout(conn queryConn, dealID, payedAmount *big.Int, billTS uint64) error {
 	deal, err := m.storage.GetDealByID(conn, dealID)
 	if err != nil {
-		return errors.Wrap(err, "failed to GetDealByID")
+		return fmt.Errorf("failed to GetDealByID: %v", err)
 	}
 
 	newDealTotalPayout := big.NewInt(0).Add(deal.Deal.TotalPayout.Unwrap(), payedAmount)
 	err = m.storage.UpdateDealPayout(conn, dealID, newDealTotalPayout, billTS)
 	if err != nil {
-		return errors.Wrap(err, "failed to updateDealPayout")
+		return fmt.Errorf("failed to updateDealPayout: %v", err)
 	}
 
 	return nil
@@ -842,18 +843,18 @@ func (m *DWH) updateDealPayout(conn queryConn, dealID, payedAmount *big.Int, bil
 func (m *DWH) onOrderPlaced(eventTS uint64, orderID *big.Int) error {
 	order, err := m.blockchain.Market().GetOrderInfo(m.ctx, orderID)
 	if err != nil {
-		return errors.Wrapf(err, "failed to GetOrderInfo")
+		return fmt.Errorf("failed to GetOrderInfo: %v", err)
 	}
 
 	conn, err := newTxConn(m.db, m.logger)
 	if err != nil {
-		return errors.Wrap(err, "failed to begin transaction")
+		return fmt.Errorf("failed to begin transaction: %v", err)
 	}
 	defer conn.Finish()
 
 	if order.OrderStatus == pb.OrderStatus_ORDER_INACTIVE && order.DealID.IsZero() {
 		if err := m.storage.StoreStaleID(conn, orderID, "Order"); err != nil {
-			return errors.Wrap(err, "failed to StoreStaleID")
+			return fmt.Errorf("failed to StoreStaleID: %v", err)
 		}
 		m.logger.Debug("skipping inactive order", zap.String("order_id", orderID.String()))
 		return nil
@@ -879,7 +880,7 @@ func (m *DWH) onOrderPlaced(eventTS uint64, orderID *big.Int) error {
 	} else {
 		if order.OrderStatus == pb.OrderStatus_ORDER_ACTIVE {
 			if err := m.updateProfileStats(conn, order.OrderType, userID, 1); err != nil {
-				return errors.Wrap(err, "failed to updateProfileStats")
+				return fmt.Errorf("failed to updateProfileStats: %v", err)
 			}
 		}
 	}
@@ -913,7 +914,7 @@ func (m *DWH) onOrderPlaced(eventTS uint64, orderID *big.Int) error {
 		},
 	})
 	if err != nil {
-		return errors.Wrapf(err, "failed to insertOrder")
+		return fmt.Errorf("failed to insertOrder: %v", err)
 	}
 
 	return nil
@@ -922,19 +923,19 @@ func (m *DWH) onOrderPlaced(eventTS uint64, orderID *big.Int) error {
 func (m *DWH) onOrderUpdated(orderID *big.Int) error {
 	marketOrder, err := m.blockchain.Market().GetOrderInfo(m.ctx, orderID)
 	if err != nil {
-		return errors.Wrap(err, "failed to GetOrderInfo")
+		return fmt.Errorf("failed to GetOrderInfo: %v", err)
 	}
 
 	conn, err := newTxConn(m.db, m.logger)
 	if err != nil {
-		return errors.Wrap(err, "failed to begin transaction")
+		return fmt.Errorf("failed to begin transaction: %v", err)
 	}
 	defer conn.Finish()
 
 	// If the order was known to be inactive, delete it from the list of inactive entities
 	// and skip.
 	if ok, err := m.storage.CheckStaleID(conn, orderID, "Order"); err != nil {
-		return errors.Wrap(err, "failed to CheckStaleID")
+		return fmt.Errorf("failed to CheckStaleID: %v", err)
 	} else {
 		if ok {
 			m.removeStaleEntityID(orderID, "Order")
@@ -947,7 +948,7 @@ func (m *DWH) onOrderUpdated(orderID *big.Int) error {
 	// we always use the user ID that was chosen in `onOrderPlaced` (i.e., the one that is already stored in DB).
 	dwhOrder, err := m.storage.GetOrderByID(conn, marketOrder.GetId().Unwrap())
 	if err != nil {
-		return errors.Wrap(err, "failed to GetOrderByID")
+		return fmt.Errorf("failed to GetOrderByID: %v", err)
 	}
 
 	var userID common.Address
@@ -967,13 +968,13 @@ func (m *DWH) onOrderUpdated(orderID *big.Int) error {
 		// Otherwise update order status.
 		err := m.storage.UpdateOrderStatus(conn, marketOrder.Id.Unwrap(), marketOrder.OrderStatus)
 		if err != nil {
-			return errors.Wrap(err, "failed to updateOrderStatus (possibly old log entry)")
+			return fmt.Errorf("failed to updateOrderStatus (possibly old log entry): %v", err)
 		}
 	}
 
 	if dwhOrder.GetOrder().OrderStatus == pb.OrderStatus_ORDER_ACTIVE {
 		if err := m.updateProfileStats(conn, marketOrder.OrderType, userID, -1); err != nil {
-			return errors.Wrapf(err, "failed to updateProfileStats (AuthorID: `%s`)", marketOrder.AuthorID.Unwrap().String())
+			return fmt.Errorf("failed to updateProfileStats (AuthorID: `%s`): %v", marketOrder.AuthorID.Unwrap().String(), err)
 		}
 	}
 
@@ -988,7 +989,7 @@ func (m *DWH) onWorkerAnnounced(masterID, slaveID common.Address) error {
 	defer conn.Finish()
 
 	if ok, err := m.storage.CheckWorkerExists(conn, masterID, slaveID); err != nil {
-		return errors.Wrap(err, "failed to CheckWorker")
+		return fmt.Errorf("failed to CheckWorker: %v", err)
 	} else {
 		if ok {
 			// Worker already exists, skipping.
@@ -997,7 +998,7 @@ func (m *DWH) onWorkerAnnounced(masterID, slaveID common.Address) error {
 	}
 
 	if err := m.storage.InsertWorker(conn, masterID, slaveID); err != nil {
-		return errors.Wrap(err, "onWorkerAnnounced failed")
+		return fmt.Errorf("onWorkerAnnounced failed: %v", err)
 	}
 
 	return nil
@@ -1008,7 +1009,7 @@ func (m *DWH) onWorkerConfirmed(masterID, slaveID common.Address) error {
 	defer conn.Finish()
 
 	if err := m.storage.UpdateWorker(conn, masterID, slaveID); err != nil {
-		return errors.Wrap(err, "onWorkerConfirmed failed")
+		return fmt.Errorf("onWorkerConfirmed failed: %v", err)
 	}
 
 	return nil
@@ -1019,7 +1020,7 @@ func (m *DWH) onWorkerRemoved(masterID, slaveID common.Address) error {
 	defer conn.Finish()
 
 	if err := m.storage.DeleteWorker(conn, masterID, slaveID); err != nil {
-		return errors.Wrap(err, "onWorkerRemoved failed")
+		return fmt.Errorf("onWorkerRemoved failed: %v", err)
 	}
 
 	return nil
@@ -1030,7 +1031,7 @@ func (m *DWH) onAddedToBlacklist(adderID, addeeID common.Address) error {
 	defer conn.Finish()
 
 	if err := m.storage.InsertBlacklistEntry(conn, adderID, addeeID); err != nil {
-		return errors.Wrap(err, "onAddedToBlacklist failed")
+		return fmt.Errorf("onAddedToBlacklist failed: %v", err)
 	}
 
 	return nil
@@ -1041,7 +1042,7 @@ func (m *DWH) onRemovedFromBlacklist(removerID, removeeID common.Address) error 
 	defer conn.Finish()
 
 	if err := m.storage.DeleteBlacklistEntry(conn, removerID, removeeID); err != nil {
-		return errors.Wrap(err, "onRemovedFromBlacklist failed")
+		return fmt.Errorf("onRemovedFromBlacklist failed: %v", err)
 	}
 
 	return nil
@@ -1050,14 +1051,14 @@ func (m *DWH) onRemovedFromBlacklist(removerID, removeeID common.Address) error 
 func (m *DWH) onValidatorCreated(validatorID common.Address) error {
 	validator, err := m.blockchain.ProfileRegistry().GetValidator(m.ctx, validatorID)
 	if err != nil {
-		return errors.Wrapf(err, "failed to get validator `%s`", validatorID.String())
+		return fmt.Errorf("failed to get validator `%s`: %v", validatorID.String(), err)
 	}
 
 	conn := newSimpleConn(m.db)
 	defer conn.Finish()
 
 	if err := m.storage.InsertOrUpdateValidator(conn, validator); err != nil {
-		return errors.Wrap(err, "failed to insertValidator")
+		return fmt.Errorf("failed to insertValidator: %v", err)
 	}
 
 	return nil
@@ -1066,14 +1067,14 @@ func (m *DWH) onValidatorCreated(validatorID common.Address) error {
 func (m *DWH) onValidatorDeleted(validatorID common.Address) error {
 	validator, err := m.blockchain.ProfileRegistry().GetValidator(m.ctx, validatorID)
 	if err != nil {
-		return errors.Wrapf(err, "failed to get validator `%s`", validatorID.String())
+		return fmt.Errorf("failed to get validator `%s`: %v", validatorID.String(), err)
 	}
 
 	conn := newSimpleConn(m.db)
 	defer conn.Finish()
 
 	if err := m.storage.UpdateValidator(conn, validator); err != nil {
-		return errors.Wrap(err, "failed to InsertOrUpdateValidator")
+		return fmt.Errorf("failed to InsertOrUpdateValidator: %v", err)
 	}
 
 	return nil
@@ -1085,25 +1086,25 @@ func (m *DWH) onCertificateCreated(certificateID *big.Int) error {
 
 	certificate, err := m.blockchain.ProfileRegistry().GetCertificate(m.ctx, certificateID)
 	if err != nil {
-		return errors.Wrap(err, "failed to GetCertificate")
+		return fmt.Errorf("failed to GetCertificate: %v", err)
 	}
 
 	conn, err := newTxConn(m.db, m.logger)
 	if err != nil {
-		return errors.Wrap(err, "failed to begin transaction")
+		return fmt.Errorf("failed to begin transaction: %v", err)
 	}
 	defer conn.Finish()
 
 	if err = m.storage.InsertCertificate(conn, certificate); err != nil {
-		return errors.Wrap(err, "failed to insertCertificate")
+		return fmt.Errorf("failed to insertCertificate: %v", err)
 	}
 
 	if err := m.updateProfile(conn, certificate); err != nil {
-		return errors.Wrap(err, "failed to updateProfile")
+		return fmt.Errorf("failed to updateProfile: %v", err)
 	}
 
 	if err := m.updateEntitiesByProfile(conn, certificate); err != nil {
-		return errors.Wrap(err, "failed to updateEntitiesByProfile")
+		return fmt.Errorf("failed to updateEntitiesByProfile: %v", err)
 	}
 
 	return nil
@@ -1115,7 +1116,7 @@ func (m *DWH) updateProfile(conn queryConn, certificate *pb.Certificate) error {
 		MasterID:  certificate.OwnerID,
 		WithCount: true})
 	if err != nil {
-		return errors.WithMessage(err, "failed to get active ASKs count")
+		return fmt.Errorf("failed to get active ASKs count: %v", err)
 	}
 
 	_, activeBids, err := m.storage.GetOrders(conn, &pb.OrdersRequest{
@@ -1123,7 +1124,7 @@ func (m *DWH) updateProfile(conn queryConn, certificate *pb.Certificate) error {
 		MasterID:  certificate.OwnerID,
 		WithCount: true})
 	if err != nil {
-		return errors.WithMessage(err, "failed to get active BIDs count")
+		return fmt.Errorf("failed to get active BIDs count: %v", err)
 	}
 
 	certBytes, _ := json.Marshal([]*pb.Certificate{})
@@ -1134,7 +1135,7 @@ func (m *DWH) updateProfile(conn queryConn, certificate *pb.Certificate) error {
 		ActiveBids:   activeBids,
 	})
 	if err != nil {
-		return errors.Wrap(err, "failed to insertProfileUserID")
+		return fmt.Errorf("failed to insertProfileUserID: %v", err)
 	}
 
 	// Update distinct Profile columns.
@@ -1143,19 +1144,19 @@ func (m *DWH) updateProfile(conn queryConn, certificate *pb.Certificate) error {
 		err := m.storage.UpdateProfile(conn, certificate.OwnerID.Unwrap(), attributeToString[certificate.Attribute],
 			string(certificate.Value))
 		if err != nil {
-			return errors.Wrapf(err, "failed to UpdateProfile (%s)", attributeToString[certificate.Attribute])
+			return fmt.Errorf("failed to UpdateProfile (%s): %v err", attributeToString[certificate.Attribute], err)
 		}
 	}
 
 	// Update certificates blob.
 	certificates, err := m.storage.GetCertificates(conn, certificate.OwnerID.Unwrap())
 	if err != nil {
-		return errors.Wrap(err, "failed to GetCertificates")
+		return fmt.Errorf("failed to GetCertificates: %v", err)
 	}
 
 	certificateAttrsBytes, err := json.Marshal(certificates)
 	if err != nil {
-		return errors.Wrap(err, "failed to marshal certificates")
+		return fmt.Errorf("failed to marshal certificates: %v", err)
 	}
 
 	var maxIdentityLevel uint64
@@ -1167,12 +1168,12 @@ func (m *DWH) updateProfile(conn queryConn, certificate *pb.Certificate) error {
 
 	err = m.storage.UpdateProfile(conn, certificate.OwnerID.Unwrap(), "Certificates", certificateAttrsBytes)
 	if err != nil {
-		return errors.Wrap(err, "failed to updateProfileCertificates (Certificates)")
+		return fmt.Errorf("failed to updateProfileCertificates (Certificates): %v", err)
 	}
 
 	err = m.storage.UpdateProfile(conn, certificate.OwnerID.Unwrap(), "IdentityLevel", maxIdentityLevel)
 	if err != nil {
-		return errors.Wrap(err, "failed to updateProfileCertificates (Level)")
+		return fmt.Errorf("failed to updateProfileCertificates (Level): %v", err)
 	}
 
 	return nil
@@ -1181,20 +1182,20 @@ func (m *DWH) updateProfile(conn queryConn, certificate *pb.Certificate) error {
 func (m *DWH) updateEntitiesByProfile(conn queryConn, certificate *pb.Certificate) error {
 	profile, err := m.storage.GetProfileByID(conn, certificate.OwnerID.Unwrap())
 	if err != nil {
-		return errors.Wrap(err, "failed to getProfileInfo")
+		return fmt.Errorf("failed to getProfileInfo: %v", err)
 	}
 
 	if err := m.storage.UpdateOrders(conn, profile); err != nil {
-		return errors.Wrap(err, "failed to updateOrders")
+		return fmt.Errorf("failed to updateOrders: %v", err)
 	}
 
 	if err = m.storage.UpdateDealsSupplier(conn, profile); err != nil {
-		return errors.Wrap(err, "failed to updateDealsSupplier")
+		return fmt.Errorf("failed to updateDealsSupplier: %v", err)
 	}
 
 	err = m.storage.UpdateDealsConsumer(conn, profile)
 	if err != nil {
-		return errors.Wrap(err, "failed to updateDealsConsumer")
+		return fmt.Errorf("failed to updateDealsConsumer: %v", err)
 	}
 
 	return nil
@@ -1209,7 +1210,7 @@ func (m *DWH) updateProfileStats(conn queryConn, orderType pb.OrderType, userID 
 	}
 
 	if err := m.storage.UpdateProfileStats(conn, userID, field, update); err != nil {
-		return errors.Wrap(err, "failed to UpdateProfileStats")
+		return fmt.Errorf("failed to UpdateProfileStats: %v", err)
 	}
 
 	return nil
@@ -1222,7 +1223,7 @@ func (m *DWH) coldStart() error {
 
 	targetBlock, err := m.blockchain.Events().GetLastBlock(m.ctx)
 	if err != nil {
-		return errors.WithMessage(err, "failed to GetLastBlock")
+		return fmt.Errorf("failed to GetLastBlock: %v", err)
 	}
 	var retries = 5
 	for {
@@ -1277,7 +1278,7 @@ func (m *DWH) updateLastKnownBlock(blockNumber int64) error {
 	defer conn.Finish()
 
 	if err := m.storage.UpdateLastKnownBlock(conn, blockNumber); err != nil {
-		return errors.Wrap(err, "failed to updateLastKnownBlock")
+		return fmt.Errorf("failed to updateLastKnownBlock: %v", err)
 	}
 
 	return nil
@@ -1288,7 +1289,7 @@ func (m *DWH) insertLastKnownBlock(blockNumber int64) error {
 	defer conn.Finish()
 
 	if err := m.storage.InsertLastKnownBlock(conn, blockNumber); err != nil {
-		return errors.Wrap(err, "failed to updateLastKnownBlock")
+		return fmt.Errorf("failed to updateLastKnownBlock: %v", err)
 	}
 
 	return nil
@@ -1297,12 +1298,12 @@ func (m *DWH) insertLastKnownBlock(blockNumber int64) error {
 func (m *DWH) updateDealConditionEndTime(conn queryConn, dealID *pb.BigInt, eventTS uint64) error {
 	dealConditions, _, err := m.storage.GetDealConditions(conn, &pb.DealConditionsRequest{DealID: dealID})
 	if err != nil {
-		return errors.Wrap(err, "failed to getDealConditions")
+		return fmt.Errorf("failed to getDealConditions: %v", err)
 	}
 
 	dealCondition := dealConditions[0]
 	if err := m.storage.UpdateDealConditionEndTime(conn, dealCondition.Id, eventTS); err != nil {
-		return errors.Wrap(err, "failed to update DealCondition")
+		return fmt.Errorf("failed to update DealCondition: %v", err)
 	}
 
 	return nil
@@ -1311,7 +1312,7 @@ func (m *DWH) updateDealConditionEndTime(conn queryConn, dealID *pb.BigInt, even
 func (m *DWH) removeStaleEntityID(id *big.Int, entity string) error {
 	m.logger.Debug("removing stale entity from cache", zap.String("entity", entity), zap.String("id", id.String()))
 	if err := m.storage.RemoveStaleID(newSimpleConn(m.db), id, entity); err != nil {
-		return errors.Wrapf(err, "failed to RemoveStaleID (%s %s)", entity, id.String())
+		return fmt.Errorf("failed to RemoveStaleID (%s %s): %v", entity, id.String(), err)
 	}
 
 	return nil

--- a/insonmnia/dwh/storage.go
+++ b/insonmnia/dwh/storage.go
@@ -2,10 +2,10 @@ package dwh
 
 import (
 	"database/sql"
+	"fmt"
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/pkg/errors"
 	pb "github.com/sonm-io/core/proto"
 	"go.uber.org/zap"
 )
@@ -111,7 +111,7 @@ func (t *txConn) Exec(query string, args ...interface{}) (sql.Result, error) {
 	result, err := t.tx.Exec(query, args...)
 	if err != nil {
 		t.hasErrors = true
-		return nil, errors.Wrapf(err, "failed to exec %s", query)
+		return nil, fmt.Errorf("failed to exec %s: %v", query, err)
 	}
 	return result, nil
 }
@@ -120,7 +120,7 @@ func (t *txConn) Query(query string, args ...interface{}) (*sql.Rows, error) {
 	rows, err := t.tx.Query(query, args...)
 	if err != nil {
 		t.hasErrors = true
-		return nil, errors.Wrapf(err, "failed to run %s", query)
+		return nil, fmt.Errorf("failed to run %s: %v", query, err)
 	}
 	return rows, nil
 }

--- a/insonmnia/matcher/matcher.go
+++ b/insonmnia/matcher/matcher.go
@@ -3,11 +3,12 @@ package matcher
 import (
 	"context"
 	"crypto/ecdsa"
+	"errors"
+	"fmt"
 	"math/big"
 	"time"
 
 	"github.com/noxiouz/zapctx/ctxlog"
-	"github.com/pkg/errors"
 	"github.com/sonm-io/core/blockchain"
 	"github.com/sonm-io/core/insonmnia/dwh"
 	"github.com/sonm-io/core/proto"
@@ -65,7 +66,7 @@ type matcher struct {
 
 func NewMatcher(cfg *Config) (Matcher, error) {
 	if err := cfg.validate(); err != nil {
-		return nil, errors.Wrap(err, "invalid matcher config")
+		return nil, fmt.Errorf("invalid matcher config: %v", err)
 	}
 
 	return &matcher{cfg: cfg}, nil

--- a/insonmnia/node/blacklist.go
+++ b/insonmnia/node/blacklist.go
@@ -2,8 +2,9 @@ package node
 
 import (
 	"context"
+	"errors"
+	"fmt"
 
-	"github.com/pkg/errors"
 	"github.com/sonm-io/core/proto"
 )
 
@@ -26,7 +27,7 @@ func (b *blacklistAPI) List(ctx context.Context, addr *sonm.EthAddress) (*sonm.B
 
 func (b *blacklistAPI) Remove(ctx context.Context, addr *sonm.EthAddress) (*sonm.Empty, error) {
 	if err := b.remotes.eth.Blacklist().Remove(ctx, b.remotes.key, addr.Unwrap()); err != nil {
-		return nil, errors.WithMessage(err, "cannot remove address from blacklist")
+		return nil, fmt.Errorf("cannot remove address from blacklist: %v", err)
 	}
 
 	return &sonm.Empty{}, nil

--- a/insonmnia/node/deals.go
+++ b/insonmnia/node/deals.go
@@ -1,12 +1,12 @@
 package node
 
 import (
+	"errors"
 	"fmt"
 	"time"
 
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/noxiouz/zapctx/ctxlog"
-	"github.com/pkg/errors"
 	pb "github.com/sonm-io/core/proto"
 	"golang.org/x/net/context"
 )
@@ -134,7 +134,7 @@ func (d *dealsAPI) CreateChangeRequest(ctx context.Context, req *pb.DealChangeRe
 
 	id, err := d.remotes.eth.Market().CreateChangeRequest(ctx, d.remotes.key, req)
 	if err != nil {
-		return nil, errors.WithMessage(err, "cannot create change request")
+		return nil, fmt.Errorf("cannot create change request: %v", err)
 	}
 
 	return pb.NewBigInt(id), nil
@@ -143,7 +143,7 @@ func (d *dealsAPI) CreateChangeRequest(ctx context.Context, req *pb.DealChangeRe
 func (d *dealsAPI) ApproveChangeRequest(ctx context.Context, id *pb.BigInt) (*pb.Empty, error) {
 	req, err := d.remotes.eth.Market().GetDealChangeRequestInfo(ctx, id.Unwrap())
 	if err != nil {
-		return nil, errors.WithMessage(err, "cannot get change request by id")
+		return nil, fmt.Errorf("cannot get change request by id: %v", err)
 	}
 
 	matchingRequest := &pb.DealChangeRequest{
@@ -155,7 +155,7 @@ func (d *dealsAPI) ApproveChangeRequest(ctx context.Context, id *pb.BigInt) (*pb
 
 	_, err = d.remotes.eth.Market().CreateChangeRequest(ctx, d.remotes.key, matchingRequest)
 	if err != nil {
-		return nil, errors.WithMessage(err, "cannot approve change request")
+		return nil, fmt.Errorf("cannot approve change request: %v", err)
 	}
 
 	return &pb.Empty{}, nil

--- a/insonmnia/node/market.go
+++ b/insonmnia/node/market.go
@@ -1,11 +1,11 @@
 package node
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/noxiouz/zapctx/ctxlog"
-	"github.com/pkg/errors"
 	"github.com/sonm-io/core/insonmnia/dwh"
 	pb "github.com/sonm-io/core/proto"
 	"github.com/sonm-io/core/util"
@@ -142,7 +142,7 @@ func (m *marketAPI) Purge(ctx context.Context, _ *pb.Empty) (*pb.Empty, error) {
 	})
 
 	if err != nil {
-		return nil, errors.WithMessage(err, "cannot get orders from dwh")
+		return nil, fmt.Errorf("cannot get orders from dwh: %v", err)
 	}
 
 	merr := multierror.NewMultiError()

--- a/insonmnia/node/tasks.go
+++ b/insonmnia/node/tasks.go
@@ -5,8 +5,8 @@ import (
 	"io"
 	"strconv"
 
+	"errors"
 	log "github.com/noxiouz/zapctx/ctxlog"
-	"github.com/pkg/errors"
 	pb "github.com/sonm-io/core/proto"
 	"go.uber.org/zap"
 	"golang.org/x/net/context"

--- a/insonmnia/node/tokens.go
+++ b/insonmnia/node/tokens.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/ethereum/go-ethereum/crypto"
-	"github.com/pkg/errors"
 	"github.com/sonm-io/core/blockchain"
 	"github.com/sonm-io/core/proto"
 	"golang.org/x/net/context"
@@ -27,12 +26,12 @@ func (t *tokenAPI) Balance(ctx context.Context, _ *sonm.Empty) (*sonm.BalanceRep
 
 	live, err := t.remotes.eth.MasterchainToken().BalanceOf(ctx, addr)
 	if err != nil {
-		return nil, errors.Wrap(err, "cannot get live token balance")
+		return nil, fmt.Errorf("cannot get live token balance: %v", err)
 	}
 
 	side, err := t.remotes.eth.SidechainToken().BalanceOf(ctx, addr)
 	if err != nil {
-		return nil, errors.Wrap(err, "cannot get side token balance")
+		return nil, fmt.Errorf("cannot get side token balance: %v", err)
 	}
 
 	return &sonm.BalanceReply{

--- a/insonmnia/structs/network_spec.go
+++ b/insonmnia/structs/network_spec.go
@@ -1,10 +1,10 @@
 package structs
 
 import (
+	"errors"
 	"strings"
 
 	"github.com/pborman/uuid"
-	"github.com/pkg/errors"
 	"github.com/sonm-io/core/proto"
 )
 

--- a/insonmnia/worker/container.go
+++ b/insonmnia/worker/container.go
@@ -2,13 +2,9 @@ package worker
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
-
-	"github.com/pkg/errors"
-	"github.com/sonm-io/core/insonmnia/worker/plugin"
-	"github.com/sonm-io/core/util/multierror"
-	"go.uber.org/zap"
 
 	"github.com/docker/distribution/reference"
 	"github.com/docker/docker/api/types"
@@ -17,6 +13,9 @@ import (
 	"github.com/docker/docker/client"
 	"github.com/gliderlabs/ssh"
 	log "github.com/noxiouz/zapctx/ctxlog"
+	"github.com/sonm-io/core/insonmnia/worker/plugin"
+	"github.com/sonm-io/core/util/multierror"
+	"go.uber.org/zap"
 )
 
 type containerDescriptor struct {

--- a/insonmnia/worker/network/l2tp_config.go
+++ b/insonmnia/worker/network/l2tp_config.go
@@ -1,6 +1,8 @@
 package network
 
 import (
+	"errors"
+	"fmt"
 	"net"
 
 	"crypto/md5"
@@ -9,7 +11,6 @@ import (
 	"github.com/docker/go-plugins-helpers/ipam"
 	"github.com/docker/go-plugins-helpers/network"
 	"github.com/jinzhu/configor"
-	"github.com/pkg/errors"
 )
 
 type L2TPConfig struct {
@@ -50,11 +51,11 @@ func (o *l2tpNetworkConfig) PoolID() string {
 
 func (o *l2tpNetworkConfig) validate() error {
 	if ip := net.ParseIP(o.LNSAddr); ip == nil {
-		return errors.Errorf("failed to parse lns_addr `%s` to IP", o.LNSAddr)
+		return fmt.Errorf("failed to parse lns_addr `%s` to IP", o.LNSAddr)
 	}
 
 	if _, _, err := net.ParseCIDR(o.Subnet); err != nil {
-		return errors.Wrapf(err, "failed to parse Subnet `%s` to CIDR", o.Subnet)
+		return fmt.Errorf("failed to parse Subnet `%s` to CIDR: %v", o.Subnet, err)
 	}
 
 	return nil

--- a/insonmnia/worker/network/l2tp_network.go
+++ b/insonmnia/worker/network/l2tp_network.go
@@ -2,10 +2,10 @@ package network
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/docker/go-plugins-helpers/network"
 	log "github.com/noxiouz/zapctx/ctxlog"
-	"github.com/pkg/errors"
 	"go.uber.org/zap"
 )
 
@@ -38,14 +38,14 @@ func (d *L2TPNetworkDriver) CreateNetwork(request *network.CreateNetworkRequest)
 	opts, err := parseOptsNetwork(request)
 	if err != nil {
 		d.logger.Errorw("failed to parse options", zap.Error(err))
-		return errors.Wrap(err, "failed to parse options")
+		return fmt.Errorf("failed to parse options: %v", err)
 	}
 
 	n, err := d.GetNetwork(opts.PoolID())
 	if err != nil {
 		d.logger.Errorw("failed to get network", zap.String("pool_id", request.IPv4Data[0].Pool),
 			zap.Error(err))
-		return errors.Wrap(err, "failed to get network")
+		return fmt.Errorf("failed to get network: %v", err)
 	}
 
 	n.ID = request.NetworkID
@@ -66,18 +66,18 @@ func (d *L2TPNetworkDriver) CreateEndpoint(request *network.CreateEndpointReques
 	n, err := d.GetNetwork(request.NetworkID)
 	if err != nil {
 		d.logger.Errorw("failed to get network", zap.Error(err))
-		return nil, errors.Wrap(err, "failed to get network")
+		return nil, fmt.Errorf("failed to get network: %v", err)
 	}
 
 	if n.Endpoint == nil {
 		d.logger.Errorw("network's endpoint is nil", zap.String("network_id", n.ID))
-		return nil, errors.Errorf("network %s endpoint is nil", n.ID)
+		return nil, fmt.Errorf("network %s endpoint is nil", n.ID)
 	}
 
 	if len(n.Endpoint.ID) > 0 {
 		d.logger.Errorw("asked to create second endpoint for network, aborting",
 			zap.String("network_id", n.ID))
-		return nil, errors.Errorf("asked to create second endpoint for network %s, aborting", n.ID)
+		return nil, fmt.Errorf("asked to create second endpoint for network %s, aborting", n.ID)
 	}
 
 	n.Endpoint.ID = request.EndpointID
@@ -95,7 +95,7 @@ func (d *L2TPNetworkDriver) Join(request *network.JoinRequest) (*network.JoinRes
 	if err != nil {
 		d.logger.Errorw("failed to get network", zap.String("pool_id", request.NetworkID),
 			zap.Error(err))
-		return nil, errors.Wrap(err, "failed to get network")
+		return nil, fmt.Errorf("failed to get network: %v", err)
 	}
 
 	d.logger.Infow("joined endpoint", zap.String("pool_id", n.PoolID),
@@ -125,7 +125,7 @@ func (d *L2TPNetworkDriver) EndpointInfo(request *network.InfoRequest) (*network
 	if err != nil {
 		d.logger.Errorw("failed to get network", zap.String("pool_id", request.NetworkID),
 			zap.Error(err))
-		return nil, errors.Wrap(err, "failed to get network")
+		return nil, fmt.Errorf("failed to get network: %v", err)
 	}
 
 	return &network.InfoResponse{

--- a/insonmnia/worker/network/l2tp_state.go
+++ b/insonmnia/worker/network/l2tp_state.go
@@ -5,14 +5,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-
 	"sync"
 
 	"github.com/docker/libkv"
 	"github.com/docker/libkv/store"
 	"github.com/docker/libkv/store/boltdb"
 	log "github.com/noxiouz/zapctx/ctxlog"
-	"github.com/pkg/errors"
 	"go.uber.org/zap"
 )
 
@@ -72,7 +70,7 @@ func (s *l2tpState) sync() (err error) {
 
 func (s *l2tpState) AddNetwork(netID string, netInfo *l2tpNetwork) error {
 	if _, ok := s.Aliases[netID]; ok {
-		return errors.Errorf("network already exists: %s", netID)
+		return fmt.Errorf("network already exists: %s", netID)
 	}
 
 	s.Aliases[netID] = netID
@@ -83,7 +81,7 @@ func (s *l2tpState) AddNetwork(netID string, netInfo *l2tpNetwork) error {
 
 func (s *l2tpState) AddNetworkAlias(netID, alias string) error {
 	if _, ok := s.Aliases[netID]; !ok {
-		return errors.Errorf("network not found: %s", netID)
+		return fmt.Errorf("network not found: %s", netID)
 	}
 
 	s.Aliases[alias] = netID
@@ -94,7 +92,7 @@ func (s *l2tpState) AddNetworkAlias(netID, alias string) error {
 func (s *l2tpState) RemoveNetwork(netID string) error {
 	translatedID, ok := s.Aliases[netID]
 	if !ok {
-		return errors.Errorf("network not found: %s", netID)
+		return fmt.Errorf("network not found: %s", netID)
 	}
 
 	delete(s.Networks, translatedID)
@@ -111,14 +109,14 @@ func (s *l2tpState) RemoveNetwork(netID string) error {
 func (s *l2tpState) GetNetwork(netID string) (*l2tpNetwork, error) {
 	translatedID, ok := s.Aliases[netID]
 	if !ok {
-		return nil, errors.Errorf("network not found: %s", netID)
+		return nil, fmt.Errorf("network not found: %s", netID)
 	}
 
 	if netInfo, ok := s.Networks[translatedID]; ok {
 		return netInfo, nil
 	}
 
-	return nil, errors.Errorf("network not found: %s", netID)
+	return nil, fmt.Errorf("network not found: %s", netID)
 }
 
 type l2tpNetwork struct {

--- a/insonmnia/worker/network/tinc_driver.go
+++ b/insonmnia/worker/network/tinc_driver.go
@@ -2,6 +2,7 @@ package network
 
 import (
 	"context"
+	"fmt"
 	"net"
 	"strings"
 
@@ -9,7 +10,6 @@ import (
 	"github.com/docker/go-plugins-helpers/network"
 	log "github.com/noxiouz/zapctx/ctxlog"
 	"github.com/pborman/uuid"
-	"github.com/pkg/errors"
 	"github.com/sonm-io/core/insonmnia/structs"
 	"github.com/sonm-io/core/proto"
 	"go.uber.org/zap"
@@ -143,7 +143,7 @@ func (t *TincNetworkDriver) DeleteEndpoint(request *network.DeleteEndpointReques
 
 	n, ok := t.Networks[request.NetworkID]
 	if !ok {
-		return errors.Errorf("no such network %s", request.NetworkID)
+		return fmt.Errorf("no such network %s", request.NetworkID)
 	}
 	return n.Stop(t.ctx)
 }
@@ -202,7 +202,7 @@ func (t *TincNetworkDriver) GenerateInvitation(NodeID string) (structs.Network, 
 	defer t.mu.Unlock()
 	n, ok := t.Networks[NodeID]
 	if !ok {
-		return nil, errors.Errorf("no such network %s", NodeID)
+		return nil, fmt.Errorf("no such network %s", NodeID)
 	}
 
 	//TODO: Check this

--- a/insonmnia/worker/network/tinc_network.go
+++ b/insonmnia/worker/network/tinc_network.go
@@ -3,12 +3,13 @@ package network
 import (
 	"bytes"
 	"context"
+	"errors"
+	"fmt"
 	"net"
 	"strings"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/pkg/stdcopy"
-	"github.com/pkg/errors"
 )
 
 // A comparable type for v4 address
@@ -161,7 +162,7 @@ func (t *TincNetwork) runCommandWithOutput(ctx context.Context, name string, arg
 	}
 
 	if inspect.ExitCode != 0 {
-		return stdout, stderr, errors.Errorf("failed to execute command %s %s, exit code %d, stdout - %s, stderr - %s", name, arg, inspect.ExitCode, stdout, stderr)
+		return stdout, stderr, fmt.Errorf("failed to execute command %s %s, exit code %d, stdout - %s, stderr - %s", name, arg, inspect.ExitCode, stdout, stderr)
 	} else {
 		t.logger.Debugf("finished command - %s %s, stdout - %s, stderr - %s", name, arg, stdout, stderr)
 		return stdout, stderr, err

--- a/insonmnia/worker/network/tinc_state.go
+++ b/insonmnia/worker/network/tinc_state.go
@@ -3,6 +3,8 @@ package network
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"net"
 	"sync"
 
@@ -14,7 +16,6 @@ import (
 	"github.com/docker/libkv/store"
 	"github.com/docker/libkv/store/boltdb"
 	log "github.com/noxiouz/zapctx/ctxlog"
-	"github.com/pkg/errors"
 	"github.com/sonm-io/core/insonmnia/structs"
 	"go.uber.org/zap"
 )
@@ -131,7 +132,7 @@ func (t *TincNetworkState) netByID(id string) (*TincNetwork, error) {
 	defer t.mu.Unlock()
 	n, ok := t.Networks[id]
 	if !ok {
-		return nil, errors.Errorf("could not find network by id %s", id)
+		return nil, fmt.Errorf("could not find network by id %s", id)
 	}
 	return n, nil
 }
@@ -168,7 +169,7 @@ func (t *TincNetworkState) netByDockerID(id string) (*TincNetwork, error) {
 			return n, nil
 		}
 	}
-	return nil, errors.Errorf("network not found by docker id %s", id)
+	return nil, fmt.Errorf("network not found by docker id %s", id)
 }
 
 func makeStore(ctx context.Context, path string) (store.Store, error) {

--- a/insonmnia/worker/options.go
+++ b/insonmnia/worker/options.go
@@ -2,11 +2,12 @@ package worker
 
 import (
 	"crypto/ecdsa"
+	"errors"
+	"fmt"
 	"os"
 
 	"github.com/ethereum/go-ethereum/accounts/keystore"
 	"github.com/ethereum/go-ethereum/crypto"
-	"github.com/pkg/errors"
 	"github.com/sonm-io/core/blockchain"
 	"github.com/sonm-io/core/insonmnia/benchmarks"
 	"github.com/sonm-io/core/insonmnia/matcher"
@@ -230,7 +231,7 @@ func (m *options) setupMatcher() error {
 				QueryLimit: m.cfg.Matcher.QueryLimit,
 			})
 			if err != nil {
-				return errors.Wrap(err, "cannot create matcher")
+				return fmt.Errorf("cannot create matcher: %v", err)
 			}
 			m.matcher = matcher
 		} else {

--- a/insonmnia/worker/salesman/salesman.go
+++ b/insonmnia/worker/salesman/salesman.go
@@ -3,6 +3,7 @@ package salesman
 import (
 	"context"
 	"crypto/ecdsa"
+	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -10,7 +11,6 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/mohae/deepcopy"
 	"github.com/pborman/uuid"
-	"github.com/pkg/errors"
 	"github.com/sonm-io/core/blockchain"
 	"github.com/sonm-io/core/insonmnia/cgroups"
 	"github.com/sonm-io/core/insonmnia/hardware"

--- a/insonmnia/worker/server.go
+++ b/insonmnia/worker/server.go
@@ -3,6 +3,7 @@ package worker
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"strconv"
@@ -20,7 +21,6 @@ import (
 	log "github.com/noxiouz/zapctx/ctxlog"
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/pborman/uuid"
-	"github.com/pkg/errors"
 	"github.com/sonm-io/core/insonmnia/auth"
 	"github.com/sonm-io/core/insonmnia/cgroups"
 	"github.com/sonm-io/core/insonmnia/hardware/disk"

--- a/insonmnia/worker/whitelist.go
+++ b/insonmnia/worker/whitelist.go
@@ -3,6 +3,7 @@ package worker
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -13,7 +14,6 @@ import (
 	dc "github.com/docker/docker/client"
 	"github.com/ethereum/go-ethereum/common"
 	log "github.com/noxiouz/zapctx/ctxlog"
-	"github.com/pkg/errors"
 	"github.com/sonm-io/core/insonmnia/auth"
 	"github.com/sonm-io/core/util"
 	"go.uber.org/zap"
@@ -89,7 +89,7 @@ func (w *whitelist) fillFromJsonReader(ctx context.Context, jsonReader io.Reader
 	r := make(map[string]WhitelistRecord)
 	err := decoder.Decode(&r)
 	if err != nil {
-		return errors.Wrap(err, "could not decode whitelist data")
+		return fmt.Errorf("could not decode whitelist data: %v", err)
 	}
 
 	w.RecordsMu.Lock()
@@ -158,7 +158,7 @@ func (w *whitelist) Allowed(ctx context.Context, referenceStr string, authority 
 
 	inspection, err := dockerClient.DistributionInspect(ctx, referenceStr, authority)
 	if err != nil {
-		return false, nil, errors.Wrap(err, "could not perform DistributionInspect")
+		return false, nil, fmt.Errorf("could not perform DistributionInspect: %v", err)
 	}
 
 	ref, err = reference.WithDigest(ref.(reference.Named), inspection.Descriptor.Digest)

--- a/optimus/normalize.go
+++ b/optimus/normalize.go
@@ -1,8 +1,9 @@
 package optimus
 
 import (
+	"errors"
+
 	"github.com/montanaflynn/stats"
-	"github.com/pkg/errors"
 )
 
 var (

--- a/proto/rendezvous.go
+++ b/proto/rendezvous.go
@@ -1,7 +1,7 @@
 package sonm
 
 import (
-	"github.com/pkg/errors"
+	"errors"
 )
 
 func (m *ConnectRequest) Validate() error {


### PR DESCRIPTION
This PR removes usage of `errors.Wrap` and `errors.WithMessage`, format all errors using `fmt.Errorf` and replaces imports with "errors" package. 
Some mistypes in error messages are accidentally fixed, also lowercased err message text to be consistent with the Golang standards. 