### PR TITLE
fix: assign created timestamp for worker's own orders

### DIFF
--- a/optimus/engine.go
+++ b/optimus/engine.go
@@ -402,7 +402,8 @@ func (m *workerEngine) ordersForPlans(ctx context.Context, plans map[string]*son
 			mu.Lock()
 			defer mu.Unlock()
 			orders = append(orders, &MarketOrder{
-				Order: order,
+				Order:     order,
+				CreatedTS: sonm.CurrentTimestamp(),
 			})
 
 			return nil


### PR DESCRIPTION
Otherwise they will have 0 weigth and will be replaced at every opportunity.