### PR TITLE
chore: dwh startup refactoring

### DIFF
--- a/etc/dwh.yaml
+++ b/etc/dwh.yaml
@@ -18,11 +18,6 @@ blockchain:
   contract_registry: "0xaf1ffd7f652be7e9a0854a42b2d3046f853f80f1"
   blocks_batch_size: 500000
 
-#blockchain:
-#  sidechain_endpoint: https://sidechain.livenet.sonm.com/
-#  contract_registry: 0xd1a6f3d1ae33b4b19565a6b283d7a05c5a0decb0
-#  blocks_batch_size: 500000
-
 logging:
   # The desired logging level.
   # Allowed values are "debug", "info", "warn", "error", "panic" and "fatal"

--- a/etc/dwh.yaml
+++ b/etc/dwh.yaml
@@ -15,9 +15,13 @@ ethereum:
 blockchain:
   endpoint: "https://rinkeby.infura.io/00iTrs5PIy0uGODwcsrb"
   sidechain_endpoint: "http://localhost:8545"
-  #  sidechain_endpoint: "https://sidechain-dev.sonm.com"
   contract_registry: "0xaf1ffd7f652be7e9a0854a42b2d3046f853f80f1"
   blocks_batch_size: 500000
+
+#blockchain:
+#  sidechain_endpoint: https://sidechain.livenet.sonm.com/
+#  contract_registry: 0xd1a6f3d1ae33b4b19565a6b283d7a05c5a0decb0
+#  blocks_batch_size: 500000
 
 logging:
   # The desired logging level.

--- a/insonmnia/dwh/server.go
+++ b/insonmnia/dwh/server.go
@@ -93,10 +93,8 @@ func (m *DWH) Serve() error {
 	}
 
 	wg := errgroup.Group{}
-	m.mu.Lock()
 	wg.Go(m.serveGRPC)
 	wg.Go(m.serveHTTP)
-	m.mu.Unlock()
 
 	return wg.Wait()
 }

--- a/insonmnia/dwh/server.go
+++ b/insonmnia/dwh/server.go
@@ -183,7 +183,7 @@ func (m *DWH) serveHTTP() error {
 		m.mu.Lock()
 		defer m.mu.Unlock()
 
-		options := []rest.Option{rest.WithContext(m.ctx)}
+		options := []rest.Option{rest.WithLog(m.logger)}
 		lis, err := net.Listen("tcp", m.cfg.HTTPListenAddr)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create http listener: %v", err)


### PR DESCRIPTION
prettify locks for `serveGRPC()` and `serveHttp()`.

notice: locking these sections is required to properly handle interrupts while startup.