### PR TITLE
fix: spurious continuum devastation

### DIFF
--- a/insonmnia/npp/relay/errors.go
+++ b/insonmnia/npp/relay/errors.go
@@ -12,6 +12,7 @@ const (
 	ErrTimeout
 	ErrNoPeer
 	ErrWrongNode
+	ErrEmptyContinuum
 )
 
 type protocolError struct {
@@ -48,4 +49,8 @@ func errNoPeer() error {
 
 func errWrongNode() error {
 	return newProtocolError(ErrWrongNode, fmt.Errorf("peer connected to wrong node"))
+}
+
+func errEmptyContinuum() error {
+	return newProtocolError(ErrEmptyContinuum, fmt.Errorf("no nodes in the continuum"))
 }

--- a/insonmnia/npp/relay/hashring.go
+++ b/insonmnia/npp/relay/hashring.go
@@ -133,14 +133,22 @@ func newNode(name, addr string) *Node {
 }
 
 func ParseNode(node string) (*Node, error) {
-	parts := strings.SplitN(node, "@", 2)
-	if len(parts) != 2 {
+	idx := strings.LastIndex(node, "@")
+	if idx < 0 {
 		return nil, fmt.Errorf("continuum node must be in `<name>@<addr>` format")
 	}
 
+	name, addr := node[:idx], node[idx+1:]
+	if len(name) == 0 {
+		return nil, fmt.Errorf("node name is empty")
+	}
+	if len(addr) == 0 {
+		return nil, fmt.Errorf("node address is empty")
+	}
+
 	m := &Node{
-		Name: parts[0],
-		Addr: parts[1],
+		Name: name,
+		Addr: addr,
 	}
 
 	return m, nil

--- a/insonmnia/npp/relay/hashring.go
+++ b/insonmnia/npp/relay/hashring.go
@@ -125,20 +125,7 @@ type Node struct {
 	Addr string
 }
 
-func newNode(name, addr string) *Node {
-	return &Node{
-		Name: name,
-		Addr: addr,
-	}
-}
-
-func ParseNode(node string) (*Node, error) {
-	idx := strings.LastIndex(node, "@")
-	if idx < 0 {
-		return nil, fmt.Errorf("continuum node must be in `<name>@<addr>` format")
-	}
-
-	name, addr := node[:idx], node[idx+1:]
+func newNode(name, addr string) (*Node, error) {
 	if len(name) == 0 {
 		return nil, fmt.Errorf("node name is empty")
 	}
@@ -152,6 +139,17 @@ func ParseNode(node string) (*Node, error) {
 	}
 
 	return m, nil
+}
+
+func ParseNode(node string) (*Node, error) {
+	idx := strings.LastIndex(node, "@")
+	if idx < 0 {
+		return nil, fmt.Errorf("continuum node must be in `<name>@<addr>` format")
+	}
+
+	name, addr := node[:idx], node[idx+1:]
+
+	return newNode(name, addr)
 }
 
 func (m *Node) String() string {

--- a/insonmnia/npp/relay/hashring_test.go
+++ b/insonmnia/npp/relay/hashring_test.go
@@ -1,0 +1,48 @@
+package relay
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseEmptyNode(t *testing.T) {
+	node, err := ParseNode("")
+	assert.Error(t, err)
+	assert.Nil(t, node)
+}
+
+func TestParseNode(t *testing.T) {
+	node, err := ParseNode("uuid@127.0.0.1")
+	require.NoError(t, err)
+	require.NotNil(t, node)
+
+	assert.Equal(t, &Node{Name: "uuid", Addr: "127.0.0.1"}, node)
+}
+
+func TestParseNodeEmptyName(t *testing.T) {
+	node, err := ParseNode("@127.0.0.1")
+	assert.Error(t, err)
+	assert.Nil(t, node)
+}
+
+func TestParseNodeEmptyAddr(t *testing.T) {
+	node, err := ParseNode("uuid@")
+	assert.Error(t, err)
+	assert.Nil(t, node)
+}
+
+func TestParseNodeNoSeparator(t *testing.T) {
+	node, err := ParseNode("uuid")
+	assert.Error(t, err)
+	assert.Nil(t, node)
+}
+
+func TestParseNodeSuchMuchSeparator(t *testing.T) {
+	node, err := ParseNode("sonm@what@127.0.0.1")
+	require.NoError(t, err)
+	require.NotNil(t, node)
+
+	assert.Equal(t, &Node{Name: "sonm@what", Addr: "127.0.0.1"}, node)
+}

--- a/insonmnia/npp/relay/server.go
+++ b/insonmnia/npp/relay/server.go
@@ -606,6 +606,7 @@ func (m *server) NotifyJoin(node *memberlist.Node) {
 	continuumNode, err := newNode(node.Name, m.formatEndpoint(node.Addr))
 	if err != nil {
 		m.log.Warnf("received malformed node join notification: %v", err)
+		return
 	}
 
 	discarded := m.continuum.Add(continuumNode.String(), 1)
@@ -618,6 +619,7 @@ func (m *server) NotifyLeave(node *memberlist.Node) {
 	continuumNode, err := newNode(node.Name, m.formatEndpoint(node.Addr))
 	if err != nil {
 		m.log.Warnf("received malformed node leave notification: %v", err)
+		return
 	}
 
 	discarded := m.continuum.Remove(continuumNode.String())


### PR DESCRIPTION
This fixes a bug in the Relay server, when it suddenly devastates the continuum, returning 0.0.0.0 on any discovery request.

Also it fixes a bug introduced in #1046, when an inproperly configured node stopped to work.