### PR TITLE
fix: increase timeout for deposits command

### DIFF
--- a/cmd/cli/commands/tokens.go
+++ b/cmd/cli/commands/tokens.go
@@ -1,7 +1,9 @@
 package commands
 
 import (
+	"context"
 	"os"
+	"time"
 
 	"github.com/sonm-io/core/proto"
 	"github.com/sonm-io/core/util"
@@ -76,7 +78,7 @@ var tokenDepositCmd = &cobra.Command{
 	Args:   cobra.MinimumNArgs(1),
 	PreRun: loadKeyStoreIfRequired,
 	Run: func(cmd *cobra.Command, args []string) {
-		ctx, cancel := newTimeoutContext()
+		ctx, cancel := context.WithTimeout(context.Background(), 150*time.Second)
 		defer cancel()
 
 		token, err := newTokenManagementClient(ctx)


### PR DESCRIPTION
This commit increases timeout for `sonmcli token deposit`
method. The average time of command execution is about 100s with
a default timeout of 60s. So for a user it looks like that command
is always failing.

This PR absorbs #1111.
