### PR TITLE
feat: blacklist support in Optimus

### DIFF
--- a/optimus/blacklist.go
+++ b/optimus/blacklist.go
@@ -1,0 +1,57 @@
+package optimus
+
+import (
+	"context"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/sonm-io/core/proto"
+	"go.uber.org/zap"
+)
+
+// Blacklist is a thing that can be asked to determine whether a specific ETH
+// address is in the "owner" blacklist and vise-verse.
+// This is used to be sure that the order created via Optimus can be bought
+// by the user this order was created for.
+type blacklist struct {
+	owner     common.Address
+	blacklist map[common.Address]struct{}
+	dwh       sonm.DWHClient
+	log       *zap.SugaredLogger
+}
+
+func newBlacklist(owner common.Address, dwh sonm.DWHClient, log *zap.SugaredLogger) *blacklist {
+	return &blacklist{
+		owner:     owner,
+		blacklist: map[common.Address]struct{}{},
+		dwh:       dwh,
+		log:       log,
+	}
+}
+
+// IsAllowed checks whether the given "addr" is allowed for this blacklist.
+// This method returns true both if an "owner" is in the "addr" blacklist
+// and vice-versa.
+// The blacklist needs to be updated before calling this method.
+func (m *blacklist) IsAllowed(addr common.Address) bool {
+	_, ok := m.blacklist[addr]
+	return !ok
+}
+
+func (m *blacklist) Update(ctx context.Context) error {
+	m.log.Debug("updating blacklist")
+	defer m.log.Infow("blacklist has been updated", zap.Any("blacklist", m.blacklist))
+
+	blacklist, err := m.dwh.GetBlacklistsContainingUser(ctx, &sonm.BlacklistRequest{
+		UserID: sonm.NewEthAddress(m.owner),
+	})
+	if err != nil {
+		return err
+	}
+
+	m.blacklist = map[common.Address]struct{}{}
+	for _, addr := range blacklist.Blacklists {
+		m.blacklist[addr.Unwrap()] = struct{}{}
+	}
+
+	return nil
+}

--- a/optimus/blacklist.go
+++ b/optimus/blacklist.go
@@ -39,7 +39,6 @@ func (m *blacklist) IsAllowed(addr common.Address) bool {
 
 func (m *blacklist) Update(ctx context.Context) error {
 	m.log.Debug("updating blacklist")
-	defer m.log.Infow("blacklist has been updated", zap.Any("blacklist", m.blacklist))
 
 	blacklist, err := m.dwh.GetBlacklistsContainingUser(ctx, &sonm.BlacklistRequest{
 		UserID: sonm.NewEthAddress(m.owner),
@@ -52,6 +51,8 @@ func (m *blacklist) Update(ctx context.Context) error {
 	for _, addr := range blacklist.Blacklists {
 		m.blacklist[addr.Unwrap()] = struct{}{}
 	}
+
+	m.log.Infow("blacklist has been updated", zap.Any("blacklist", m.blacklist))
 
 	return nil
 }

--- a/optimus/engine.go
+++ b/optimus/engine.go
@@ -88,13 +88,18 @@ func (m *optimizationInput) freeDevices(removalVictims map[string]*sonm.AskPlan)
 	return freeWorkerHardware.IntoProto(), nil
 }
 
+type Blacklist interface {
+	Update(ctx context.Context) error
+	IsAllowed(addr common.Address) bool
+}
+
 type workerEngine struct {
 	cfg workerConfig
 	log *zap.SugaredLogger
 
 	addr             common.Address
 	masterAddr       common.Address
-	blacklist        *blacklist
+	blacklist        Blacklist
 	market           blockchain.MarketAPI
 	marketCache      *MarketCache
 	worker           WorkerManagementClientExt
@@ -103,7 +108,7 @@ type workerEngine struct {
 	optimizationConfig optimizationConfig
 }
 
-func newWorkerEngine(cfg workerConfig, addr, masterAddr common.Address, blacklist *blacklist, worker sonm.WorkerManagementClient, market blockchain.MarketAPI, marketCache *MarketCache, benchmarkMapping benchmarks.Mapping, optimizationConfig optimizationConfig, log *zap.SugaredLogger) (*workerEngine, error) {
+func newWorkerEngine(cfg workerConfig, addr, masterAddr common.Address, blacklist Blacklist, worker sonm.WorkerManagementClient, market blockchain.MarketAPI, marketCache *MarketCache, benchmarkMapping benchmarks.Mapping, optimizationConfig optimizationConfig, log *zap.SugaredLogger) (*workerEngine, error) {
 	m := &workerEngine{
 		cfg: cfg,
 		log: log.With(zap.Stringer("addr", addr)),
@@ -145,6 +150,10 @@ func (m *workerEngine) execute(ctx context.Context) error {
 	}
 	if time.Since(maintenance.Unix()) >= 0 {
 		return fmt.Errorf("worker is on the maintenance")
+	}
+
+	if err := m.blacklist.Update(ctx); err != nil {
+		return fmt.Errorf("failed to update blacklist: %v", err)
 	}
 
 	input, err := m.optimizationInput(ctx)

--- a/optimus/optimus.go
+++ b/optimus/optimus.go
@@ -64,12 +64,15 @@ func (m *Optimus) Run(ctx context.Context) error {
 			return err
 		}
 
+		blacklist := newMultiBlacklist(
+			newBlacklist(ethAddr, dwh, m.log),
+			newBlacklist(masterAddr, dwh, m.log),
+		)
+
 		worker, err := registry.NewWorkerManagement(ctx, m.cfg.Node.Endpoint, m.cfg.Node.PrivateKey.Unwrap())
 		if err != nil {
 			return err
 		}
-
-		blacklist := newBlacklist(ethAddr, dwh, m.log)
 
 		control, err := newWorkerEngine(cfg, ethAddr, masterAddr, blacklist, worker, market.Market(), marketCache, benchmarkMapping, m.cfg.Optimization, m.log)
 		if err != nil {

--- a/optimus/optimus.go
+++ b/optimus/optimus.go
@@ -69,7 +69,9 @@ func (m *Optimus) Run(ctx context.Context) error {
 			return err
 		}
 
-		control, err := newWorkerEngine(cfg, ethAddr, masterAddr, worker, market.Market(), marketCache, benchmarkMapping, m.cfg.Optimization, m.log)
+		blacklist := newBlacklist(ethAddr, dwh, m.log)
+
+		control, err := newWorkerEngine(cfg, ethAddr, masterAddr, blacklist, worker, market.Market(), marketCache, benchmarkMapping, m.cfg.Optimization, m.log)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
This change activetes blacklists support in Optimus. Now orders whose author is in worker's blacklist are now filtered out. The same thing happens at the opposite: when worker's address is in the order's blacklist.