### PR TITLE
feat: let cli read it's config from --config flag

### DIFF
--- a/cmd/cli/commands/common.go
+++ b/cmd/cli/commands/common.go
@@ -44,6 +44,7 @@ var (
 	timeoutFlag     = 60 * time.Second
 	insecureFlag    bool
 	keystoreFlag    string
+	configFlag      string
 
 	// logging flag vars
 	logType       string
@@ -55,7 +56,7 @@ var (
 	prependStream bool
 
 	// session-related vars
-	cfg      *config.Config
+	cfg      = &config.Config{}
 	creds    credentials.TransportCredentials
 	keystore *accounts.MultiKeystore
 )
@@ -83,20 +84,29 @@ func getDefaultKey() (*ecdsa.PrivateKey, error) {
 }
 
 func init() {
+	cobra.OnInitialize(func() {
+		var err error
+		cfg, err = config.NewConfig(configFlag)
+		if err != nil {
+			fmt.Printf("Cannot load config: %s\r\n", err)
+			os.Exit(1)
+		}
+	})
+
 	rootCmd.PersistentFlags().StringVar(&nodeAddressFlag, "node", "localhost:15030", "node endpoint")
 	rootCmd.PersistentFlags().DurationVar(&timeoutFlag, "timeout", 60*time.Second, "Connection timeout")
 	rootCmd.PersistentFlags().StringVar(&outputModeFlag, "out", "", "Output mode: simple or json")
 	rootCmd.PersistentFlags().BoolVar(&insecureFlag, "insecure", false, "Disable TLS for connection")
 	rootCmd.PersistentFlags().StringVar(&keystoreFlag, "keystore", "", "Keystore dir")
+	rootCmd.PersistentFlags().StringVar(&configFlag, "config", "", "Configuration file")
 
 	rootCmd.AddCommand(workerMgmtCmd, orderRootCmd, dealRootCmd, taskRootCmd, blacklistRootCmd)
 	rootCmd.AddCommand(loginCmd, tokenRootCmd, versionCmd, autoCompleteCmd, masterRootCmd, profileRootCmd)
 }
 
 // Root configure and return root command
-func Root(appVersion string, c *config.Config) *cobra.Command {
+func Root(appVersion string) *cobra.Command {
 	version = appVersion
-	cfg = c
 
 	rootCmd.SetOutput(os.Stdout)
 	return rootCmd

--- a/cmd/cli/commands/err_test.go
+++ b/cmd/cli/commands/err_test.go
@@ -43,21 +43,24 @@ func TestJsonErrorCustom(t *testing.T) {
 }
 
 func TestShowErrorNilErr(t *testing.T) {
-	buf := initRootCmd(t, "1.2.3", config.OutputModeSimple)
+	cfg = &config.Config{OutFormat: config.OutputModeSimple}
+	buf := initRootCmd(t, "1.2.3")
 	ShowError(rootCmd, "test error", nil)
 	out := buf.String()
 	assert.Equal(t, "[ERR] test error\r\n", out)
 }
 
 func TestShowErrorWithErr(t *testing.T) {
-	buf := initRootCmd(t, "1.2.3", config.OutputModeSimple)
+	cfg = &config.Config{OutFormat: config.OutputModeSimple}
+	buf := initRootCmd(t, "1.2.3")
 	ShowError(rootCmd, "test error", errors.New("internal"))
 	out := buf.String()
 	assert.Equal(t, "[ERR] test error: internal\r\n", out)
 }
 
 func TestShowErrorJsonNilErr(t *testing.T) {
-	buf := initRootCmd(t, "1.2.3", config.OutputModeJSON)
+	cfg = &config.Config{OutFormat: config.OutputModeJSON}
+	buf := initRootCmd(t, "1.2.3")
 	ShowError(rootCmd, "test error", nil)
 	out := buf.String()
 
@@ -68,7 +71,8 @@ func TestShowErrorJsonNilErr(t *testing.T) {
 }
 
 func TestShowErrorJsonWithErr(t *testing.T) {
-	buf := initRootCmd(t, "1.2.3", config.OutputModeJSON)
+	cfg = &config.Config{OutFormat: config.OutputModeJSON}
+	buf := initRootCmd(t, "1.2.3")
 	ShowError(rootCmd, "test error", errors.New("reason"))
 	out := buf.String()
 

--- a/cmd/cli/commands/printers_test.go
+++ b/cmd/cli/commands/printers_test.go
@@ -14,7 +14,8 @@ import (
 )
 
 func TestJsonOutputForOrder(t *testing.T) {
-	buf := initRootCmd(t, "", config.OutputModeJSON)
+	cfg = &config.Config{OutFormat: config.OutputModeJSON}
+	buf := initRootCmd(t, "")
 
 	bigVal, _ := pb.NewBigIntFromString("1000000000000000000000000000")
 	printOrdersList(rootCmd, []*pb.Order{{
@@ -58,8 +59,8 @@ func TestDealInfoWithZeroDuration(t *testing.T) {
 		TotalPayout: pb.NewBigIntFromInt(5),
 	}
 
-	buf := initRootCmd(t, "", config.OutputModeSimple)
-	cfg = &config.Config{Eth: accounts.EthConfig{Passphrase: "test"}}
+	cfg = &config.Config{OutFormat: config.OutputModeSimple, Eth: accounts.EthConfig{Passphrase: "test"}}
+	buf := initRootCmd(t, "")
 
 	printDealInfo(rootCmd, &pb.DealInfoReply{Deal: deal}, nil, suppressWarnings)
 

--- a/cmd/cli/commands/version_test.go
+++ b/cmd/cli/commands/version_test.go
@@ -9,14 +9,10 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func initRootCmd(t *testing.T, ver, outFormat string) *bytes.Buffer {
+func initRootCmd(t *testing.T, ver string) *bytes.Buffer {
 	buf := new(bytes.Buffer)
 
-	cfg := &config.Config{
-		OutFormat: outFormat,
-	}
-
-	Root(ver, cfg)
+	Root(ver)
 
 	rootCmd.ResetCommands()
 	rootCmd.ResetFlags()
@@ -27,7 +23,8 @@ func initRootCmd(t *testing.T, ver, outFormat string) *bytes.Buffer {
 }
 
 func TestGetVersionCmdSimple(t *testing.T) {
-	buf := initRootCmd(t, "1.2.3", config.OutputModeSimple)
+	cfg = &config.Config{OutFormat: config.OutputModeSimple}
+	buf := initRootCmd(t, "1.2.3")
 
 	printVersion(rootCmd, version)
 	out := buf.String()
@@ -35,7 +32,8 @@ func TestGetVersionCmdSimple(t *testing.T) {
 }
 
 func TestGetVersionCmdJson(t *testing.T) {
-	buf := initRootCmd(t, "1.2.3", config.OutputModeJSON)
+	cfg = &config.Config{OutFormat: config.OutputModeJSON}
+	buf := initRootCmd(t, "1.2.3")
 
 	printVersion(rootCmd, version)
 

--- a/cmd/cli/config/config.go
+++ b/cmd/cli/config/config.go
@@ -103,6 +103,9 @@ func getConfigPath(p ...string) (string, error) {
 		}
 	}
 
-	cfgPath = path.Join(cfgPath, configName)
-	return cfgPath, nil
+	if util.FileExists(cfgPath) == nil {
+		return cfgPath, nil
+	}
+
+	return path.Join(cfgPath, configName), nil
 }

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -1,23 +1,15 @@
 package main
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/sonm-io/core/cmd/cli/commands"
-	"github.com/sonm-io/core/cmd/cli/config"
 )
 
 var appVersion string
 
 func main() {
-	cfg, err := config.NewConfig()
-	if err != nil {
-		fmt.Printf("Cannot load config: %s\r\n", err)
-		return
-	}
-
-	cmd := commands.Root(appVersion, cfg)
+	cmd := commands.Root(appVersion)
 	if err := cmd.Execute(); err != nil {
 		commands.ShowError(cmd, err.Error(), nil)
 		os.Exit(1)


### PR DESCRIPTION
Might be useful for debugging when we have two or more nodes on one host, so we don't have to re-login all the time, can specify node addreses in config etc.