### PR TITLE
fix: properly forward "expose" section in Worker

### DIFF
--- a/cmd/cli/task_config/config_test.go
+++ b/cmd/cli/task_config/config_test.go
@@ -183,3 +183,19 @@ resources:
 
 	assert.Equal(t, uint64(30e6), cfg.GetResources().GetRAM().GetSize().GetBytes())
 }
+
+func TestTaskConfigExpose(t *testing.T) {
+	createTestConfigFile(`
+container:
+  image: user/image:v1
+  expose:
+    - 80:80
+`)
+	defer deleteTestConfigFile()
+
+	cfg, err := LoadConfig(testCfgPath)
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+
+	assert.Equal(t, []string{"80:80"}, cfg.GetContainer().GetExpose())
+}

--- a/insonmnia/worker/server.go
+++ b/insonmnia/worker/server.go
@@ -651,6 +651,7 @@ func (m *Worker) StartTask(ctx context.Context, request *pb.StartTaskRequest) (*
 		volumes:       spec.Container.Volumes,
 		mounts:        mounts,
 		networks:      networks,
+		expose:        spec.Container.GetExpose(),
 	}
 
 	// TODO: Detect whether it's the first time allocation. If so - release resources on error.


### PR DESCRIPTION
This fixes forgetting "expose" section while forwarding it from start task request to a container.

Also a tiny test added to check whether the task config is parsed properly.