### PR TITLE
feat: utilize hostname for Relay

### DIFF
--- a/insonmnia/node/server.go
+++ b/insonmnia/node/server.go
@@ -17,6 +17,7 @@ import (
 	"github.com/sonm-io/core/insonmnia/benchmarks"
 	"github.com/sonm-io/core/insonmnia/matcher"
 	"github.com/sonm-io/core/insonmnia/npp"
+	"github.com/sonm-io/core/insonmnia/npp/relay"
 	pb "github.com/sonm-io/core/proto"
 	"github.com/sonm-io/core/util"
 	"github.com/sonm-io/core/util/rest"
@@ -75,7 +76,7 @@ func (re *remoteOptions) getWorkerClientByEthAddr(ctx context.Context, eth strin
 func newRemoteOptions(ctx context.Context, key *ecdsa.PrivateKey, cfg *Config, credentials credentials.TransportCredentials) (*remoteOptions, error) {
 	nppDialerOptions := []npp.Option{
 		npp.WithRendezvous(cfg.NPP.Rendezvous, credentials),
-		npp.WithRelayClient(cfg.NPP.Relay.Endpoints, log.G(ctx)),
+		npp.WithRelayDialer(&relay.Dialer{Addrs: cfg.NPP.Relay.Endpoints, Log: log.G(ctx)}),
 		npp.WithLogger(log.G(ctx)),
 	}
 	nppDialer, err := npp.NewDialer(ctx, nppDialerOptions...)

--- a/insonmnia/npp/relay/config.go
+++ b/insonmnia/npp/relay/config.go
@@ -83,5 +83,5 @@ func NewServerConfig(path string) (*ServerConfig, error) {
 //
 // Used as a basic building block for high-level configurations.
 type Config struct {
-	Endpoints []netutil.TCPAddr
+	Endpoints []string
 }

--- a/insonmnia/worker/config_test.go
+++ b/insonmnia/worker/config_test.go
@@ -59,7 +59,7 @@ whitelist:
 		"0x8125721C2413d99a33E351e1F6Bb4e56b6b633FD@127.0.0.1:14099")
 
 	assert.Len(t, conf.NPP.Relay.Endpoints, 1)
-	assert.Contains(t, conf.NPP.Relay.Endpoints[0].String(), "2.3.4.5:12345")
+	assert.Contains(t, conf.NPP.Relay.Endpoints[0], "2.3.4.5:12345")
 
 	assert.Equal(t, "/var/lib/sonm/worker.boltdb", conf.Storage.Endpoint)
 	assert.Equal(t, "sonm", conf.Storage.Bucket)

--- a/insonmnia/worker/server.go
+++ b/insonmnia/worker/server.go
@@ -25,6 +25,7 @@ import (
 	"github.com/sonm-io/core/insonmnia/cgroups"
 	"github.com/sonm-io/core/insonmnia/hardware/disk"
 	"github.com/sonm-io/core/insonmnia/npp"
+	"github.com/sonm-io/core/insonmnia/npp/relay"
 	"github.com/sonm-io/core/insonmnia/worker/gpu"
 	"github.com/sonm-io/core/insonmnia/worker/salesman"
 	"github.com/sonm-io/core/util"
@@ -157,11 +158,16 @@ func (m *Worker) Serve() error {
 		return err
 	}
 
+	relayListener, err := relay.NewListener(m.cfg.NPP.Relay.Endpoints, m.key, log.G(m.ctx))
+	if err != nil {
+		return err
+	}
+
 	listener, err := npp.NewListener(m.ctx, m.cfg.Endpoint,
 		npp.WithNPPBacklog(m.cfg.NPP.Backlog),
 		npp.WithNPPBackoff(m.cfg.NPP.MinBackoffInterval, m.cfg.NPP.MaxBackoffInterval),
 		npp.WithRendezvous(m.cfg.NPP.Rendezvous, m.creds),
-		npp.WithRelay(m.cfg.NPP.Relay.Endpoints, m.key, log.G(m.ctx)),
+		npp.WithRelayListener(relayListener),
 		npp.WithLogger(log.G(m.ctx)),
 	)
 	if err != nil {

--- a/util/netutil/net.go
+++ b/util/netutil/net.go
@@ -115,3 +115,27 @@ func isPrivateIPv6(ip net.IP) bool {
 
 	return block.Contains(ip) || ip.IsLoopback() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast()
 }
+
+func LookupTCPHostPort(hostport string) ([]net.Addr, error) {
+	host, port, err := net.SplitHostPort(hostport)
+	if err != nil {
+		return nil, err
+	}
+
+	addrs, err := net.LookupHost(host)
+	if err != nil {
+		return nil, err
+	}
+
+	netAddrs := make([]net.Addr, len(addrs))
+	for id, addr := range addrs {
+		tcpAddr, err := net.ResolveTCPAddr("tcp", fmt.Sprintf("%s:%s", addr, port))
+		if err != nil {
+			return nil, err
+		}
+
+		netAddrs[id] = tcpAddr
+	}
+
+	return netAddrs, nil
+}


### PR DESCRIPTION
This change allows to utilize specifying hostnames as a relay address, increasing stability.

Previously such hostname was resolved once at construction time and the relay client tried to connect to the resolved TCP addresses even if some of them are already down.
Now each time a client requires new connection hostname resolution occurs. All this allows dynamic addition/removal backends under the DNS.

Of course we try to connect to all returned endpoints.