### PR TITLE
fix: Keep task-to-askplan data till the deal is finished

### DIFF
--- a/insonmnia/resource/pool.go
+++ b/insonmnia/resource/pool.go
@@ -159,8 +159,19 @@ func (m *Scheduler) ReleaseTask(taskID string) error {
 	if err != nil {
 		return err
 	}
-	delete(m.taskToAskPlan, taskID)
 	m.log.Debugf("released task %s", taskID)
+	return nil
+}
+
+func (m *Scheduler) OnDealFinish(taskID string) error {
+	_, ok := m.taskToAskPlan[taskID]
+
+	if !ok {
+		return fmt.Errorf("failed finish deal for task %s from scheduler: could not find corresponding ask plan", taskID)
+	}
+
+	delete(m.taskToAskPlan, taskID)
+
 	return nil
 }
 

--- a/insonmnia/worker/overseer.go
+++ b/insonmnia/worker/overseer.go
@@ -98,6 +98,7 @@ type ContainerInfo struct {
 	CgroupParent string
 	NetworkIDs   []string
 	DealID       string
+	TaskId       string
 }
 
 func (c *ContainerInfo) IntoProto(ctx context.Context) *pb.TaskStatusReply {
@@ -515,6 +516,7 @@ func (o *overseer) Start(ctx context.Context, description Description) (status c
 		Cgroup:       string(cjson.HostConfig.Cgroup),
 		CgroupParent: string(cjson.HostConfig.CgroupParent),
 		NetworkIDs:   networkIDs,
+		TaskId:       description.TaskId,
 	}
 
 	return status, cinfo, nil

--- a/insonmnia/worker/server.go
+++ b/insonmnia/worker/server.go
@@ -358,6 +358,9 @@ func (m *Worker) cancelDealTasks(deal *pb.Deal) error {
 		if err := m.ovs.OnDealFinish(m.ctx, container.ID); err != nil {
 			result = multierror.Append(result, err)
 		}
+		if err := m.resources.OnDealFinish(container.TaskId); err != nil {
+			result = multierror.Append(result, err)
+		}
 	}
 	return result.ErrorOrNil()
 }


### PR DESCRIPTION
When the container dies, or the task is stopped we keep all the task's data until the deal is finished, but we don't keep the task-to-askplan data deleting in ReleaseTask method. So when we ask for logs or any other data on an already stopped container, we will end up in the following error:

```
./sonmcli_darwin_x86_64 tasks logs 157 521845a3-ad69-49a5-b717-2cc0dd7fec5a
[ERR] Cannot fetch log chunk: rpc error: code = Unknown desc = failure during receiving logs from worker: rpc error: code = NotFound desc = ask plan for task 521845a3-ad69-49a5-b717-2cc0dd7fec5a not found: ask plan for task 521845a3-ad69-49a5-b717-2cc0dd7fec5a is not found
```

This patch proposes keeping this info until the deal is closed, so we can, for instance, still ask for logs on a stopped container:

```
 $ sonmcli_linux_x86_64 task  start 156 task.yaml --config ./cli_client.yaml 
Task ID:    db1b66b8-13ab-4e8d-aa7f-0ff8def671d3
  Endpoint: 80/tcp: 172.17.0.1:32816
  Endpoint: 80/tcp: 10.10.111.158:32816
  Network:  bridge
$ sonmcli_linux_x86_64 task  logs  156 db1b66b8-13ab-4e8d-aa7f-0ff8def671d3 --config ./cli_client.yaml 
2018-07-11T19:52:57.302012398Z AH00558: httpd: Could not reliably determine the server's fully qualified domain name, using 172.17.0.2. Set the 'ServerName' directive globally to suppress this message
2018-07-11T19:52:57.304045060Z AH00558: httpd: Could not reliably determine the server's fully qualified domain name, using 172.17.0.2. Set the 'ServerName' directive globally to suppress this message
2018-07-11T19:52:57.305395905Z [Wed Jul 11 19:52:57.305189 2018] [mpm_event:notice] [pid 1:tid 139795335923584] AH00489: Apache/2.4.33 (Unix) configured -- resuming normal operations
2018-07-11T19:52:57.305410082Z [Wed Jul 11 19:52:57.305349 2018] [core:notice] [pid 1:tid 139795335923584] AH00094: Command line: 'httpd -D FOREGROUND'
$ sonmcli_linux_x86_64 task stop   156 db1b66b8-13ab-4e8d-aa7f-0ff8def671d3 --config ./cli_client.yaml 
OK
$ sonmcli_linux_x86_64 task  logs  156 db1b66b8-13ab-4e8d-aa7f-0ff8def671d3 --config ./cli_client.yaml 
2018-07-11T19:52:57.302012398Z AH00558: httpd: Could not reliably determine the server's fully qualified domain name, using 172.17.0.2. Set the 'ServerName' directive globally to suppress this message
2018-07-11T19:52:57.304045060Z AH00558: httpd: Could not reliably determine the server's fully qualified domain name, using 172.17.0.2. Set the 'ServerName' directive globally to suppress this message
2018-07-11T19:52:57.305395905Z [Wed Jul 11 19:52:57.305189 2018] [mpm_event:notice] [pid 1:tid 139795335923584] AH00489: Apache/2.4.33 (Unix) configured -- resuming normal operations
2018-07-11T19:52:57.305410082Z [Wed Jul 11 19:52:57.305349 2018] [core:notice] [pid 1:tid 139795335923584] AH00094: Command line: 'httpd -D FOREGROUND'
```