### PR TITLE
refactor: do not apply whitelist to identified consumers

### DIFF
--- a/blockchain/api.go
+++ b/blockchain/api.go
@@ -39,6 +39,7 @@ type ProfileRegistryAPI interface {
 	GetCertificate(ctx context.Context, certificateID *big.Int) (*pb.Certificate, error)
 	GetAttributeCount(ctx context.Context, owner common.Address, attributeType *big.Int) (*big.Int, error)
 	GetAttributeValue(ctx context.Context, owner common.Address, attributeType *big.Int) ([]byte, error)
+	GetProfileLevel(ctx context.Context, owner common.Address) (pb.IdentityLevel, error)
 }
 
 type EventsAPI interface {
@@ -651,6 +652,14 @@ func (api *ProfileRegistry) GetAttributeCount(ctx context.Context, owner common.
 
 func (api *ProfileRegistry) GetAttributeValue(ctx context.Context, owner common.Address, attributeType *big.Int) ([]byte, error) {
 	return api.profileRegistryContract.GetAttributeValue(getCallOptions(ctx), owner, attributeType)
+}
+
+func (api *ProfileRegistry) GetProfileLevel(ctx context.Context, owner common.Address) (pb.IdentityLevel, error) {
+	lev, err := api.profileRegistryContract.GetProfileLevel(getCallOptions(ctx), owner)
+	if err != nil {
+		return pb.IdentityLevel_UNKNOWN, fmt.Errorf("failed to get profile level: %s", err)
+	}
+	return pb.IdentityLevel(lev), err
 }
 
 func (api *ProfileRegistry) GetValidator(ctx context.Context, validatorID common.Address) (*pb.Validator, error) {

--- a/insonmnia/worker/server.go
+++ b/insonmnia/worker/server.go
@@ -538,7 +538,7 @@ func (m *Worker) taskAllowed(ctx context.Context, request *pb.StartTaskRequest) 
 	if err != nil {
 		return false, nil, err
 	}
-	if level <= pb.IdentityLevel_ANONYMOUS {
+	if level <= pb.IdentityLevel_REGISTERED {
 		return m.whitelist.Allowed(ctx, reference, spec.GetRegistry().Auth())
 	}
 

--- a/insonmnia/worker/server.go
+++ b/insonmnia/worker/server.go
@@ -523,13 +523,32 @@ func (m *Worker) PullTask(request *pb.PullTaskRequest, stream pb.Worker_PullTask
 	return nil
 }
 
+func (m *Worker) taskAllowed(ctx context.Context, request *pb.StartTaskRequest) (bool, reference.Reference, error) {
+	spec := request.GetSpec()
+	reference, err := reference.Parse(spec.GetContainer().GetImage())
+	if err != nil {
+		return false, nil, fmt.Errorf("failed to parse reference: %s", err)
+	}
+
+	deal, err := m.salesman.Deal(request.GetDealID())
+	if err != nil {
+		return false, nil, err
+	}
+	level, err := m.eth.ProfileRegistry().GetProfileLevel(ctx, deal.GetConsumerID().Unwrap())
+	if err != nil {
+		return false, nil, err
+	}
+	if level <= pb.IdentityLevel_ANONYMOUS {
+		return m.whitelist.Allowed(ctx, reference, spec.GetRegistry().Auth())
+	}
+
+	return true, reference, nil
+}
+
 func (m *Worker) StartTask(ctx context.Context, request *pb.StartTaskRequest) (*pb.StartTaskReply, error) {
 	log.G(m.ctx).Info("handling StartTask request", zap.Any("request", request))
 
-	spec := request.GetSpec()
-	registry := spec.GetRegistry()
-	image := spec.GetContainer().GetImage()
-	allowed, reference, err := m.whitelist.Allowed(ctx, image, registry.Auth())
+	allowed, reference, err := m.taskAllowed(ctx, request)
 	if err != nil {
 		return nil, err
 	}
@@ -551,7 +570,8 @@ func (m *Worker) StartTask(ctx context.Context, request *pb.StartTaskRequest) (*
 		return nil, err
 	}
 
-	publicKey, err := parsePublicKey(spec.Container.SshKey)
+	spec := request.GetSpec()
+	publicKey, err := parsePublicKey(spec.GetContainer().GetSshKey())
 	if err != nil {
 		return nil, status.Errorf(codes.Unauthenticated, "invalid public key provided %v", err)
 	}

--- a/insonmnia/worker/whitelist.go
+++ b/insonmnia/worker/whitelist.go
@@ -20,7 +20,7 @@ import (
 )
 
 type Whitelist interface {
-	Allowed(ctx context.Context, reference string, auth string) (bool, reference.Reference, error)
+	Allowed(ctx context.Context, ref reference.Reference, auth string) (bool, reference.Reference, error)
 }
 
 func NewWhitelist(ctx context.Context, config *WhitelistConfig) Whitelist {
@@ -121,12 +121,7 @@ func (w *whitelist) digestAllowed(name string, digest string) (bool, error) {
 	return false, nil
 }
 
-func (w *whitelist) Allowed(ctx context.Context, referenceStr string, authority string) (bool, reference.Reference, error) {
-	ref, err := reference.Parse(referenceStr)
-	if err != nil {
-		return false, nil, err
-	}
-
+func (w *whitelist) Allowed(ctx context.Context, ref reference.Reference, authority string) (bool, reference.Reference, error) {
 	wallet, err := auth.ExtractWalletFromContext(ctx)
 	if err != nil {
 		log.G(ctx).Warn("could not extract wallet from context", zap.Error(err))
@@ -156,7 +151,7 @@ func (w *whitelist) Allowed(ctx context.Context, referenceStr string, authority 
 	}
 	defer dockerClient.Close()
 
-	inspection, err := dockerClient.DistributionInspect(ctx, referenceStr, authority)
+	inspection, err := dockerClient.DistributionInspect(ctx, ref.String(), authority)
 	if err != nil {
 		return false, nil, errors.Wrap(err, "could not perform DistributionInspect")
 	}
@@ -175,11 +170,6 @@ func (w *whitelist) Allowed(ctx context.Context, referenceStr string, authority 
 type disabledWhitelist struct {
 }
 
-func (w *disabledWhitelist) Allowed(ctx context.Context, referenceStr string, auth string) (bool, reference.Reference, error) {
-	ref, err := reference.Parse(referenceStr)
-	if err != nil {
-		return false, nil, err
-	}
-
+func (w *disabledWhitelist) Allowed(ctx context.Context, ref reference.Reference, auth string) (bool, reference.Reference, error) {
 	return true, ref, nil
 }

--- a/insonmnia/worker/whitelist_test.go
+++ b/insonmnia/worker/whitelist_test.go
@@ -5,9 +5,11 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/docker/distribution/reference"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/sonm-io/core/insonmnia/auth"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/peer"
@@ -28,12 +30,15 @@ func TestWhitelistSuperuser(t *testing.T) {
 	}
 
 	ctx := walletCtx(addr)
-	allowed, _, err := w.Allowed(ctx, "docker.io/hello-world", "")
+	ref, err := reference.ParseAnyReference("docker.io/hello-world")
+	require.NoError(t, err)
+
+	allowed, _, err := w.Allowed(ctx, ref, "")
 	assert.NoError(t, err)
 	assert.True(t, allowed)
 
 	w.superusers = map[string]struct{}{}
-	allowed, _, err = w.Allowed(ctx, "docker.io/hello-world", "")
+	allowed, _, err = w.Allowed(ctx, ref, "")
 	assert.False(t, allowed)
 }
 
@@ -51,7 +56,11 @@ func TestWhitelistAllowed(t *testing.T) {
 	reader := strings.NewReader(data)
 	w := whitelist{}
 	w.fillFromJsonReader(ctx, reader)
-	allowed, _, err := w.Allowed(ctx, "sonm/eth-claymore@sha256:b5f9a9e47fa319607ed339789ef6692d4937ae5910b86e0ab929d035849e491e", "")
+
+	ref, err := reference.ParseAnyReference("sonm/eth-claymore@sha256:b5f9a9e47fa319607ed339789ef6692d4937ae5910b86e0ab929d035849e491e")
+	require.NoError(t, err)
+
+	allowed, _, err := w.Allowed(ctx, ref, "")
 	assert.True(t, allowed)
 	assert.NoError(t, err)
 }


### PR DESCRIPTION
This PR takes consumer identity level in concern. If customer has at least IDENTIFIED level whitelist checking doesn't take place