### PR TITLE
refactor: prepare optimus cancelling orders

### DIFF
--- a/optimus/learning_test.go
+++ b/optimus/learning_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/sonm-io/core/proto"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
 )
 
 func TestSortDescending(t *testing.T) {
@@ -32,7 +33,7 @@ func TestSortDescending(t *testing.T) {
 }
 
 func TestLearning(t *testing.T) {
-	model := newLLSModel(ModelConfig{
+	model := newLLSModelFactory(llsModelConfig{
 		Alpha:          1e-6,
 		Regularization: 6.0,
 		MaxIterations:  1000,
@@ -118,7 +119,7 @@ func TestLearning(t *testing.T) {
 		})
 	}
 
-	classifier := newRegressionClassifier(model, sigmoid, time.Now)
+	classifier := newRegressionClassifier(model, sigmoid, time.Now, zap.NewNop())
 	weightedOrders, err := classifier.Classify(orders)
 
 	require.NoError(t, err)

--- a/optimus/math.go
+++ b/optimus/math.go
@@ -7,8 +7,8 @@ import (
 type sigmoid func(x float64) float64
 
 type sigmoidConfig struct {
-	Alpha float64 `yaml:"alpha" default:"10.0"`
-	Delta float64 `yaml:"delta" default:"43200.0"`
+	Alpha float64 `yaml:"α" default:"10.0"`
+	Delta float64 `yaml:"∂" default:"43200.0"`
 }
 
 func newSigmoid(cfg sigmoidConfig) sigmoid {

--- a/optimus/optimus.go
+++ b/optimus/optimus.go
@@ -75,7 +75,7 @@ func (m *Optimus) Run(ctx context.Context) error {
 		return err
 	}
 
-	ordersControl, err := newOrdersControl(ordersScanner, m.cfg.Optimization.Classifier(), ordersSet, m.log.Desugar())
+	ordersControl, err := newOrdersControl(ordersScanner, m.cfg.Optimization.ClassifierFactory(m.log.Desugar()), ordersSet, m.log.Desugar())
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Changed:
- Model and classifier factories now has appropriate names.
- Decomposed model and classifier creation logic into their sub-functions instead of doing this directly in unmarshallers.
- Forward logger to models.
- Some comments added.