### PR TITLE
feat: make masterchain gas price configurable

### DIFF
--- a/blockchain/config.go
+++ b/blockchain/config.go
@@ -41,7 +41,7 @@ func (m *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		SidechainEndpoint    string         `yaml:"sidechain_endpoint"`
 		ContractRegistryAddr common.Address `yaml:"contract_registry"`
 		BlocksBatchSize      uint64         `yaml:"blocks_batch_size" default:"500"`
-		MasterchainGasPrice  string         `yaml:"masterchain_gas_price"`
+		MasterchainGasPrice  GasPrice       `yaml:"masterchain_gas_price"`
 	}
 
 	if err := unmarshal(&cfg); err != nil {
@@ -70,13 +70,7 @@ func (m *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	m.SidechainEndpoint = *sidechainEndpoint
 	m.ContractRegistryAddr = cfg.ContractRegistryAddr
 	m.BlocksBatchSize = cfg.BlocksBatchSize
-
-	price := GasPrice{}
-	err = price.UnmarshalText([]byte(cfg.MasterchainGasPrice))
-	if err != nil {
-		return err
-	}
-	m.MasterchainGasPrice = price.Int
+	m.MasterchainGasPrice = cfg.MasterchainGasPrice.Int
 
 	return nil
 }

--- a/blockchain/config.go
+++ b/blockchain/config.go
@@ -1,6 +1,7 @@
 package blockchain
 
 import (
+	"math/big"
 	"net/url"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -13,6 +14,7 @@ type Config struct {
 	SidechainEndpoint    url.URL
 	ContractRegistryAddr common.Address
 	BlocksBatchSize      uint64
+	MasterchainGasPrice  *big.Int
 }
 
 func NewDefaultConfig() (*Config, error) {
@@ -39,6 +41,7 @@ func (m *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		SidechainEndpoint    string         `yaml:"sidechain_endpoint"`
 		ContractRegistryAddr common.Address `yaml:"contract_registry"`
 		BlocksBatchSize      uint64         `yaml:"blocks_batch_size" default:"500"`
+		MasterchainGasPrice  string         `yaml:"masterchain_gas_price"`
 	}
 
 	if err := unmarshal(&cfg); err != nil {
@@ -67,6 +70,13 @@ func (m *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	m.SidechainEndpoint = *sidechainEndpoint
 	m.ContractRegistryAddr = cfg.ContractRegistryAddr
 	m.BlocksBatchSize = cfg.BlocksBatchSize
+
+	price := GasPrice{}
+	err = price.UnmarshalText([]byte(cfg.MasterchainGasPrice))
+	if err != nil {
+		return err
+	}
+	m.MasterchainGasPrice = price.Int
 
 	return nil
 }

--- a/blockchain/options.go
+++ b/blockchain/options.go
@@ -11,14 +11,14 @@ import (
 )
 
 const (
-	defaultMasterchainEndpoint = "https://mainnet.infura.io/00iTrs5PIy0uGODwcsrb"
-	defaultSidechainEndpoint   = "https://sidechain.livenet.sonm.com/"
-	defaultMasterchainGasPrice = 20000000000 // 20 Gwei
-	defaultSidechainGasPrice   = 0
-	defaultBlockConfirmations  = 5
-	defaultLogParsePeriod      = time.Second
-	defaultMasterchainGasLimit = 500000
-	defaultSidechainGasLimit   = 2000000
+	defaultMasterchainEndpoint        = "https://mainnet.infura.io/00iTrs5PIy0uGODwcsrb"
+	defaultSidechainEndpoint          = "https://sidechain.livenet.sonm.com/"
+	defaultMasterchainGasPrice uint64 = 20000000000 // 20 Gwei
+	defaultSidechainGasPrice   uint64 = 0
+	defaultBlockConfirmations         = 5
+	defaultLogParsePeriod             = time.Second
+	defaultMasterchainGasLimit        = 500000
+	defaultSidechainGasLimit          = 2000000
 )
 
 // chainOpts describes common options

--- a/blockchain/options.go
+++ b/blockchain/options.go
@@ -26,7 +26,7 @@ const (
 // (live Eth network, rinkeby, SONM sidechain
 // or local geth-node for testing).
 type chainOpts struct {
-	gasPrice           int64
+	gasPrice           *big.Int
 	gasLimit           uint64
 	endpoint           string
 	logParsePeriod     time.Duration
@@ -48,7 +48,7 @@ func (c *chainOpts) getTxOpts(ctx context.Context, key *ecdsa.PrivateKey, gasLim
 	opts := bind.NewKeyedTransactor(key)
 	opts.Context = ctx
 	opts.GasLimit = gasLimit
-	opts.GasPrice = big.NewInt(c.gasPrice)
+	opts.GasPrice = c.gasPrice
 
 	return opts
 }
@@ -63,14 +63,14 @@ type options struct {
 func defaultOptions() *options {
 	return &options{
 		masterchain: &chainOpts{
-			gasPrice:           defaultMasterchainGasPrice,
+			gasPrice:           big.NewInt(0).SetUint64(defaultMasterchainGasPrice),
 			gasLimit:           defaultMasterchainGasLimit,
 			endpoint:           defaultMasterchainEndpoint,
 			logParsePeriod:     defaultLogParsePeriod,
 			blockConfirmations: defaultBlockConfirmations,
 		},
 		sidechain: &chainOpts{
-			gasPrice:           defaultSidechainGasPrice,
+			gasPrice:           big.NewInt(0).SetUint64(defaultSidechainGasPrice),
 			gasLimit:           defaultSidechainGasLimit,
 			endpoint:           defaultSidechainEndpoint,
 			logParsePeriod:     defaultLogParsePeriod,
@@ -82,13 +82,13 @@ func defaultOptions() *options {
 
 type Option func(options *options)
 
-func WithMasterchainGasPrice(p int64) Option {
+func WithMasterchainGasPrice(p *big.Int) Option {
 	return func(o *options) {
 		o.masterchain.gasPrice = p
 	}
 }
 
-func WithSidechainGasPrice(p int64) Option {
+func WithSidechainGasPrice(p *big.Int) Option {
 	return func(o *options) {
 		o.sidechain.gasPrice = p
 	}
@@ -121,6 +121,7 @@ func WithConfig(cfg *Config) Option {
 				o.contractRegistry = cfg.ContractRegistryAddr
 			}
 			o.blocksBatchSize = cfg.BlocksBatchSize
+			o.masterchain.gasPrice = cfg.MasterchainGasPrice
 		}
 	}
 }

--- a/cmd/pandora/gun_marketplace.go
+++ b/cmd/pandora/gun_marketplace.go
@@ -23,8 +23,7 @@ func NewMarketplaceGun(cfg MarketplaceExtConfig) (Gun, error) {
 	privateKey := PrivateKey(cfg.Ethereum)
 
 	market, err := blockchain.NewAPI(context.Background(),
-		blockchain.WithSidechainEndpoint(cfg.Ethereum.Endpoint),
-		blockchain.WithSidechainGasPrice(0))
+		blockchain.WithSidechainEndpoint(cfg.Ethereum.Endpoint))
 	if err != nil {
 		return nil, err
 	}

--- a/etc/node.yaml
+++ b/etc/node.yaml
@@ -51,3 +51,9 @@ ethereum:
   pass_phrase: "any"
 
 metrics_listen_addr: "127.0.0.1:14003"
+
+
+blockchain:
+  # gas price for masterchain transactions, in wei
+  # default is 20 Gwei
+  masterchain_gas_price: 20000000000

--- a/etc/node.yaml
+++ b/etc/node.yaml
@@ -56,4 +56,4 @@ metrics_listen_addr: "127.0.0.1:14003"
 blockchain:
   # gas price for masterchain transactions, in wei
   # default is 20 Gwei
-  masterchain_gas_price: 20000000000
+  # masterchain_gas_price: 20Gwei


### PR DESCRIPTION
This option now usefull for `deposit` and gatekeeper `withdraw`;
If option not defined gas price is determined by the latest blocks median gas price.