### PR TITLE
fix: proper value in status channel

### DIFF
--- a/insonmnia/worker/overseer.go
+++ b/insonmnia/worker/overseer.go
@@ -566,6 +566,7 @@ func (o *overseer) OnDealFinish(ctx context.Context, containerID string) error {
 	status, sok := o.statuses[containerID]
 	delete(o.statuses, containerID)
 	if sok {
+		status <- pb.TaskStatusReply_FINISHED
 		close(status)
 	}
 	if !ok {


### PR DESCRIPTION
This PR fixes behaviour when deal was finished, but task resources were not released as status event was not delivered via status channel