### PR TITLE
fix: optimus should now track incoming network

### DIFF
--- a/optimus/optimus.go
+++ b/optimus/optimus.go
@@ -256,9 +256,19 @@ func (m *workerControl) Execute(ctx context.Context) {
 			continue
 		}
 
-		if freeWorkerBenchmarks.Contains(order.Order.Order.Benchmarks) {
-			matchedOrders = append(matchedOrders, order)
+		if !freeWorkerBenchmarks.Contains(order.Order.Order.Benchmarks) {
+			continue
 		}
+
+		// No more than a single order with incoming network requirement should
+		// be selected.
+		// For this purpose we explicitly disable incoming network if such
+		// order is matched.
+		if order.Order.GetOrder().GetNetflags().GetIncoming() {
+			freeDevices.GetNetwork().GetNetFlags().SetIncoming(false)
+		}
+
+		matchedOrders = append(matchedOrders, order)
 	}
 
 	m.log.Infof("found %d/%d matching orders", len(matchedOrders), len(orders))


### PR DESCRIPTION
Previously the autosell bot could match more than a single order with incoming network required. Because we do not allow such behaviour it led to multiple errors while trying to create sell plans.
This change explicitly disables incoming network after a first matching orders found.