### PR TITLE
fix: handle temporary network errors in Relay

### DIFF
--- a/cmd/common.go
+++ b/cmd/common.go
@@ -1,13 +1,18 @@
 package cmd
 
 import (
+	"context"
 	"os"
 	"os/signal"
 	"syscall"
 )
 
-func WaitInterrupted() {
+func WaitInterrupted(ctx context.Context) {
 	sigChan := make(chan os.Signal, 1)
 	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
-	<-sigChan
+
+	select {
+	case <-sigChan:
+	case <-ctx.Done():
+	}
 }

--- a/cmd/relay/main.go
+++ b/cmd/relay/main.go
@@ -8,6 +8,7 @@ import (
 	"github.com/sonm-io/core/cmd"
 	"github.com/sonm-io/core/insonmnia/logging"
 	"github.com/sonm-io/core/insonmnia/npp/relay"
+	"golang.org/x/sync/errgroup"
 )
 
 var (
@@ -32,10 +33,23 @@ func start() error {
 		return fmt.Errorf("failed to construct a Relay server: %s", err)
 	}
 
-	go server.Serve()
-	defer server.Close()
+	wg, ctx := errgroup.WithContext(ctx)
+	wg.Go(func() error {
+		return server.Serve(ctx)
+	})
 
-	cmd.WaitInterrupted()
+	// Passing the context tells about server shutdown if so.
+	//
+	// There are two possible cases here:
+	// - User interrupts the server - then server is closed explicitly and
+	// 	 everything inside is cleared.
+	// - Server stops for some reason - then the context is notified about this
+	//	 forcing interruption handler to return.
+	cmd.WaitInterrupted(ctx)
+
+	server.Close()
+	wg.Wait()
+
 	return nil
 }
 

--- a/insonmnia/npp/relay/net.go
+++ b/insonmnia/npp/relay/net.go
@@ -1,0 +1,44 @@
+package relay
+
+import (
+	"net"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+const (
+	minSleepInterval = 5 * time.Millisecond
+	maxSleepInterval = 1 * time.Second
+	sleepMultiplier  = 2
+)
+
+type BackPressureListener struct {
+	net.Listener
+
+	Log *zap.Logger
+}
+
+func (m *BackPressureListener) Accept() (net.Conn, error) {
+	interval := minSleepInterval
+
+	for {
+		conn, err := m.Listener.Accept()
+		if err == nil {
+			return conn, nil
+		}
+
+		if netError, ok := err.(net.Error); ok && netError.Temporary() {
+			if max := maxSleepInterval; interval > max {
+				interval = max
+			}
+
+			m.Log.Warn("failed to accept connection", zap.Error(netError), zap.Duration("sleep", interval))
+			time.Sleep(interval)
+
+			interval *= sleepMultiplier
+		} else {
+			return nil, err
+		}
+	}
+}

--- a/insonmnia/npp/relay/server.go
+++ b/insonmnia/npp/relay/server.go
@@ -303,7 +303,7 @@ func NewServer(cfg ServerConfig, options ...Option) (*server, error) {
 		cfg: cfg,
 
 		port:     port,
-		listener: listener,
+		listener: &BackPressureListener{listener, opts.log},
 		cluster:  nil,
 		members:  cfg.Cluster.Members,
 
@@ -376,15 +376,25 @@ func (m *server) initCluster(cfg ClusterConfig) error {
 }
 
 // Serve starts the relay TCP server.
-func (m *server) Serve() error {
-	wg := errgroup.Group{}
-	wg.Go(m.serveTCP)
-	wg.Go(m.serveGRPC)
+func (m *server) Serve(ctx context.Context) error {
+	wg, ctx := errgroup.WithContext(ctx)
+	wg.Go(func() error {
+		return m.serveTCP(ctx)
+	})
+	wg.Go(func() error {
+		// GRPC API doesn't allow to forward the context. Hence the server
+		// must be stopped explicitly.
+		return m.serveGRPC()
+	})
+
+	if <-ctx.Done(); ctx.Err() != nil {
+		m.Close()
+	}
 
 	return wg.Wait()
 }
 
-func (m *server) serveTCP() error {
+func (m *server) serveTCP(ctx context.Context) error {
 	m.log.Infof("running Relay server on %s", m.listener.Addr())
 	defer m.log.Info("Relay server has been stopped")
 
@@ -395,12 +405,13 @@ func (m *server) serveTCP() error {
 
 	m.log.Infof("joined the cluster of %d nodes", nodes)
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
 	for {
 		conn, err := m.listener.Accept()
 		if err != nil {
+			m.log.Warnf("failed to accept connection: %v", err)
 			return err
 		}
 


### PR DESCRIPTION
This fixes a bug when Relay server finished accepting new connections when a temporary error occurs, such as EMFILE.
Now it will sleep for some period of time, but still interrupting on non-recoverable error.

Also the entire server now will stop on such non-recoverable errors instead of waiting for interruption signal.