### PR TITLE
fix: invalid netflag filtering

### DIFF
--- a/optimus/optimus.go
+++ b/optimus/optimus.go
@@ -255,7 +255,7 @@ func (m *workerControl) Execute(ctx context.Context) {
 			}
 		}
 
-		if !devices.GetNetwork().GetNetFlags().ConverseImplication(order.Order.Order.GetNetflags()) {
+		if !freeDevices.GetNetwork().GetNetFlags().ConverseImplication(order.Order.Order.GetNetflags()) {
 			continue
 		}
 


### PR DESCRIPTION
Now Optimus will check for netflags inclusion using free devices instead of just devices.