### PR TITLE
feat: specify worker settings in Optimus config

### DIFF
--- a/etc/optimus.yaml
+++ b/etc/optimus.yaml
@@ -17,7 +17,7 @@ workers:
   0xccBe701e568577983E90968161ABB391759D589e@[::1]:15010:
     # Epoch is an interval of scanning worker's free resources and selling them
     # by cutting ask plans.
-    epoch: 5s
+    epoch: 60s
 
 benchmarks:
   # URL to download benchmark list, use `file://` schema to load file from a filesystem.

--- a/etc/optimus.yaml
+++ b/etc/optimus.yaml
@@ -14,10 +14,10 @@ ethereum: &ethereum
 # Map of workers this bot manages defined by its trusted endpoints with their
 # settings.
 workers:
- 0xccBe701e568577983E90968161ABB391759D589e@[::1]:15010:
-   # Epoch is an interval of scanning worker's free resources and selling them
-   # by cutting ask plans.
-   epoch: 5s
+  0xccBe701e568577983E90968161ABB391759D589e@[::1]:15010:
+    # Epoch is an interval of scanning worker's free resources and selling them
+    # by cutting ask plans.
+    epoch: 5s
 
 benchmarks:
   # URL to download benchmark list, use `file://` schema to load file from a filesystem.

--- a/etc/optimus.yaml
+++ b/etc/optimus.yaml
@@ -10,10 +10,14 @@ ethereum: &ethereum
   # Passphrase for the keystore.
   pass_phrase: "any"
 
-# List of workers trusted endpoints this bot manages.
+
+# Map of workers this bot manages defined by its trusted endpoints with their
+# settings.
 workers:
- - 0x8125721C2413d99a33E351e1F6Bb4e56b6b633FD@[::1]:15010
- # TODO: Support multiple timeouts per each worker. How?
+ 0xccBe701e568577983E90968161ABB391759D589e@[::1]:15010:
+   # Epoch is an interval of scanning worker's free resources and selling them
+   # by cutting ask plans.
+   epoch: 5s
 
 benchmarks:
   # URL to download benchmark list, use `file://` schema to load file from a filesystem.

--- a/insonmnia/auth/addr.go
+++ b/insonmnia/auth/addr.go
@@ -80,6 +80,10 @@ func (m Addr) String() string {
 	return m.netAddr
 }
 
+func (m Addr) MarshalText() ([]byte, error) {
+	return []byte(m.String()), nil
+}
+
 func (m *Addr) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	var addr string
 	if err := unmarshal(&addr); err != nil {

--- a/optimus/config.go
+++ b/optimus/config.go
@@ -15,10 +15,14 @@ import (
 type Config struct {
 	PrivateKey   privateKey `yaml:"ethereum" json:"-"`
 	Logging      logging.Config
-	Workers      []auth.Addr
-	Benchmarks   benchmarks.Config `yaml:"benchmarks"`
+	Workers      map[auth.Addr]WorkerConfig `yaml:"workers"`
+	Benchmarks   benchmarks.Config          `yaml:"benchmarks"`
 	Marketplace  marketplaceConfig
 	Optimization optimizationConfig
+}
+
+type WorkerConfig struct {
+	Epoch time.Duration `yaml:"epoch"`
 }
 
 func LoadConfig(path string) (*Config, error) {

--- a/optimus/config.go
+++ b/optimus/config.go
@@ -15,13 +15,13 @@ import (
 type Config struct {
 	PrivateKey   privateKey `yaml:"ethereum" json:"-"`
 	Logging      logging.Config
-	Workers      map[auth.Addr]WorkerConfig `yaml:"workers"`
+	Workers      map[auth.Addr]workerConfig `yaml:"workers"`
 	Benchmarks   benchmarks.Config          `yaml:"benchmarks"`
 	Marketplace  marketplaceConfig
 	Optimization optimizationConfig
 }
 
-type WorkerConfig struct {
+type workerConfig struct {
 	Epoch time.Duration `yaml:"epoch"`
 }
 

--- a/optimus/optimus.go
+++ b/optimus/optimus.go
@@ -90,7 +90,7 @@ func (m *Optimus) Run(ctx context.Context) error {
 		return err
 	}
 
-	for _, addr := range m.cfg.Workers {
+	for addr, cfg := range m.cfg.Workers {
 		ethAddr, err := addr.ETH()
 		if err != nil {
 			return err
@@ -112,7 +112,7 @@ func (m *Optimus) Run(ctx context.Context) error {
 		}
 
 		wg.Go(func() error {
-			return newManagedWatcher(control, 60*time.Second).Run(ctx)
+			return newManagedWatcher(control, cfg.Epoch).Run(ctx)
 		})
 	}
 


### PR DESCRIPTION
Now it is possible to define some worker specific settings in the autosell bot config.
For example now we can specify epoch interval, where the bot scans worker's resources and tries to sell them.

This is a BREAKING change.