### PR TITLE
fix: properly handle zero GPU benchmark

### DIFF
--- a/optimus/devices.go
+++ b/optimus/devices.go
@@ -333,6 +333,19 @@ func (m *DeviceManager) consumeGPU(minCount uint64, benchmarks []uint64) (*sonm.
 					if m.mapping.DeviceType(id) == sonm.DeviceType_DEV_GPU {
 						if m.mapping.SplittingAlgorithm(id) == sonm.SplittingAlgorithm_PROPORTIONAL {
 							if benchmark, ok := gpu.Benchmarks[uint64(id)]; ok {
+								if benchmark.Result == 0 {
+									if benchmarks[id] == 0 {
+										// Nothing to subtract using this benchmark. Nothing to add to the score.
+										// Still try the rest of benchmarks.
+										continue
+									} else {
+										// The GPU set can't fit the benchmark. Well, possibly can,
+										// but without this GPU.
+										// Anyway the score will be +Inf, so definitely it's not the minimum one.
+										break
+									}
+								}
+
 								if currentBenchmarks[id] > benchmark.Result {
 									currentBenchmarks[id] -= benchmark.Result
 								} else {

--- a/optimus/devices_test.go
+++ b/optimus/devices_test.go
@@ -587,19 +587,37 @@ func TestGPUStrange(t *testing.T) {
 
 	controller := gomock.NewController(t)
 	defer controller.Finish()
+	{
+		manager, err := newDeviceManager(devices, devices, newMappingMock(controller))
+		require.NoError(t, err)
+		require.NotNil(t, manager)
 
-	manager, err := newDeviceManager(devices, devices, newMappingMock(controller))
-	require.NoError(t, err)
-	require.NotNil(t, manager)
+		benchmark := sonm.Benchmarks{
+			Values: []uint64{1000, 800, 1, 1000000, 0, 1000, 1000, 1, 4096000000, 84936696, 0, 0},
+		}
 
-	benchmark := sonm.Benchmarks{
-		Values: []uint64{1000, 800, 1, 1000000, 0, 1000, 1000, 1, 4096000000, 84936696, 0, 0},
+		plans, err := manager.Consume(benchmark)
+		require.NoError(t, err)
+		require.NotNil(t, plans)
+
+		assert.True(t, len(plans.GPU.Hashes) > 0)
+		assert.Equal(t, 4, len(plans.GPU.Hashes))
 	}
 
-	plans, err := manager.Consume(benchmark)
-	require.NoError(t, err)
-	require.NotNil(t, plans)
+	{
+		manager, err := newDeviceManager(devices, devices, newMappingMock(controller))
+		require.NoError(t, err)
+		require.NotNil(t, manager)
 
-	assert.True(t, len(plans.GPU.Hashes) > 0)
-	assert.Equal(t, 4, len(plans.GPU.Hashes))
+		benchmark := sonm.Benchmarks{
+			Values: []uint64{1000, 800, 1, 1000000, 0, 1000, 1000, 1, 4096000000, 218587776, 0, 0},
+		}
+
+		plans, err := manager.Consume(benchmark)
+		require.NoError(t, err)
+		require.NotNil(t, plans)
+
+		assert.True(t, len(plans.GPU.Hashes) > 0)
+		assert.Equal(t, 10, len(plans.GPU.Hashes))
+	}
 }


### PR DESCRIPTION
This fixes a bug where Optimus fails to fit GPU benchmarks with some of them equal zero.