### PR TITLE
proposal: better error handling for the cli

### DIFF
--- a/cmd/cli/commands/deals.go
+++ b/cmd/cli/commands/deals.go
@@ -1,7 +1,7 @@
 package commands
 
 import (
-	"os"
+	"fmt"
 	"time"
 
 	pb "github.com/sonm-io/core/proto"
@@ -39,93 +39,84 @@ func init() {
 }
 
 var dealRootCmd = &cobra.Command{
-	Use:   "deal",
-	Short: "Manage deals",
+	Use:               "deal",
+	Short:             "Manage deals",
+	PersistentPreRunE: loadKeyStoreIfRequired,
 }
 
 var dealListCmd = &cobra.Command{
-	Use:    "list",
-	Short:  "Show your active deals",
-	PreRun: loadKeyStoreWrapper,
-	Run: func(cmd *cobra.Command, _ []string) {
+	Use:   "list",
+	Short: "Show your active deals",
+	RunE: func(cmd *cobra.Command, _ []string) error {
 		ctx, cancel := newTimeoutContext()
 		defer cancel()
 
 		dealer, err := newDealsClient(ctx)
 		if err != nil {
-			showError(cmd, "Cannot create client connection", err)
-			os.Exit(1)
+			return fmt.Errorf("cannot create client connection: %v", err)
 		}
 
 		req := &pb.Count{Count: dealsSearchCount}
 		deals, err := dealer.List(ctx, req)
 		if err != nil {
-			showError(cmd, "Cannot get deals list", err)
-			os.Exit(1)
+			return fmt.Errorf("cannot get deals list: %v", err)
 		}
 
 		printDealsList(cmd, deals.GetDeal())
+		return nil
 	},
 }
 
 var dealStatusCmd = &cobra.Command{
-	Use:    "status <deal_id>",
-	Short:  "Show deal status",
-	Args:   cobra.MinimumNArgs(1),
-	PreRun: loadKeyStoreIfRequired,
-	Run: func(cmd *cobra.Command, args []string) {
+	Use:   "status <deal_id>",
+	Short: "Show deal status",
+	Args:  cobra.MinimumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx, cancel := newTimeoutContext()
 		defer cancel()
 
 		dealer, err := newDealsClient(ctx)
 		if err != nil {
-			showError(cmd, "Cannot create client connection", err)
-			os.Exit(1)
+			return fmt.Errorf("cannot create client connection: %v", err)
 		}
 
 		id, err := pb.NewBigIntFromString(args[0])
 		if err != nil {
-			showError(cmd, "Cannot convert arg to number", err)
-			os.Exit(1)
+			return err
 		}
 
 		reply, err := dealer.Status(ctx, id)
 		if err != nil {
-			showError(cmd, "Cannot get deal info", err)
-			os.Exit(1)
+			return fmt.Errorf("cannot get deal info: %v", err)
 		}
 
 		changeRequests, _ := dealer.ChangeRequestsList(ctx, id)
 		printDealInfo(cmd, reply, changeRequests, printEverything)
+		return nil
 	},
 }
 
 var dealOpenCmd = &cobra.Command{
-	Use:    "open <ask_id> <bid_id>",
-	Short:  "Open deal with given orders",
-	Args:   cobra.MinimumNArgs(2),
-	PreRun: loadKeyStoreWrapper,
-	Run: func(cmd *cobra.Command, args []string) {
+	Use:   "open <ask_id> <bid_id>",
+	Short: "Open deal with given orders",
+	Args:  cobra.MinimumNArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx, cancel := newTimeoutContext()
 		defer cancel()
 
 		askID, err := util.ParseBigInt(args[0])
 		if err != nil {
-			// do not wraps error with human-readable text, the error text is self-explainable.
-			showError(cmd, err.Error(), nil)
-			os.Exit(1)
+			return err
 		}
 
 		bidID, err := util.ParseBigInt(args[1])
 		if err != nil {
-			showError(cmd, err.Error(), nil)
-			os.Exit(1)
+			return err
 		}
 
 		deals, err := newDealsClient(ctx)
 		if err != nil {
-			showError(cmd, "Cannot create blockchain connection", err)
-			os.Exit(1)
+			return fmt.Errorf("cannot create client connection: %v", err)
 		}
 
 		deal, err := deals.Open(ctx, &pb.OpenDealRequest{
@@ -134,66 +125,62 @@ var dealOpenCmd = &cobra.Command{
 		})
 
 		if err != nil {
-			showError(cmd, "Cannot open deal", err)
-			os.Exit(1)
+			return fmt.Errorf("cannot open deal: %v", err)
 		}
 
 		printID(cmd, deal.GetId().Unwrap().String())
+		return nil
 	},
 }
 
 var dealQuickBuyCmd = &cobra.Command{
-	Use:    "quick-buy <ask_id> [duration]",
-	Short:  "Instantly open deal with provided ask order id and optional duration (should be less or equal comparing to ask order)",
-	Args:   cobra.MinimumNArgs(1),
-	PreRun: loadKeyStoreWrapper,
-	Run: func(cmd *cobra.Command, args []string) {
+	Use:   "quick-buy <ask_id> [duration]",
+	Short: "Instantly open deal with provided ask order id and optional duration (should be less or equal comparing to ask order)",
+	Args:  cobra.MinimumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx, cancel := newTimeoutContext()
 		defer cancel()
 
 		deals, err := newDealsClient(ctx)
 		if err != nil {
-			showError(cmd, "Cannot create client connection", err)
-			os.Exit(1)
+			return fmt.Errorf("cannot create client connection: %v", err)
 		}
 
 		id, err := pb.NewBigIntFromString(args[0])
 		if err != nil {
-			showError(cmd, "Cannot convert arg to number", err)
-			os.Exit(1)
+			return fmt.Errorf("cannot convert arg to number: %v", err)
 		}
 
-		req := &pb.QuickBuyRequest{
-			AskID: id,
-		}
+		req := &pb.QuickBuyRequest{AskID: id}
+
 		if len(args) >= 2 {
 			duration, err := time.ParseDuration(args[1])
 			if err != nil {
-				showError(cmd, "Cannot parse specified duration", err)
-				os.Exit(1)
+				return fmt.Errorf("cannot parse specified duration: %v", err)
 			}
 			req.Duration = &pb.Duration{
 				Nanoseconds: duration.Nanoseconds(),
 			}
 		}
+
 		deal, err := deals.QuickBuy(ctx, req)
 		if err != nil {
-			showError(cmd, "Cannot perform quick buy on given order", err)
-			os.Exit(1)
+			return fmt.Errorf("cannot perform quick buy on given order: %v", err)
 		}
 
 		printDealInfo(cmd, deal, nil, printEverything)
+		return nil
 	},
 }
 
 var dealCloseCmd = &cobra.Command{
-	Use:    "close <deal_id>",
-	Short:  "Close given deal",
-	Args:   cobra.MinimumNArgs(1),
-	PreRun: loadKeyStoreIfRequired,
-	Run: func(cmd *cobra.Command, args []string) {
+	Use:   "close <deal_id>",
+	Short: "Close given deal",
+	Args:  cobra.MinimumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx, cancel := newTimeoutContext()
 		defer cancel()
+
 		var blacklistType pb.BlacklistType
 		switch blacklistTypeStr {
 		case "none":
@@ -203,31 +190,28 @@ var dealCloseCmd = &cobra.Command{
 		case "master":
 			blacklistType = pb.BlacklistType_BLACKLIST_MASTER
 		default:
-			showError(cmd, "Cannot parse `blacklist` argumet, allowed values are `none`, `worker` and `master`", nil)
-			os.Exit(1)
+			return fmt.Errorf("cannot parse `blacklist` argumet, allowed values are `none`, `worker` and `master`")
 		}
 
 		dealer, err := newDealsClient(ctx)
 		if err != nil {
-			showError(cmd, "Cannot create client connection", err)
-			os.Exit(1)
+			return fmt.Errorf("cannot create client connection: %v", err)
 		}
 
 		id, err := util.ParseBigInt(args[0])
 		if err != nil {
-			showError(cmd, "Cannot convert arg to number", err)
-			os.Exit(1)
+			return err
 		}
 
-		_, err = dealer.Finish(ctx, &pb.DealFinishRequest{
+		if _, err = dealer.Finish(ctx, &pb.DealFinishRequest{
 			Id:            pb.NewBigInt(id),
 			BlacklistType: blacklistType,
-		})
-		if err != nil {
-			showError(cmd, "Cannot finish deal", err)
-			os.Exit(1)
+		}); err != nil {
+			return fmt.Errorf("cannot finosh deal: %v", err)
 		}
+
 		showOk(cmd)
+		return nil
 	},
 }
 
@@ -242,21 +226,18 @@ var changeRequestCreateCmd = &cobra.Command{
 	Example: "  sonmcli deal change-request create 123 --new-duration=10h --new-price=0.3USD/h",
 	Short:   "Request changes for given deal",
 	Args:    cobra.MinimumNArgs(1),
-	PreRun:  loadKeyStoreIfRequired,
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx, cancel := newTimeoutContext()
 		defer cancel()
 
 		dealer, err := newDealsClient(ctx)
 		if err != nil {
-			showError(cmd, "Cannot create client connection", err)
-			os.Exit(1)
+			return fmt.Errorf("cannot create client connection: %v", err)
 		}
 
 		id, err := util.ParseBigInt(args[0])
 		if err != nil {
-			showError(cmd, "Cannot convert arg to id", err)
-			os.Exit(1)
+			return err
 		}
 
 		durationRaw := cmd.Flag("new-duration").Value.String()
@@ -264,8 +245,7 @@ var changeRequestCreateCmd = &cobra.Command{
 
 		// check that at least one flag is present
 		if len(durationRaw) == 0 && len(priceRaw) == 0 {
-			showError(cmd, "Please specify at least one flag: --new-duration or --new-price", nil)
-			os.Exit(1)
+			return fmt.Errorf("please specify at least one flag: --new-duration or --new-price")
 		}
 
 		var newPrice = &pb.Price{}
@@ -274,15 +254,13 @@ var changeRequestCreateCmd = &cobra.Command{
 		if len(durationRaw) > 0 {
 			newDuration, err = time.ParseDuration(durationRaw)
 			if err != nil {
-				showError(cmd, "Cannot convert flag value to duration", err)
-				os.Exit(1)
+				return fmt.Errorf("cannot convert flag value to duration: %v", err)
 			}
 		}
 
 		if len(priceRaw) > 0 {
 			if err := newPrice.LoadFromString(priceRaw); err != nil {
-				showError(cmd, "Cannot convert flag value to price", err)
-				os.Exit(1)
+				return fmt.Errorf("cannot convert flag value to price: %v", err)
 			}
 		}
 
@@ -294,69 +272,64 @@ var changeRequestCreateCmd = &cobra.Command{
 
 		crid, err := dealer.CreateChangeRequest(ctx, req)
 		if err != nil {
-			showError(cmd, "Cannot create change request", err)
-			os.Exit(1)
+			return fmt.Errorf("cannot create change request: %v", err)
 		}
 
 		cmd.Printf("Change request ID = %v\n", crid.Unwrap().String())
+		return nil
 	},
 }
 
 var changeRequestApproveCmd = &cobra.Command{
-	Use:    "approve <req_id>",
-	Short:  "Agree to change deal conditions with given change request",
-	Args:   cobra.MinimumNArgs(1),
-	PreRun: loadKeyStoreIfRequired,
-	Run: func(cmd *cobra.Command, args []string) {
+	Use:   "approve <req_id>",
+	Short: "Agree to change deal conditions with given change request",
+	Args:  cobra.MinimumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx, cancel := newTimeoutContext()
 		defer cancel()
 
 		dealer, err := newDealsClient(ctx)
 		if err != nil {
-			showError(cmd, "Cannot create client connection", err)
-			os.Exit(1)
+			return fmt.Errorf("cannot create client connection: %v", err)
 		}
 
 		id, err := util.ParseBigInt(args[0])
 		if err != nil {
-			showError(cmd, "Cannot convert arg to id", err)
-			os.Exit(1)
+			return err
 		}
 
 		if _, err := dealer.ApproveChangeRequest(ctx, pb.NewBigInt(id)); err != nil {
-			showError(cmd, "Cannot approve change request", err)
-			os.Exit(1)
+			return fmt.Errorf("cannot approve change request: %v", err)
 		}
+
 		showOk(cmd)
+		return nil
 	},
 }
 
 var changeRequestCancelCmd = &cobra.Command{
-	Use:    "cancel <req_id>",
-	Short:  "Decline given change request",
-	Args:   cobra.MinimumNArgs(1),
-	PreRun: loadKeyStoreIfRequired,
-	Run: func(cmd *cobra.Command, args []string) {
+	Use:   "cancel <req_id>",
+	Short: "Decline given change request",
+	Args:  cobra.MinimumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx, cancel := newTimeoutContext()
 		defer cancel()
 
 		dealer, err := newDealsClient(ctx)
 		if err != nil {
-			showError(cmd, "Cannot create client connection", err)
-			os.Exit(1)
+			return fmt.Errorf("cannot create client connection: %v", err)
 		}
 
 		id, err := util.ParseBigInt(args[0])
 		if err != nil {
-			showError(cmd, "Cannot convert arg to id", err)
-			os.Exit(1)
+			return fmt.Errorf("cannot convert arg to id: %v", err)
 		}
 
 		if _, err := dealer.CancelChangeRequest(ctx, pb.NewBigInt(id)); err != nil {
-			showError(cmd, "Cannot cancel change request", err)
-			os.Exit(1)
+			return fmt.Errorf("cannot cancel change request: %v", err)
 		}
 
 		showOk(cmd)
+		return nil
 	},
 }

--- a/cmd/cli/commands/err_test.go
+++ b/cmd/cli/commands/err_test.go
@@ -44,21 +44,21 @@ func TestJsonErrorCustom(t *testing.T) {
 
 func TestShowErrorNilErr(t *testing.T) {
 	buf := initRootCmd(t, "1.2.3", config.OutputModeSimple)
-	showError(rootCmd, "test error", nil)
+	ShowError(rootCmd, "test error", nil)
 	out := buf.String()
 	assert.Equal(t, "[ERR] test error\r\n", out)
 }
 
 func TestShowErrorWithErr(t *testing.T) {
 	buf := initRootCmd(t, "1.2.3", config.OutputModeSimple)
-	showError(rootCmd, "test error", errors.New("internal"))
+	ShowError(rootCmd, "test error", errors.New("internal"))
 	out := buf.String()
 	assert.Equal(t, "[ERR] test error: internal\r\n", out)
 }
 
 func TestShowErrorJsonNilErr(t *testing.T) {
 	buf := initRootCmd(t, "1.2.3", config.OutputModeJSON)
-	showError(rootCmd, "test error", nil)
+	ShowError(rootCmd, "test error", nil)
 	out := buf.String()
 
 	cmdErr, err := stringToCommandError(out)
@@ -69,7 +69,7 @@ func TestShowErrorJsonNilErr(t *testing.T) {
 
 func TestShowErrorJsonWithErr(t *testing.T) {
 	buf := initRootCmd(t, "1.2.3", config.OutputModeJSON)
-	showError(rootCmd, "test error", errors.New("reason"))
+	ShowError(rootCmd, "test error", errors.New("reason"))
 	out := buf.String()
 
 	cmdErr, err := stringToCommandError(out)

--- a/cmd/cli/commands/printers.go
+++ b/cmd/cli/commands/printers.go
@@ -235,7 +235,7 @@ func printAskList(cmd *cobra.Command, slots *pb.AskPlansReply) {
 		}
 		out, err := yaml.Marshal(plans)
 		if err != nil {
-			showError(cmd, "could not marshall ask plans", err)
+			ShowError(cmd, "could not marshall ask plans", err)
 		} else {
 			cmd.Println(string(out))
 		}
@@ -322,8 +322,14 @@ func printDealInfo(cmd *cobra.Command, info *pb.DealInfoReply, changes *pb.DealC
 			}
 		}
 
+		key, err := getDefaultKey()
+		if err != nil {
+			cmd.Printf("cannot get default key: %v\r\n", err)
+			return
+		}
+
 		noWorkerRespond := info.GetResources() == nil && info.GetRunning() == nil && info.GetCompleted() == nil
-		iamConsumer := crypto.PubkeyToAddress(getDefaultKeyOrDie().PublicKey).Big().Cmp(deal.GetConsumerID().Unwrap().Big()) == 0
+		iamConsumer := crypto.PubkeyToAddress(key.PublicKey).Big().Cmp(deal.GetConsumerID().Unwrap().Big()) == 0
 
 		if noWorkerRespond && iamConsumer && !flags.WarningSuppressed() {
 			// seems like worker is offline, notify user about it

--- a/cmd/cli/commands/tasks.go
+++ b/cmd/cli/commands/tasks.go
@@ -49,21 +49,28 @@ func init() {
 var taskPullOutput string
 
 var taskRootCmd = &cobra.Command{
-	Use:   "task",
-	Short: "Tasks management",
+	Use:     "task",
+	Short:   "Tasks management",
+	PreRunE: loadKeyStoreIfRequired,
 }
 
 func getActiveDealIDs(ctx context.Context) ([]*big.Int, error) {
 	dealCli, err := newDealsClient(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("cannot connect to Node: %s", err)
+		return nil, fmt.Errorf("cannot create client connection: %v", err)
 	}
+
 	deals, err := dealCli.List(ctx, &pb.Count{Count: 0})
 	if err != nil {
 		return nil, fmt.Errorf("cannot fetch deals list: %s", err)
 	}
+
 	dealIDs := make([]*big.Int, 0, len(deals.Deal))
-	myAddr := crypto.PubkeyToAddress(getDefaultKeyOrDie().PublicKey).Big()
+	key, err := getDefaultKey()
+	if err != nil {
+		return nil, err
+	}
+	myAddr := crypto.PubkeyToAddress(key.PublicKey).Big()
 
 	for _, deal := range deals.Deal {
 		// append active deal id only if current user is supplier
@@ -76,87 +83,81 @@ func getActiveDealIDs(ctx context.Context) ([]*big.Int, error) {
 }
 
 var taskListCmd = &cobra.Command{
-	Use:    "list [deal_id]",
-	Short:  "Show active tasks",
-	PreRun: loadKeyStoreIfRequired,
-	Run: func(cmd *cobra.Command, args []string) {
+	Use:   "list [deal_id]",
+	Short: "Show active tasks",
+	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx, cancel := newTimeoutContext()
 		defer cancel()
 
 		node, err := newTaskClient(ctx)
 		if err != nil {
-			showError(cmd, "Cannot connect to Node", err)
-			os.Exit(1)
+			return fmt.Errorf("cannot create client connection: %v", err)
 		}
 
 		var dealIDs []*big.Int
 		if len(args) > 0 {
 			dealID, err := util.ParseBigInt(args[0])
 			if err != nil {
-				showError(cmd, err.Error(), nil)
-				os.Exit(1)
+				return nil
 			}
 			dealIDs = append(dealIDs, dealID)
 		} else {
 			if !isSimpleFormat() {
-				showError(cmd, "listing task for all deals is prohibited in JSON mode", nil)
-				os.Exit(1)
+				return fmt.Errorf("listing task for all deals is prohibited in JSON mode")
 			}
+
 			cmd.Printf("fetching deals ...\n")
 			dealIDs, err = getActiveDealIDs(ctx)
 			if err != nil {
-				showError(cmd, err.Error(), nil)
-				os.Exit(1)
+				return err
 			}
 		}
 
 		if len(dealIDs) == 0 {
 			cmd.Println("No active deals found.")
-			return
+			return nil
 		}
 
 		for k, dealID := range dealIDs {
 			timeoutCtx, cancel := context.WithTimeout(ctx, time.Second*10)
 			cmd.Printf("Deal %s (%d/%d):\n", dealID.String(), k+1, len(dealIDs))
+
 			list, err := node.List(timeoutCtx, &pb.TaskListRequest{DealID: pb.NewBigInt(dealID)})
 			if err != nil {
-				showError(cmd, "Cannot get task list for deal", err)
+				cmd.Printf("cannot get task list for deal: %v", err)
 			} else {
 				printNodeTaskStatus(cmd, list.GetInfo())
 			}
 			cancel()
 		}
+
+		return nil
 	},
 }
 
 var taskStartCmd = &cobra.Command{
-	Use:    "start <deal_id> <task.yaml>",
-	Short:  "Start task",
-	PreRun: loadKeyStoreWrapper,
-	Args:   cobra.MinimumNArgs(2),
-	Run: func(cmd *cobra.Command, args []string) {
+	Use:   "start <deal_id> <task.yaml>",
+	Short: "Start task",
+	Args:  cobra.MinimumNArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
 		node, err := newTaskClient(ctx)
 		if err != nil {
-			showError(cmd, "Cannot connect to Node", err)
-			os.Exit(1)
+			return fmt.Errorf("cannot create client connection: %v", err)
 		}
 
 		dealID := args[0]
 		taskFile := args[1]
-
 		spec, err := task_config.LoadConfig(taskFile)
 		if err != nil {
-			showError(cmd, "Cannot load task definition", err)
-			os.Exit(1)
+			return fmt.Errorf("cannot load task definition: %v", err)
 		}
 
 		bigDealID, err := pb.NewBigIntFromString(dealID)
 		if err != nil {
-			showError(cmd, "Cannot parse deal ID", err)
-			os.Exit(1)
+			return err
 		}
 
 		request := &pb.StartTaskRequest{
@@ -166,70 +167,64 @@ var taskStartCmd = &cobra.Command{
 
 		reply, err := node.Start(ctx, request)
 		if err != nil {
-			showError(cmd, "Cannot start task", err)
-			os.Exit(1)
+			return fmt.Errorf("cannot start task: %v", err)
 		}
 
 		printTaskStart(cmd, reply)
+		return nil
 	},
 }
 
 var taskStatusCmd = &cobra.Command{
-	Use:    "status <deal_id> <task_id>",
-	Short:  "Show task status",
-	Args:   cobra.MinimumNArgs(2),
-	PreRun: loadKeyStoreIfRequired,
-	Run: func(cmd *cobra.Command, args []string) {
+	Use:   "status <deal_id> <task_id>",
+	Short: "Show task status",
+	Args:  cobra.MinimumNArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx, cancel := newTimeoutContext()
 		defer cancel()
 
 		node, err := newTaskClient(ctx)
 		if err != nil {
-			showError(cmd, "Cannot connect to Node", err)
-			os.Exit(1)
+			return fmt.Errorf("cannot create client connection: %v", err)
 		}
 
-		dealID, err := util.ParseBigInt(args[0])
+		dealID, err := pb.NewBigIntFromString(args[0])
 		if err != nil {
-			showError(cmd, err.Error(), nil)
-			os.Exit(1)
+			return err
 		}
 
 		taskID := args[1]
 		req := &pb.TaskID{
 			Id:     taskID,
-			DealID: pb.NewBigInt(dealID),
+			DealID: dealID,
 		}
 
 		status, err := node.Status(ctx, req)
 		if err != nil {
-			showError(cmd, "Cannot get task status", err)
-			os.Exit(1)
+			return fmt.Errorf("cannot get task status: %v", err)
 		}
 
 		printTaskStatus(cmd, taskID, status)
+		return nil
 	},
 }
 
 var taskJoinNetworkCmd = &cobra.Command{
-	Use:    "join <deal_id> <task_id> <network_id>",
-	Short:  "Provide network specs for joining to specified task's specific network",
-	Args:   cobra.MinimumNArgs(3),
-	PreRun: loadKeyStoreIfRequired,
-	Run: func(cmd *cobra.Command, args []string) {
+	Use:   "join <deal_id> <task_id> <network_id>",
+	Short: "Provide network specs for joining to specified task's specific network",
+	Args:  cobra.MinimumNArgs(3),
+	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx, cancel := newTimeoutContext()
 		defer cancel()
 
 		node, err := newTaskClient(ctx)
 		if err != nil {
-			showError(cmd, "Cannot connect to Node", err)
-			os.Exit(1)
+			return fmt.Errorf("cannot create client connection: %v", err)
 		}
 
-		dealID, err := util.ParseBigInt(args[0])
+		dealID, err := pb.NewBigIntFromString(args[0])
 		if err != nil {
-			showError(cmd, err.Error(), nil)
-			os.Exit(1)
+			return err
 		}
 
 		taskID := args[1]
@@ -237,16 +232,16 @@ var taskJoinNetworkCmd = &cobra.Command{
 		spec, err := node.JoinNetwork(ctx, &pb.JoinNetworkRequest{
 			TaskID: &pb.TaskID{
 				Id:     taskID,
-				DealID: pb.NewBigInt(dealID),
+				DealID: dealID,
 			},
 			NetworkID: netID,
 		})
 		if err != nil {
-			showError(cmd, "Cannot get task status", err)
-			os.Exit(1)
+			return fmt.Errorf("cannot get task status: %v", err)
 		}
 
 		printNetworkSpec(cmd, spec)
+		return nil
 	},
 }
 
@@ -298,29 +293,26 @@ func parseType(logType string) (pb.TaskLogsRequest_Type, error) {
 }
 
 var taskLogsCmd = &cobra.Command{
-	Use:    "logs <deal_id> <task_id>",
-	Short:  "Retrieve task logs",
-	Args:   cobra.MinimumNArgs(2),
-	PreRun: loadKeyStoreIfRequired,
-	Run: func(cmd *cobra.Command, args []string) {
+	Use:   "logs <deal_id> <task_id>",
+	Short: "Retrieve task logs",
+	Args:  cobra.MinimumNArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx, cancel := newTimeoutContext()
 		defer cancel()
 
 		node, err := newTaskClient(ctx)
 		if err != nil {
-			showError(cmd, "Cannot connect to Node", err)
-			os.Exit(1)
+			return fmt.Errorf("cannot create client connection: %v", err)
 		}
 
 		dealID, err := util.ParseBigInt(args[0])
 		if err != nil {
-			showError(cmd, err.Error(), nil)
-			os.Exit(1)
+			return err
 		}
+
 		logType, err := parseType(logType)
 		if err != nil {
-			showError(cmd, "failed to parse log type", err)
-			os.Exit(1)
+			return fmt.Errorf("failed to parse log type: %v", err)
 		}
 
 		req := &pb.TaskLogsRequest{
@@ -336,8 +328,7 @@ var taskLogsCmd = &cobra.Command{
 
 		logClient, err := node.Logs(ctx, req)
 		if err != nil {
-			showError(cmd, "Cannot get task logs", err)
-			os.Exit(1)
+			return fmt.Errorf("cannot get task logs: %v", err)
 		}
 
 		reader := logReader{cli: logClient}
@@ -347,55 +338,52 @@ var taskLogsCmd = &cobra.Command{
 			stdout = &logWriter{stdout, "[STDOUT] "}
 			stderr = &logWriter{stderr, "[STDERR] "}
 		}
-		_, err = stdcopy.StdCopy(stdout, stderr, &reader)
-		if err != nil {
-			showError(cmd, "failed to read logs", err)
-			os.Exit(1)
+
+		if _, err := stdcopy.StdCopy(stdout, stderr, &reader); err != nil {
+			return fmt.Errorf("failed to read logs: %v", err)
 		}
+
+		return nil
 	},
 }
 
 var taskStopCmd = &cobra.Command{
-	Use:    "stop <deal_id> <task_id>",
-	Short:  "Stop task",
-	Args:   cobra.MinimumNArgs(2),
-	PreRun: loadKeyStoreIfRequired,
-	Run: func(cmd *cobra.Command, args []string) {
+	Use:   "stop <deal_id> <task_id>",
+	Short: "Stop task",
+	Args:  cobra.MinimumNArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx, cancel := newTimeoutContext()
 		defer cancel()
 
 		node, err := newTaskClient(ctx)
 		if err != nil {
-			showError(cmd, "Cannot connect to Node", err)
-			os.Exit(1)
+			return fmt.Errorf("cannot create client connection: %v", err)
 		}
 
-		dealID, err := util.ParseBigInt(args[0])
+		dealID, err := pb.NewBigIntFromString(args[0])
 		if err != nil {
-			showError(cmd, err.Error(), nil)
-			os.Exit(1)
+			return nil
 		}
 
 		req := &pb.TaskID{
 			Id:     args[1],
-			DealID: pb.NewBigInt(dealID),
+			DealID: dealID,
 		}
 
 		if _, err := node.Stop(ctx, req); err != nil {
-			showError(cmd, "Cannot stop status", err)
-			os.Exit(1)
+			return fmt.Errorf("cannot stop status: %v", err)
 		}
 
 		showOk(cmd)
+		return nil
 	},
 }
 
 var taskPullCmd = &cobra.Command{
-	Use:    "pull <deal_id> <task_id>",
-	Short:  "Pull committed image from the completed task.",
-	Args:   cobra.MinimumNArgs(2),
-	PreRun: loadKeyStoreIfRequired,
-	Run: func(cmd *cobra.Command, args []string) {
+	Use:   "pull <deal_id> <task_id>",
+	Short: "Pull committed image from the completed task.",
+	Args:  cobra.MinimumNArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
 		dealID := args[0]
 		taskID := args[1]
 
@@ -406,8 +394,7 @@ var taskPullCmd = &cobra.Command{
 		} else {
 			file, err := os.Create(taskPullOutput)
 			if err != nil {
-				showError(cmd, "Cannot create file", err)
-				os.Exit(1)
+				return fmt.Errorf("cannot create file: %v", err)
 			}
 
 			defer file.Close()
@@ -421,8 +408,7 @@ var taskPullCmd = &cobra.Command{
 
 		node, err := newTaskClient(ctx)
 		if err != nil {
-			showError(cmd, "Cannot connect to Node", err)
-			os.Exit(1)
+			return fmt.Errorf("cannot create client connection: %v", err)
 		}
 
 		req := &pb.PullTaskRequest{
@@ -432,8 +418,7 @@ var taskPullCmd = &cobra.Command{
 
 		client, err := node.PullTask(ctx, req)
 		if err != nil {
-			showError(cmd, "Cannot create image pull client", err)
-			os.Exit(1)
+			return fmt.Errorf("cannot create image pull client: %v", err)
 		}
 
 		var bar *uiprogress.Bar
@@ -448,14 +433,12 @@ var taskPullCmd = &cobra.Command{
 
 					header, err := client.Header()
 					if err != nil {
-						showError(cmd, "Cannot get client header", err)
-						os.Exit(1)
+						return fmt.Errorf("cannot get client header: %v", err)
 					}
 
 					size, err := structs.RequireHeaderInt64(header, "size")
 					if err != nil {
-						showError(cmd, "Cannot convert header value to int64", err)
-						os.Exit(1)
+						return fmt.Errorf("cannot convert header value to int64: %v", err)
 					}
 
 					if taskPullOutput != "" {
@@ -471,8 +454,7 @@ var taskPullCmd = &cobra.Command{
 
 				n, err := io.Copy(wr, bytes.NewReader(chunk.Chunk))
 				if err != nil {
-					showError(cmd, "Cannot write to file", err)
-					os.Exit(1)
+					return fmt.Errorf("cannot write to file: %v", err)
 				}
 
 				bytesRecv += n
@@ -485,40 +467,37 @@ var taskPullCmd = &cobra.Command{
 				if err == io.EOF {
 					streaming = false
 				} else {
-					showError(cmd, "Streaming error", err)
-					os.Exit(1)
+					return fmt.Errorf("streaming error: %v", err)
 				}
 			}
 		}
 
 		if err := w.Flush(); err != nil {
-			showError(cmd, "Cannot flush writer", err)
-			os.Exit(1)
+			return fmt.Errorf("cannot flush writer: %v", err)
 		}
+
+		return nil
 	},
 }
 
 var taskPushCmd = &cobra.Command{
-	Use:    "push <deal_id> <archive_path>",
-	Short:  "Push an image from the filesystem",
-	Args:   cobra.MinimumNArgs(2),
-	PreRun: loadKeyStoreIfRequired,
-	Run: func(cmd *cobra.Command, args []string) {
+	Use:   "push <deal_id> <archive_path>",
+	Short: "Push an image from the filesystem",
+	Args:  cobra.MinimumNArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
 		dealID := args[0]
 		path := args[1]
 
 		file, err := os.Open(path)
 		if err != nil {
-			showError(cmd, "Cannot open archive path", err)
-			os.Exit(1)
+			return fmt.Errorf("сannot open archive path: %v", err)
 		}
 
 		defer file.Close()
 
 		fileInfo, err := file.Stat()
 		if err != nil {
-			showError(cmd, "Cannot stat file", err)
-			os.Exit(1)
+			return fmt.Errorf("cannot stat file: %v", err)
 		}
 
 		ctx, cancel := newTimeoutContext()
@@ -526,8 +505,7 @@ var taskPushCmd = &cobra.Command{
 
 		node, err := newTaskClient(ctx)
 		if err != nil {
-			showError(cmd, "Cannot connect to Node", err)
-			os.Exit(1)
+			return fmt.Errorf("cannot create client connection: %v", err)
 		}
 
 		ctx = metadata.NewOutgoingContext(ctx, metadata.New(map[string]string{
@@ -537,8 +515,7 @@ var taskPushCmd = &cobra.Command{
 
 		client, err := node.PushTask(ctx)
 		if err != nil {
-			showError(cmd, "Cannot create push task client", err)
-			os.Exit(1)
+			return fmt.Errorf("cannot create push task client: %v", err)
 		}
 
 		readCompleted := false
@@ -561,12 +538,10 @@ var taskPushCmd = &cobra.Command{
 						readCompleted = true
 
 						if err := client.CloseSend(); err != nil {
-							showError(cmd, "Cannot close client stream", err)
-							os.Exit(1)
+							return fmt.Errorf("cannot close client stream: %v", err)
 						}
 					} else {
-						showError(cmd, "Cannot read file", err)
-						os.Exit(1)
+						return fmt.Errorf("cannot read file: %v", err)
 					}
 				}
 
@@ -582,18 +557,16 @@ var taskPushCmd = &cobra.Command{
 					if bytesCommitted == fileInfo.Size() {
 						id, ok := client.Trailer()["id"]
 						if !ok || len(id) == 0 {
-							showError(cmd, "No status returned", nil)
-							os.Exit(1)
+							return fmt.Errorf("mo status returned: %v", nil)
 						}
 
-						showJSON(cmd, map[string]interface{}{"id": id[0]})
-						return
+						printID(cmd, id[0])
+						return nil
 					}
 				}
 
 				if err != nil {
-					showError(cmd, "Cannot read from stream", err)
-					os.Exit(1)
+					return fmt.Errorf("cannot read from stream: %v", err)
 				}
 
 				bytesCommitted += progress.Size

--- a/cmd/cli/commands/tokens.go
+++ b/cmd/cli/commands/tokens.go
@@ -2,11 +2,10 @@ package commands
 
 import (
 	"context"
-	"os"
+	"fmt"
 	"time"
 
 	"github.com/sonm-io/core/proto"
-	"github.com/sonm-io/core/util"
 	"github.com/spf13/cobra"
 )
 
@@ -21,139 +20,126 @@ func init() {
 }
 
 var tokenRootCmd = &cobra.Command{
-	Use:   "token",
-	Short: "Manage tokens",
+	Use:     "token",
+	Short:   "Manage tokens",
+	PreRunE: loadKeyStoreIfRequired,
 }
 
 var tokenGetCmd = &cobra.Command{
-	Use:    "get",
-	Short:  "Get SONM test tokens (ERC20)",
-	PreRun: loadKeyStoreWrapper,
-	Run: func(cmd *cobra.Command, args []string) {
+	Use:   "get",
+	Short: "Get SONM test tokens (ERC20)",
+	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx, cancel := newTimeoutContext()
 		defer cancel()
 
 		token, err := newTokenManagementClient(ctx)
 		if err != nil {
-			showError(cmd, "Cannot create client connection", err)
-			os.Exit(1)
+			return fmt.Errorf("cannot create client connection: %v", err)
 		}
 
 		if _, err := token.TestTokens(ctx, &sonm.Empty{}); err != nil {
-			showError(cmd, "Cannot get tokens", err)
-			os.Exit(1)
+			return fmt.Errorf("cannot get tokens: %v", err)
 		}
 
 		showOk(cmd)
+		return nil
 	},
 }
 
 var tokenBalanceCmd = &cobra.Command{
-	Use:    "balance",
-	Short:  "Show SONM token balance (ERC20)",
-	PreRun: loadKeyStoreWrapper,
-	Run: func(cmd *cobra.Command, args []string) {
+	Use:   "balance",
+	Short: "Show SONM token balance (ERC20)",
+	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx, cancel := newTimeoutContext()
 		defer cancel()
 
 		token, err := newTokenManagementClient(ctx)
 		if err != nil {
-			showError(cmd, "Cannot create client connection", err)
-			os.Exit(1)
+			return fmt.Errorf("cannot create client connection: %v", err)
 		}
 
 		balance, err := token.Balance(ctx, &sonm.Empty{})
 		if err != nil {
-			showError(cmd, "Cannot load balance", err)
-			os.Exit(1)
+			return fmt.Errorf("cannot load balance: %v", err)
 		}
 
 		printBalanceInfo(cmd, balance)
+		return nil
 	},
 }
 
 var tokenDepositCmd = &cobra.Command{
-	Use:    "deposit <amount>",
-	Short:  "Transfer funds from masterchain to SONM blockchain",
-	Args:   cobra.MinimumNArgs(1),
-	PreRun: loadKeyStoreIfRequired,
-	Run: func(cmd *cobra.Command, args []string) {
+	Use:   "deposit <amount>",
+	Short: "Transfer funds from masterchain to SONM blockchain",
+	Args:  cobra.MinimumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx, cancel := context.WithTimeout(context.Background(), 150*time.Second)
 		defer cancel()
 
 		token, err := newTokenManagementClient(ctx)
 		if err != nil {
-			showError(cmd, "Cannot create client connection", err)
-			os.Exit(1)
+			return fmt.Errorf("cannot create client connection: %v", err)
 		}
 
-		amount, err := util.ParseBigInt(args[0])
+		amount, err := sonm.NewBigIntFromString(args[0])
 		if err != nil {
-			showError(cmd, err.Error(), nil)
-			os.Exit(1)
+			return err
 		}
 
-		_, err = token.Deposit(ctx, sonm.NewBigInt(amount))
-		if err != nil {
-			showError(cmd, "Cannot deposit funds", err)
-			os.Exit(1)
+		if _, err := token.Deposit(ctx, amount); err != nil {
+			return fmt.Errorf("cannot deposit funds: %v", err)
 		}
 
 		showOk(cmd)
+		return nil
 	},
 }
 
 var tokenWithdrawCmd = &cobra.Command{
-	Use:    "withdraw <amount>",
-	Short:  "Transfer funds from SONM blockchain to masterchain",
-	Args:   cobra.MinimumNArgs(1),
-	PreRun: loadKeyStoreIfRequired,
-	Run: func(cmd *cobra.Command, args []string) {
+	Use:   "withdraw <amount>",
+	Short: "Transfer funds from SONM blockchain to masterchain",
+	Args:  cobra.MinimumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx, cancel := newTimeoutContext()
 		defer cancel()
 
 		token, err := newTokenManagementClient(ctx)
 		if err != nil {
-			showError(cmd, "Cannot create client connection", err)
-			os.Exit(1)
+			return fmt.Errorf("cannot create client connection: %v", err)
 		}
 
-		amount, err := util.ParseBigInt(args[0])
+		amount, err := sonm.NewBigIntFromString(args[0])
 		if err != nil {
-			showError(cmd, err.Error(), nil)
-			os.Exit(1)
+			return err
 		}
 
-		_, err = token.Withdraw(ctx, sonm.NewBigInt(amount))
-		if err != nil {
-			showError(cmd, "Cannot withdraw funds", err)
-			os.Exit(1)
+		if _, err := token.Withdraw(ctx, amount); err != nil {
+			return fmt.Errorf("cannot withdraw funds: %v", err)
 		}
 
 		showOk(cmd)
+		return nil
 	},
 }
 
 var tokenMarketAllowanceCmd = &cobra.Command{
-	Use:    "allowance",
-	Short:  "Show current allowance for marketplace on sidechain network",
-	PreRun: loadKeyStoreIfRequired,
-	Run: func(cmd *cobra.Command, args []string) {
+	Use:   "allowance",
+	Short: "Show current allowance for marketplace on sidechain network",
+	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx, cancel := newTimeoutContext()
 		defer cancel()
 
 		token, err := newTokenManagementClient(ctx)
 		if err != nil {
-			showError(cmd, "Cannot create client connection", err)
-			os.Exit(1)
+			return fmt.Errorf("cannot create client connection: %v", err)
 		}
 
 		allowance, err := token.MarketAllowance(ctx, &sonm.Empty{})
 		if err != nil {
-			showError(cmd, "Cannot get allowance", err)
-			os.Exit(1)
+			return fmt.Errorf("cannot get allowance: %v", err)
 		}
 
 		printMarketAllowance(cmd, allowance)
+		return nil
 	},
 }

--- a/cmd/cli/commands/version.go
+++ b/cmd/cli/commands/version.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -9,8 +10,9 @@ import (
 var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Show version",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		printVersion(cmd, version)
+		return nil
 	},
 }
 
@@ -18,7 +20,7 @@ var autoCompleteCmd = &cobra.Command{
 	Use:   "completion <bash|zsh>",
 	Short: "Generate shell-completion script",
 	Args:  cobra.MinimumNArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		var err error
 		shell := args[0]
 
@@ -28,13 +30,9 @@ var autoCompleteCmd = &cobra.Command{
 		case "bash":
 			err = rootCmd.GenBashCompletion(os.Stdout)
 		default:
-			showError(cmd, "Unknown shell type", nil)
-			os.Exit(1)
+			err = fmt.Errorf("unknown shell type `%s`", shell)
 		}
 
-		if err != nil {
-			showError(cmd, "Cannot generate completion script", nil)
-			os.Exit(1)
-		}
+		return err
 	},
 }

--- a/cmd/cli/commands/worker.go
+++ b/cmd/cli/commands/worker.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"time"
 
 	"github.com/ethereum/go-ethereum/crypto"
@@ -22,26 +21,36 @@ var (
 	workerCancel context.CancelFunc
 )
 
-func workerPreRun(cmd *cobra.Command, args []string) {
-	loadKeyStoreIfRequired(cmd, args)
+func workerPreRunE(cmd *cobra.Command, args []string) error {
+	if err := loadKeyStoreIfRequired(cmd, args); err != nil {
+		return err
+	}
+
 	workerCtx, workerCancel = newTimeoutContext()
 	workerAddr := cfg.WorkerAddr
 	if len(workerAddr) == 0 {
-		workerAddr = crypto.PubkeyToAddress(getDefaultKeyOrDie().PublicKey).Hex()
+		key, err := getDefaultKey()
+		if err != nil {
+			return err
+		}
+		workerAddr = crypto.PubkeyToAddress(key.PublicKey).Hex()
 	}
+
 	md := metadata.MD{
 		util.WorkerAddressHeader: []string{cfg.WorkerAddr},
 	}
 	workerCtx = metadata.NewOutgoingContext(workerCtx, md)
+
 	var err error
 	worker, err = newWorkerManagementClient(workerCtx)
 	if err != nil {
-		showError(cmd, "Cannot create client connection", err)
-		os.Exit(1)
+		return fmt.Errorf("cannot create client connection: %v", err)
 	}
+
+	return nil
 }
 
-func workerPostRun(cmd *cobra.Command, args []string) {
+func workerPostRun(_ *cobra.Command, _ []string) {
 	if workerCancel != nil {
 		workerCancel()
 	}
@@ -66,21 +75,21 @@ func init() {
 var workerMgmtCmd = &cobra.Command{
 	Use:               "worker",
 	Short:             "Worker management",
-	PersistentPreRun:  workerPreRun,
+	PersistentPreRunE: workerPreRunE,
 	PersistentPostRun: workerPostRun,
 }
 
 var workerStatusCmd = &cobra.Command{
 	Use:   "status",
 	Short: "Show worker status",
-	Run: func(cmd *cobra.Command, _ []string) {
+	RunE: func(cmd *cobra.Command, _ []string) error {
 		status, err := worker.Status(workerCtx, &pb.Empty{})
 		if err != nil {
-			showError(cmd, "Cannot get worker status", err)
-			os.Exit(1)
+			return fmt.Errorf("cannot get worker status: %v", err)
 		}
 
 		printWorkerStatus(cmd, status)
+		return nil
 	},
 }
 
@@ -88,23 +97,23 @@ var workerSwitchCmd = &cobra.Command{
 	Use:   "switch <eth_addr>",
 	Short: "Switch current worker to specified addr",
 	Args:  cobra.MinimumNArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		addr, err := auth.NewAddr(args[0])
 		if err != nil {
-			showError(cmd, "Invalid address specified", err)
-			os.Exit(1)
+			return fmt.Errorf("invalid address specified: %v", err)
 		}
+
 		if _, err := addr.ETH(); err != nil {
-			err = errors.New("could not parse eth component of the auth addr - it's malformed or missing")
-			showError(cmd, "Invalid address specified", err)
-			os.Exit(1)
+			return fmt.Errorf("could not parse eth component of the auth addr - it's malformed or missing")
 		}
+
 		cfg.WorkerAddr = addr.String()
 		if err := cfg.Save(); err != nil {
-			showError(cmd, "Failed to save worker address", err)
-			os.Exit(1)
+			return fmt.Errorf("failed to save worker address: %v", err)
 		}
+
 		showOk(cmd)
+		return nil
 	},
 }
 
@@ -112,48 +121,52 @@ var workerScheduleMaintenanceCmd = &cobra.Command{
 	Use:   "maintenance <at or after>",
 	Short: "Schedule worker maintanance",
 	Args:  cobra.MinimumNArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		var timePoint time.Time
 		timeData := []byte(args[0])
 		if err := timePoint.UnmarshalText(timeData); err != nil {
 			duration, err := time.ParseDuration(args[0])
 			if err != nil {
-				showError(cmd, "Invalid time point or duration specified", err)
-				os.Exit(1)
+				return fmt.Errorf("invalid time point or duration specified: %v", err)
 			}
+
 			timePoint = time.Now()
 			timePoint = timePoint.Add(duration)
 		}
 
 		if _, err := worker.ScheduleMaintenance(workerCtx, &pb.Timestamp{Seconds: timePoint.Unix()}); err != nil {
-			showError(cmd, "failed to schedule maintenance", err)
-			os.Exit(1)
+			return fmt.Errorf("failed to schedule maintenance: %v", err)
 		}
+
 		showOk(cmd)
+		return nil
 	},
 }
 
 var workerNextMaintenanceCmd = &cobra.Command{
 	Use:   "next-maintenance",
 	Short: "Print next scheduled maintenance",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		next, err := worker.NextMaintenance(workerCtx, &pb.Empty{})
 		if err != nil {
-			showError(cmd, "failed to get next maintenance", err)
-			os.Exit(1)
+			return fmt.Errorf("failed to get next maintenance: %v", err)
 		}
+
+		// todo: proper printer
 		if isSimpleFormat() {
 			cmd.Println(next.Unix().String())
 		} else {
 			showJSON(cmd, next.Unix())
 		}
+
+		return nil
 	},
 }
 
 var workerCurrentCmd = &cobra.Command{
 	Use:   "current",
 	Short: "Show current worker's addr",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		type Result struct {
 			Address     string `json:"address,omitempty"`
 			Error       error  `json:"error,omitempty"`
@@ -163,8 +176,14 @@ var workerCurrentCmd = &cobra.Command{
 		result := func() Result {
 			result := Result{}
 			if len(cfg.WorkerAddr) == 0 {
+				key, err := getDefaultKey()
+				if err != nil {
+					result.Error = err
+					return result
+				}
+
 				result.Description = "current worker is not set, using cli's addr"
-				result.Address = crypto.PubkeyToAddress(getDefaultKeyOrDie().PublicKey).Hex()
+				result.Address = crypto.PubkeyToAddress(key.PublicKey).Hex()
 				return result
 			}
 			addr, err := auth.NewAddr(cfg.WorkerAddr)
@@ -184,37 +203,38 @@ var workerCurrentCmd = &cobra.Command{
 		}()
 
 		if result.Error != nil {
-			showError(cmd, result.Description, result.Error)
-			os.Exit(1)
+			return fmt.Errorf("%s: %v", result.Description, result.Error)
 		}
+
 		if isSimpleFormat() {
 			cmd.Printf("%s %s\n", result.Description, result.Address)
 		} else {
 			showJSON(cmd, result)
 		}
-
+		return nil
 	},
 }
 
 var workerDebugStateCmd = &cobra.Command{
 	Use:   "debug-state",
 	Short: "Provide some useful worker debugging info",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		reply, err := worker.DebugState(workerCtx, &pb.Empty{})
 		if err != nil {
-			showError(cmd, "failed to get debug state", err)
-			os.Exit(1)
+			return fmt.Errorf("failed to get debug state: %v", err)
 		}
+
 		if isSimpleFormat() {
 			data, err := yaml.Marshal(reply)
 			if err != nil {
-				showError(cmd, "failed to marshal state", err)
-				os.Exit(1)
+				return fmt.Errorf("failed to marshal state: %v", err)
 			}
+
 			cmd.Printf("%s\r\n", string(data))
 		} else {
 			showJSON(cmd, reply)
 		}
 
+		return nil
 	},
 }

--- a/cmd/cli/commands/worker_askplans.go
+++ b/cmd/cli/commands/worker_askplans.go
@@ -1,7 +1,7 @@
 package commands
 
 import (
-	"os"
+	"fmt"
 
 	"github.com/sonm-io/core/cmd/cli/task_config"
 	pb "github.com/sonm-io/core/proto"
@@ -25,14 +25,14 @@ var askPlansRootCmd = &cobra.Command{
 var askPlanListCmd = &cobra.Command{
 	Use:   "list",
 	Short: "Show current ask plans",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		asks, err := worker.AskPlans(workerCtx, &pb.Empty{})
 		if err != nil {
-			showError(cmd, "Cannot get Ask Orders from Worker", err)
-			os.Exit(1)
+			return fmt.Errorf("cannot get Ask Orders from Worker: %v", err)
 		}
 
 		printAskList(cmd, asks)
+		return nil
 	},
 }
 
@@ -40,22 +40,21 @@ var askPlanCreateCmd = &cobra.Command{
 	Use:   "create <ask_plan.yaml>",
 	Short: "Create new plan",
 	Args:  cobra.MinimumNArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		planPath := args[0]
 		plan := &pb.AskPlan{}
 
 		if err := task_config.LoadFromFile(planPath, plan); err != nil {
-			showError(cmd, "Cannot load AskPlan definition", err)
-			os.Exit(1)
+			return fmt.Errorf("cannot load AskPlan definition: %v", err)
 		}
 
 		id, err := worker.CreateAskPlan(workerCtx, plan)
 		if err != nil {
-			showError(cmd, "Cannot create new AskOrder", err)
-			os.Exit(1)
+			return fmt.Errorf("cannot create new AskOrder: %v", err)
 		}
 
 		printID(cmd, id.GetId())
+		return nil
 	},
 }
 
@@ -63,28 +62,27 @@ var askPlanRemoveCmd = &cobra.Command{
 	Use:   "remove <order_id>",
 	Short: "Remove plan by",
 	Args:  cobra.MinimumNArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
-		ID := args[0]
-		_, err := worker.RemoveAskPlan(workerCtx, &pb.ID{Id: ID})
+	RunE: func(cmd *cobra.Command, args []string) error {
+		_, err := worker.RemoveAskPlan(workerCtx, &pb.ID{Id: args[0]})
 		if err != nil {
-			showError(cmd, "Cannot remove AskOrder", err)
-			os.Exit(1)
+			return fmt.Errorf("cannot remove AskOrder: %v", err)
 		}
 
 		showOk(cmd)
+		return nil
 	},
 }
 
 var askPlanPurgeCmd = &cobra.Command{
 	Use:   "purge",
 	Short: "Purge all exiting ask-plans on worker",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		_, err := worker.PurgeAskPlans(workerCtx, &pb.Empty{})
 		if err != nil {
-			showError(cmd, "Cannot purge ask plans", err)
-			os.Exit(1)
+			return fmt.Errorf("cannot purge ask plans: %v", err)
 		}
 
 		showOk(cmd)
+		return nil
 	},
 }

--- a/cmd/cli/commands/worker_benchmarks.go
+++ b/cmd/cli/commands/worker_benchmarks.go
@@ -1,7 +1,7 @@
 package commands
 
 import (
-	"os"
+	"fmt"
 	"strconv"
 
 	pb "github.com/sonm-io/core/proto"
@@ -23,13 +23,14 @@ var benchmarkRootCmd = &cobra.Command{
 var workerPurgeBenchmarksCmd = &cobra.Command{
 	Use:   "purge",
 	Short: "Remove all benchmarks from cache to rebenchmark on next worker restart",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		_, err := worker.PurgeBenchmarks(workerCtx, &pb.Empty{})
 		if err != nil {
-			showError(cmd, "failed to purge benchmark cache", err)
-			os.Exit(1)
+			return fmt.Errorf("failed to purge benchmark cache: %v", err)
 		}
+
 		showOk(cmd)
+		return nil
 	},
 }
 
@@ -37,17 +38,17 @@ var workerRemoveBenchmarksCmd = &cobra.Command{
 	Use:   "remove <id>",
 	Short: "Remove specified benchmark from cache to rebenchmark on next worker restart",
 	Args:  cobra.MinimumNArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		id, err := strconv.ParseUint(args[0], 0, 64)
 		if err != nil {
-			showError(cmd, "failed to parse benchmark id", err)
-			os.Exit(1)
+			return fmt.Errorf("failed to parse benchmark id: %v", err)
 		}
-		_, err = worker.RemoveBenchmark(workerCtx, &pb.NumericID{Id: id})
-		if err != nil {
-			showError(cmd, "failed to get debug state", err)
-			os.Exit(1)
+
+		if _, err := worker.RemoveBenchmark(workerCtx, &pb.NumericID{Id: id}); err != nil {
+			return fmt.Errorf("failed to get debug state: %v", err)
 		}
+
 		showOk(cmd)
+		return nil
 	},
 }

--- a/cmd/cli/commands/worker_devices.go
+++ b/cmd/cli/commands/worker_devices.go
@@ -1,7 +1,7 @@
 package commands
 
 import (
-	"os"
+	"fmt"
 
 	pb "github.com/sonm-io/core/proto"
 	"github.com/spf13/cobra"
@@ -10,27 +10,27 @@ import (
 var workerDevicesCmd = &cobra.Command{
 	Use:   "devices",
 	Short: "Show Worker's hardware",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		devices, err := worker.Devices(workerCtx, &pb.Empty{})
 		if err != nil {
-			showError(cmd, "Cannot get devices list", err)
-			os.Exit(1)
+			return fmt.Errorf("cannot get devices list: %v", err)
 		}
 
 		printDeviceList(cmd, devices)
+		return nil
 	},
 }
 
 var workerFreeDevicesCmd = &cobra.Command{
 	Use:   "free_devices",
 	Short: "Show Worker's hardware with remaining resources available for scheduling",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		devices, err := worker.FreeDevices(workerCtx, &pb.Empty{})
 		if err != nil {
-			showError(cmd, "Cannot get devices list", err)
-			os.Exit(1)
+			return fmt.Errorf("cannot get devices list: %v", err)
 		}
 
 		printDeviceList(cmd, devices)
+		return nil
 	},
 }

--- a/cmd/cli/commands/worker_tasks.go
+++ b/cmd/cli/commands/worker_tasks.go
@@ -1,23 +1,22 @@
 package commands
 
 import (
-	"os"
+	"fmt"
 
 	pb "github.com/sonm-io/core/proto"
 	"github.com/spf13/cobra"
 )
 
 var workerTasksCmd = &cobra.Command{
-	Use:    "tasks",
-	Short:  "Show tasks running on Worker",
-	PreRun: loadKeyStoreIfRequired,
-	Run: func(cmd *cobra.Command, args []string) {
+	Use:   "tasks",
+	Short: "Show tasks running on Worker",
+	RunE: func(cmd *cobra.Command, args []string) error {
 		list, err := worker.Tasks(workerCtx, &pb.Empty{})
 		if err != nil {
-			showError(cmd, "Cannot get task list", err)
-			os.Exit(1)
+			return fmt.Errorf("cannot get task list: %v", err)
 		}
 
 		printNodeTaskStatus(cmd, list.GetInfo())
+		return nil
 	},
 }

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/sonm-io/core/cmd/cli/commands"
 	"github.com/sonm-io/core/cmd/cli/config"
@@ -16,5 +17,9 @@ func main() {
 		return
 	}
 
-	commands.Root(appVersion, cfg).Execute()
+	cmd := commands.Root(appVersion, cfg)
+	if err := cmd.Execute(); err != nil {
+		commands.ShowError(cmd, err.Error(), nil)
+		os.Exit(1)
+	}
 }


### PR DESCRIPTION
This commit changes CLI behavior in the following way:
1. Using RunE instead of Run for each cobra command.
2. Setting SilenceUsage = true, if not - cli will print help usage on every error.
3. Setting SilenceErrors = true, if not - cli will show their own error and then handle out custom code that controls the os.Exit status.
4. Introducing `newCmd` and `newCmdWithKeys` wrappers. The first one is used to wrapping cobra.Command with `SilenceUsage` and  `SilenceErrors` flags. The second one is used to wrapping command with the key loading code (if required and not handled externally).
5. Removed all of `os.Exit(1)` calls, excepts only one that handles single point of error handling now.