### PR TITLE
fix: handle tasks correctly in case of worker reload

### DIFF
--- a/insonmnia/worker/container.go
+++ b/insonmnia/worker/container.go
@@ -30,7 +30,7 @@ type containerDescriptor struct {
 	cleanup plugin.Cleanup
 }
 
-func attContainer(ctx context.Context, dockerClient *client.Client, d Description, tuners *plugin.Repository) (*containerDescriptor, error) {
+func attachContainer(ctx context.Context, dockerClient *client.Client, d Description, tuners *plugin.Repository) (*containerDescriptor, error) {
 	log.S(ctx).Infof("start container with application, reference %s", d.Reference)
 
 	cont := containerDescriptor{

--- a/insonmnia/worker/container.go
+++ b/insonmnia/worker/container.go
@@ -31,7 +31,7 @@ type containerDescriptor struct {
 }
 
 func attachContainer(ctx context.Context, dockerClient *client.Client, d Description, tuners *plugin.Repository) (*containerDescriptor, error) {
-	log.S(ctx).Infof("start container with application, reference %s", d.Reference)
+	log.S(ctx).Infof("start container with application, reference %s", d.Reference.String())
 
 	cont := containerDescriptor{
 		client:      dockerClient,
@@ -75,7 +75,7 @@ func attachContainer(ctx context.Context, dockerClient *client.Client, d Descrip
 }
 
 func newContainer(ctx context.Context, dockerClient *client.Client, d Description, tuners *plugin.Repository) (*containerDescriptor, error) {
-	log.S(ctx).Infof("start container with application, reference %s", d.Reference)
+	log.S(ctx).Infof("start container with application, reference %s", d.Reference.String())
 
 	cont := containerDescriptor{
 		client:      dockerClient,
@@ -98,7 +98,7 @@ func newContainer(ctx context.Context, dockerClient *client.Client, d Descriptio
 
 		ExposedPorts: exposedPorts,
 
-		Image: d.Reference,
+		Image: d.Reference.String(),
 		// TODO: set actual name
 		Labels:  map[string]string{overseerTag: "", dealIDTag: d.DealId},
 		Env:     d.FormatEnv(),
@@ -263,14 +263,11 @@ func (c *containerDescriptor) upload(ctx context.Context) error {
 	}
 	tag := fmt.Sprintf("%s_%s", c.description.DealId, c.description.TaskId)
 
-	ref, err := reference.ParseAnyReference(c.description.Reference)
-	if err != nil {
-		return fmt.Errorf("failed to parse reference: %s", err)
-	}
+	ref := c.description.Reference
 	if _, ok := ref.(reference.Named); !ok {
 		return errors.New("can not upload image without name")
 	}
-	newImg, err := reference.WithTag(reference.TrimNamed(ref.(reference.Named)), tag)
+	newImg, err := reference.WithTag(reference.TrimNamed(c.description.Reference.(reference.Named)), tag)
 	if err != nil {
 		c.log.Errorf("failed to add tag: %s", err)
 		return err

--- a/insonmnia/worker/container.go
+++ b/insonmnia/worker/container.go
@@ -90,7 +90,7 @@ func newContainer(ctx context.Context, dockerClient *client.Client, d Descriptio
 		PublishAllPorts: true,
 		PortBindings:    portBindings,
 		RestartPolicy:   d.RestartPolicy.Unwrap(),
-		AutoRemove:      d.autoremove,
+		AutoRemove:      d.Autoremove,
 		Resources:       d.Resources.ToHostConfigResources(d.CGroupParent),
 	}
 

--- a/insonmnia/worker/network/l2tp_tuner.go
+++ b/insonmnia/worker/network/l2tp_tuner.go
@@ -145,6 +145,19 @@ func (t *L2TPTuner) Tune(ctx context.Context, net *structs.NetworkSpec, hostCfg 
 	}, nil
 }
 
+func (t *L2TPTuner) GetCleaner(ctx context.Context, ID string) (Cleanup, error) {
+	if _, ok := t.netDriver.Networks[ID]; !ok {
+		return nil, errors.New("failed to find network with id " + ID)
+	}
+	configPath := t.cfg.ConfigDir + "/" + ID
+	return &L2TPCleaner{
+		ctx:        ctx,
+		cli:        t.cli,
+		networkID:  ID,
+		configPath: configPath,
+	}, nil
+}
+
 func (t *L2TPTuner) writeConfig(netID string, opts map[string]string) (string, error) {
 	var data string
 	for k, v := range opts {

--- a/insonmnia/worker/network/tinc_tuner.go
+++ b/insonmnia/worker/network/tinc_tuner.go
@@ -145,14 +145,14 @@ func (t *TincTuner) Tune(ctx context.Context, net *structs.NetworkSpec, hostConf
 	}, nil
 }
 
-func (t *TincTuner) GetCleaner(ctx context.Context, netID string) (Cleanup, error) {
-	if _, ok := t.netDriver.Networks[netID]; !ok {
-		return nil, errors.New("network with id %s not found " + netID)
+func (t *TincTuner) GetCleaner(ctx context.Context, ID string) (Cleanup, error) {
+	if _, ok := t.netDriver.Networks[ID]; !ok {
+		return nil, errors.New("failed to find network with id " + ID)
 	}
 	return &TincCleaner{
 		ctx:       ctx,
 		client:    t.client,
-		networkID: netID,
+		networkID: ID,
 	}, nil
 }
 

--- a/insonmnia/worker/network/tinc_tuner.go
+++ b/insonmnia/worker/network/tinc_tuner.go
@@ -2,6 +2,7 @@ package network
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"syscall"
@@ -141,6 +142,17 @@ func (t *TincTuner) Tune(ctx context.Context, net *structs.NetworkSpec, hostConf
 		ctx:       ctx,
 		client:    t.client,
 		networkID: response.ID,
+	}, nil
+}
+
+func (t *TincTuner) GetCleaner(ctx context.Context, netID string) (Cleanup, error) {
+	if _, ok := t.netDriver.Networks[netID]; !ok {
+		return nil, errors.New("network with id %s not found " + netID)
+	}
+	return &TincCleaner{
+		ctx:       ctx,
+		client:    t.client,
+		networkID: netID,
 	}, nil
 }
 

--- a/insonmnia/worker/network/tuner.go
+++ b/insonmnia/worker/network/tuner.go
@@ -17,5 +17,6 @@ type Cleanup interface {
 type Tuner interface {
 	Tune(ctx context.Context, net *structs.NetworkSpec, hostConfig *container.HostConfig, netConfig *network.NetworkingConfig) (Cleanup, error)
 	GenerateInvitation(ID string) (*structs.NetworkSpec, error)
+	GetCleaner(ctx context.Context, ID string) (Cleanup, error)
 	Tuned(ID string) bool
 }

--- a/insonmnia/worker/overseer.go
+++ b/insonmnia/worker/overseer.go
@@ -128,7 +128,7 @@ type ContainerInfo struct {
 	NetworkIDs   []string
 	DealID       string
 	Tag          string
-	TaskID       string
+	TaskId       string
 	AskID        string
 }
 

--- a/insonmnia/worker/overseer.go
+++ b/insonmnia/worker/overseer.go
@@ -586,7 +586,7 @@ func (o *overseer) Start(ctx context.Context, description Description) (status c
 		Cgroup:       string(cjson.HostConfig.Cgroup),
 		CgroupParent: string(cjson.HostConfig.CgroupParent),
 		NetworkIDs:   networkIDs,
-		TaskId:       description.TaskId,
+		TaskID:       description.TaskId,
 	}
 
 	return status, cinfo, nil

--- a/insonmnia/worker/overseer.go
+++ b/insonmnia/worker/overseer.go
@@ -568,7 +568,7 @@ func (o *overseer) Start(ctx context.Context, description Description) (status c
 		Cgroup:       string(cjson.HostConfig.Cgroup),
 		CgroupParent: string(cjson.HostConfig.CgroupParent),
 		NetworkIDs:   networkIDs,
-		TaskID:       description.TaskId,
+		TaskId:       description.TaskId,
 	}
 
 	return status, cinfo, nil

--- a/insonmnia/worker/overseer.go
+++ b/insonmnia/worker/overseer.go
@@ -57,15 +57,15 @@ type descriptionAlias Description
 
 type descriptionMarshaller struct {
 	*descriptionAlias
-	Reference string `json:"Reference"`
-	Networks  []*structs.NetworkSpec
+	Networks []*structs.NetworkSpec
+	RefField reference.Field `json:"Reference"`
 }
 
 func (d Description) MarshalJSON() ([]byte, error) {
 	b, err := json.Marshal(&descriptionMarshaller{
 		descriptionAlias: (*descriptionAlias)(&d),
-		Reference:        d.Reference.String(),
 		Networks:         d.networks,
+		RefField:         reference.AsField(d.Reference),
 	})
 
 	return b, err
@@ -77,12 +77,7 @@ func (d *Description) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	ref, err := reference.ParseAnyReference(aux.Reference)
-	if err != nil {
-		return err
-	}
-
-	d.Reference = ref
+	d.Reference = aux.RefField.Reference()
 	d.networks = aux.Networks
 	return nil
 }

--- a/insonmnia/worker/overseer.go
+++ b/insonmnia/worker/overseer.go
@@ -183,7 +183,7 @@ type Overseer interface {
 	Start(ctx context.Context, description Description) (chan pb.TaskStatusReply_Status, ContainerInfo, error)
 
 	// Attach attemps to attach to a running application with a specified description
-	Attach(ctx context.Context, ID string, client *client.Client, description Description) (chan pb.TaskStatusReply_Status, error)
+	Attach(ctx context.Context, ID string, description Description) (chan pb.TaskStatusReply_Status, error)
 
 	// Exec a given command in running container
 	Exec(ctx context.Context, Id string, cmd []string, env []string, isTty bool, wCh <-chan ssh.Window) (types.HijackedResponse, error)
@@ -474,7 +474,7 @@ func (o *overseer) Spool(ctx context.Context, d Description) error {
 	return nil
 }
 
-func (o *overseer) Attach(ctx context.Context, ID string, dockerClient *client.Client, d Description) (chan pb.TaskStatusReply_Status, error) {
+func (o *overseer) Attach(ctx context.Context, ID string, d Description) (chan pb.TaskStatusReply_Status, error) {
 	cont, err := attContainer(ctx, o.client, d, o.plugins)
 	if err != nil {
 		log.S(ctx).Debugf("failed to attach to container")

--- a/insonmnia/worker/overseer.go
+++ b/insonmnia/worker/overseer.go
@@ -475,7 +475,7 @@ func (o *overseer) Spool(ctx context.Context, d Description) error {
 }
 
 func (o *overseer) Attach(ctx context.Context, ID string, d Description) (chan pb.TaskStatusReply_Status, error) {
-	cont, err := attContainer(ctx, o.client, d, o.plugins)
+	cont, err := attachContainer(ctx, o.client, d, o.plugins)
 	if err != nil {
 		log.S(ctx).Debugf("failed to attach to container")
 		return nil, err

--- a/insonmnia/worker/overseer.go
+++ b/insonmnia/worker/overseer.go
@@ -538,7 +538,7 @@ func (o *overseer) Start(ctx context.Context, description Description) (status c
 		Cgroup:       string(cjson.HostConfig.Cgroup),
 		CgroupParent: string(cjson.HostConfig.CgroupParent),
 		NetworkIDs:   networkIDs,
-		TaskID:       description.TaskId,
+		TaskId:       description.TaskId,
 	}
 
 	return status, cinfo, nil

--- a/insonmnia/worker/overseer.go
+++ b/insonmnia/worker/overseer.go
@@ -56,11 +56,13 @@ func (d *Description) ID() string {
 func (d Description) MarshalJSON() ([]byte, error) {
 	type Alias Description
 	b, err := json.Marshal(&struct {
-		Reference string `json:"Reference"`
+		Reference  string `json:"Reference"`
+		Autoremove bool
 		Alias
 	}{
-		Reference: d.Reference.String(),
-		Alias:     (Alias)(d),
+		Reference:  d.Reference.String(),
+		Autoremove: d.autoremove,
+		Alias:      (Alias)(d),
 	})
 
 	return b, err
@@ -69,7 +71,8 @@ func (d Description) MarshalJSON() ([]byte, error) {
 func (d *Description) UnmarshalJSON(data []byte) error {
 	type Alias Description
 	aux := &struct {
-		Reference string `json:"Reference"`
+		Reference  string `json:"Reference"`
+		Autoremove bool
 		*Alias
 	}{
 		Alias: (*Alias)(d),
@@ -79,9 +82,12 @@ func (d *Description) UnmarshalJSON(data []byte) error {
 	}
 	ref, err := reference.ParseAnyReference(aux.Reference)
 
+	d.autoremove = aux.Autoremove
+
 	if err != nil {
 		return err
 	}
+
 	d.Reference = ref
 	return nil
 }

--- a/insonmnia/worker/overseer.go
+++ b/insonmnia/worker/overseer.go
@@ -538,7 +538,7 @@ func (o *overseer) Start(ctx context.Context, description Description) (status c
 		Cgroup:       string(cjson.HostConfig.Cgroup),
 		CgroupParent: string(cjson.HostConfig.CgroupParent),
 		NetworkIDs:   networkIDs,
-		TaskId:       description.TaskId,
+		TaskID:       description.TaskId,
 	}
 
 	return status, cinfo, nil

--- a/insonmnia/worker/overseer_test.go
+++ b/insonmnia/worker/overseer_test.go
@@ -27,11 +27,11 @@ func TestOvsSpool(t *testing.T) {
 
 	ref, err := reference.ParseNormalizedNamed("docker.io/alpine")
 	require.NoError(t, err, "failed to create Overseer")
-	err = ovs.Spool(ctx, Description{Reference: ref})
+	err = ovs.Spool(ctx, Description{Reference: ref.String()})
 	require.NoError(t, err, "failed to pull an image")
 
 	ref, err = reference.ParseNormalizedNamed("docker2.io/alpine")
-	err = ovs.Spool(ctx, Description{Reference: ref})
+	err = ovs.Spool(ctx, Description{Reference: ref.String()})
 	require.NotNil(t, err)
 }
 
@@ -112,7 +112,7 @@ func TestOvsSpawn(t *testing.T) {
 	require.NoError(t, err)
 	ref, err := reference.ParseNormalizedNamed("worker")
 	require.NoError(t, err)
-	ch, info, err := ovs.Start(ctx, Description{Reference: ref})
+	ch, info, err := ovs.Start(ctx, Description{Reference: ref.String()})
 	require.NoError(t, err)
 	cjson, err := cl.ContainerInspect(ctx, info.ID)
 	require.NoError(t, err)

--- a/insonmnia/worker/overseer_test.go
+++ b/insonmnia/worker/overseer_test.go
@@ -27,11 +27,11 @@ func TestOvsSpool(t *testing.T) {
 
 	ref, err := reference.ParseNormalizedNamed("docker.io/alpine")
 	require.NoError(t, err, "failed to create Overseer")
-	err = ovs.Spool(ctx, Description{Reference: ref.String()})
+	err = ovs.Spool(ctx, Description{Reference: ref})
 	require.NoError(t, err, "failed to pull an image")
 
 	ref, err = reference.ParseNormalizedNamed("docker2.io/alpine")
-	err = ovs.Spool(ctx, Description{Reference: ref.String()})
+	err = ovs.Spool(ctx, Description{Reference: ref})
 	require.NotNil(t, err)
 }
 
@@ -112,7 +112,7 @@ func TestOvsSpawn(t *testing.T) {
 	require.NoError(t, err)
 	ref, err := reference.ParseNormalizedNamed("worker")
 	require.NoError(t, err)
-	ch, info, err := ovs.Start(ctx, Description{Reference: ref.String()})
+	ch, info, err := ovs.Start(ctx, Description{Reference: ref})
 	require.NoError(t, err)
 	cjson, err := cl.ContainerInspect(ctx, info.ID)
 	require.NoError(t, err)
@@ -153,7 +153,7 @@ func TestOvsAttach(t *testing.T) {
 	require.NoError(t, err)
 	ref, err := reference.ParseNormalizedNamed("worker")
 	require.NoError(t, err)
-	_, info, err := ovs.Start(ctx, Description{Reference: ref.String()})
+	_, info, err := ovs.Start(ctx, Description{Reference: ref})
 	require.NoError(t, err)
 	cjson, err := cl.ContainerInspect(ctx, info.ID)
 	require.NoError(t, err)
@@ -166,7 +166,7 @@ func TestOvsAttach(t *testing.T) {
 
 	ovs2, err := NewOverseer(ctx, plugin.EmptyRepository())
 	require.NoError(t, err)
-	descr := Description{Reference: ref.String()}
+	descr := Description{Reference: ref}
 	ch, err := ovs2.Attach(ctx, info.ID, descr)
 	t.Logf("attached to container %s", info.ID)
 	require.NoError(t, err)

--- a/insonmnia/worker/plugin/plugin.go
+++ b/insonmnia/worker/plugin/plugin.go
@@ -318,12 +318,12 @@ func (r *Repository) GetNetworkCleaner(ctx context.Context, provider NetworkProv
 	cleanup := newNestedCleanup()
 
 	for _, net := range provider.Networks() {
-		tuner, ok := r.networkTuners[net.NetworkType()]
+		tuner, ok := r.networkTuners[net.Type]
 		if !ok {
 			cleanup.Close()
-			return nil, fmt.Errorf("network driver not supported: %s", net.NetworkType())
+			return nil, fmt.Errorf("network driver not supported: %s", net.Type)
 		}
-		c, err := tuner.GetCleaner(ctx, net.ID())
+		c, err := tuner.GetCleaner(ctx, net.NetID)
 		if err != nil {
 			cleanup.Close()
 			return nil, err

--- a/insonmnia/worker/server.go
+++ b/insonmnia/worker/server.go
@@ -363,7 +363,7 @@ func (m *Worker) cancelDealTasks(deal *pb.Deal) error {
 		if err := m.ovs.OnDealFinish(m.ctx, container.ID); err != nil {
 			result = multierror.Append(result, err)
 		}
-		if err := m.resources.OnDealFinish(container.TaskId); err != nil {
+		if err := m.resources.OnDealFinish(container.TaskID); err != nil {
 			result = multierror.Append(result, err)
 		}
 	}

--- a/insonmnia/worker/server.go
+++ b/insonmnia/worker/server.go
@@ -657,7 +657,7 @@ func (m *Worker) StartTask(ctx context.Context, request *pb.StartTaskRequest) (*
 
 	var d = Description{
 		Container:    *request.Spec.Container,
-		Reference:    reference.String(),
+		Reference:    reference,
 		Auth:         spec.Registry.Auth(),
 		CGroupParent: cgroup.Suffix(),
 		Resources:    spec.Resources,
@@ -1272,7 +1272,7 @@ func getDescriptionForBenchmark(b *pb.Benchmark) (Description, error) {
 		return Description{}, err
 	}
 	return Description{
-		Reference: reference.String(),
+		Reference: reference,
 		Container: pb.Container{Env: map[string]string{
 			bm.BenchIDEnvParamName: fmt.Sprintf("%d", b.GetID()),
 		}},

--- a/insonmnia/worker/server.go
+++ b/insonmnia/worker/server.go
@@ -962,15 +962,6 @@ func (m *Worker) setupRunningContainers() error {
 			}
 
 			m.containers[info.Cinfo.TaskId] = &info.Cinfo
-
-			networks, err := structs.NewNetworkSpecs(info.Spec.Container.Networks)
-
-			if err != nil {
-				return err
-			}
-
-			info.Description.networks = networks
-
 			mounts := make([]volume.Mount, 0)
 
 			for _, spec := range info.Spec.Container.Mounts {

--- a/insonmnia/worker/server.go
+++ b/insonmnia/worker/server.go
@@ -691,7 +691,7 @@ func (m *Worker) StartTask(ctx context.Context, request *pb.StartTaskRequest) (*
 	containerInfo.ImageName = reference.String()
 	containerInfo.DealID = dealID.Unwrap().String()
 	containerInfo.Tag = request.GetSpec().GetTag()
-	containerInfo.TaskID = taskID
+	containerInfo.TaskId = taskID
 	containerInfo.AskID = ask.ID
 
 	var reply = pb.StartTaskReply{

--- a/insonmnia/worker/server.go
+++ b/insonmnia/worker/server.go
@@ -363,7 +363,7 @@ func (m *Worker) cancelDealTasks(deal *pb.Deal) error {
 		if err := m.ovs.OnDealFinish(m.ctx, container.ID); err != nil {
 			result = multierror.Append(result, err)
 		}
-		if err := m.resources.OnDealFinish(container.TaskID); err != nil {
+		if err := m.resources.OnDealFinish(container.TaskId); err != nil {
 			result = multierror.Append(result, err)
 		}
 	}
@@ -756,7 +756,7 @@ func (m *Worker) StopTask(ctx context.Context, request *pb.ID) (*pb.Empty, error
 	}
 
 	m.setStatus(&pb.TaskStatusReply{Status: pb.TaskStatusReply_FINISHED}, request.Id)
-	_, err := m.storage.Remove(containerInfo.TaskID)
+	_, err := m.storage.Remove(containerInfo.TaskId)
 
 	if err != nil {
 		log.G(ctx).Warn("failed to delete cached container info", zap.Error(err))
@@ -961,10 +961,10 @@ func (m *Worker) setupRunningContainers() error {
 				info.Cinfo.status = pb.TaskStatusReply_BROKEN
 			}
 
-			m.containers[info.Cinfo.TaskID] = &info.Cinfo
+			m.containers[info.Cinfo.TaskId] = &info.Cinfo
 
 			m.ovs.Attach(m.ctx, container.ID, info.Description)
-			m.resources.ConsumeTask(info.Cinfo.AskID, info.Cinfo.TaskID, &info.Resources)
+			m.resources.ConsumeTask(info.Cinfo.AskID, info.Cinfo.TaskId, &info.Resources)
 		}
 	}
 

--- a/insonmnia/worker/server.go
+++ b/insonmnia/worker/server.go
@@ -963,7 +963,7 @@ func (m *Worker) setupRunningContainers() error {
 
 			m.containers[info.Cinfo.TaskID] = &info.Cinfo
 
-			m.ovs.Attach(m.ctx, container.ID, dockerClient, info.Description)
+			m.ovs.Attach(m.ctx, container.ID, info.Description)
 			m.resources.ConsumeTask(info.Cinfo.AskID, info.Cinfo.TaskID, &info.Resources)
 		}
 	}

--- a/insonmnia/worker/server.go
+++ b/insonmnia/worker/server.go
@@ -363,7 +363,7 @@ func (m *Worker) cancelDealTasks(deal *pb.Deal) error {
 		if err := m.ovs.OnDealFinish(m.ctx, container.ID); err != nil {
 			result = multierror.Append(result, err)
 		}
-		if err := m.resources.OnDealFinish(container.TaskId); err != nil {
+		if err := m.resources.OnDealFinish(container.TaskID); err != nil {
 			result = multierror.Append(result, err)
 		}
 	}
@@ -756,7 +756,7 @@ func (m *Worker) StopTask(ctx context.Context, request *pb.ID) (*pb.Empty, error
 	}
 
 	m.setStatus(&pb.TaskStatusReply{Status: pb.TaskStatusReply_FINISHED}, request.Id)
-	_, err := m.storage.Remove(containerInfo.TaskId)
+	_, err := m.storage.Remove(containerInfo.TaskID)
 
 	if err != nil {
 		log.G(ctx).Warn("failed to delete cached container info", zap.Error(err))
@@ -961,7 +961,7 @@ func (m *Worker) setupRunningContainers() error {
 				info.Cinfo.status = pb.TaskStatusReply_BROKEN
 			}
 
-			m.containers[info.Cinfo.TaskId] = &info.Cinfo
+			m.containers[info.Cinfo.TaskID] = &info.Cinfo
 			mounts := make([]volume.Mount, 0)
 
 			for _, spec := range info.Spec.Container.Mounts {
@@ -975,7 +975,7 @@ func (m *Worker) setupRunningContainers() error {
 			info.Description.mounts = mounts
 
 			m.ovs.Attach(m.ctx, container.ID, info.Description)
-			m.resources.ConsumeTask(info.Cinfo.AskID, info.Cinfo.TaskId, info.Spec.Resources)
+			m.resources.ConsumeTask(info.Cinfo.AskID, info.Cinfo.TaskID, info.Spec.Resources)
 		}
 	}
 

--- a/insonmnia/worker/server.go
+++ b/insonmnia/worker/server.go
@@ -363,7 +363,7 @@ func (m *Worker) cancelDealTasks(deal *pb.Deal) error {
 		if err := m.ovs.OnDealFinish(m.ctx, container.ID); err != nil {
 			result = multierror.Append(result, err)
 		}
-		if err := m.resources.OnDealFinish(container.TaskID); err != nil {
+		if err := m.resources.OnDealFinish(container.TaskId); err != nil {
 			result = multierror.Append(result, err)
 		}
 	}
@@ -756,7 +756,7 @@ func (m *Worker) StopTask(ctx context.Context, request *pb.ID) (*pb.Empty, error
 	}
 
 	m.setStatus(&pb.TaskStatusReply{Status: pb.TaskStatusReply_FINISHED}, request.Id)
-	_, err := m.storage.Remove(containerInfo.TaskID)
+	_, err := m.storage.Remove(containerInfo.TaskId)
 
 	if err != nil {
 		log.G(ctx).Warn("failed to delete cached container info", zap.Error(err))
@@ -961,7 +961,7 @@ func (m *Worker) setupRunningContainers() error {
 				info.Cinfo.status = pb.TaskStatusReply_BROKEN
 			}
 
-			m.containers[info.Cinfo.TaskID] = &info.Cinfo
+			m.containers[info.Cinfo.TaskId] = &info.Cinfo
 			mounts := make([]volume.Mount, 0)
 
 			for _, spec := range info.Spec.Container.Mounts {
@@ -975,7 +975,7 @@ func (m *Worker) setupRunningContainers() error {
 			info.Description.mounts = mounts
 
 			m.ovs.Attach(m.ctx, container.ID, info.Description)
-			m.resources.ConsumeTask(info.Cinfo.AskID, info.Cinfo.TaskID, info.Spec.Resources)
+			m.resources.ConsumeTask(info.Cinfo.AskID, info.Cinfo.TaskId, info.Spec.Resources)
 		}
 	}
 

--- a/insonmnia/worker/server.go
+++ b/insonmnia/worker/server.go
@@ -756,6 +756,11 @@ func (m *Worker) StopTask(ctx context.Context, request *pb.ID) (*pb.Empty, error
 	}
 
 	m.setStatus(&pb.TaskStatusReply{Status: pb.TaskStatusReply_FINISHED}, request.Id)
+	_, err := m.storage.Remove(containerInfo.TaskID)
+
+	if err != nil {
+		log.G(ctx).Warn("failed to delete cached container info", zap.Error(err))
+	}
 
 	return &pb.Empty{}, nil
 }


### PR DESCRIPTION
Curretnly a WIP, not everythin tested yet and the code's not that good. Things working so far:

A worker can attach on start to a running container, we can get it's stats etc. from the ```sonmcli```, stop the container, etc.