### PR TITLE
refactor: metrics server overhaul

### DIFF
--- a/cmd/dwh/main.go
+++ b/cmd/dwh/main.go
@@ -11,7 +11,7 @@ import (
 	"github.com/sonm-io/core/cmd"
 	"github.com/sonm-io/core/insonmnia/dwh"
 	"github.com/sonm-io/core/insonmnia/logging"
-	"github.com/sonm-io/core/util"
+	"github.com/sonm-io/core/util/metrics"
 	"go.uber.org/zap"
 )
 
@@ -44,7 +44,7 @@ func run() error {
 		return fmt.Errorf("failed to create new DWH service: %s", err)
 	}
 
-	go util.StartPrometheus(ctx, cfg.MetricsListenAddr)
+	go metrics.NewPrometheusExporter(cfg.MetricsListenAddr, metrics.WithLogging(logger.Sugar())).Serve(ctx)
 	go func() {
 		c := make(chan os.Signal, 1)
 		signal.Notify(c, syscall.SIGINT, syscall.SIGTERM)

--- a/cmd/node/main.go
+++ b/cmd/node/main.go
@@ -10,7 +10,7 @@ import (
 	"github.com/sonm-io/core/cmd"
 	"github.com/sonm-io/core/insonmnia/logging"
 	"github.com/sonm-io/core/insonmnia/node"
-	"github.com/sonm-io/core/util"
+	"github.com/sonm-io/core/util/metrics"
 	"golang.org/x/net/context"
 )
 
@@ -50,7 +50,7 @@ func run() error {
 		n.Close()
 	}()
 
-	go util.StartPrometheus(ctx, cfg.MetricsListenAddr)
+	go metrics.NewPrometheusExporter(cfg.MetricsListenAddr, metrics.WithLogging(logger.Sugar())).Serve(ctx)
 
 	if err := n.Serve(); err != nil {
 		return fmt.Errorf("node termination: %s", err)

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -11,7 +11,7 @@ import (
 	"github.com/sonm-io/core/insonmnia/logging"
 	"github.com/sonm-io/core/insonmnia/state"
 	"github.com/sonm-io/core/insonmnia/worker"
-	"github.com/sonm-io/core/util"
+	"github.com/sonm-io/core/util/metrics"
 	"go.uber.org/zap"
 	"golang.org/x/net/context"
 	"golang.org/x/sync/errgroup"
@@ -64,8 +64,7 @@ func run() error {
 		return fmt.Errorf("failed to create Worker instance: %s", err)
 	}
 
-	//TODO: fixme dangling goroutine
-	go util.StartPrometheus(ctx, cfg.MetricsListenAddr)
+	go metrics.NewPrometheusExporter(cfg.MetricsListenAddr, metrics.WithLogging(logger.Sugar())).Serve(ctx)
 
 	if err = w.Serve(); err != nil {
 		cancel()

--- a/util/metrics/prometheus.go
+++ b/util/metrics/prometheus.go
@@ -1,0 +1,85 @@
+package metrics
+
+import (
+	"context"
+	"net"
+	"net/http"
+
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"go.uber.org/zap"
+	"golang.org/x/sync/errgroup"
+)
+
+type options struct {
+	log *zap.SugaredLogger
+}
+
+func newOptions() *options {
+	return &options{
+		log: zap.NewNop().Sugar(),
+	}
+}
+
+type Option func(o *options)
+
+func WithLogging(log *zap.SugaredLogger) Option {
+	return func(o *options) {
+		o.log = log
+	}
+}
+
+type PrometheusExporter struct {
+	addr string
+	log  *zap.SugaredLogger
+}
+
+func NewPrometheusExporter(addr string, options ...Option) *PrometheusExporter {
+	return newPrometheusExporter(addr, options...)
+}
+
+func newPrometheusExporter(addr string, options ...Option) *PrometheusExporter {
+	opts := newOptions()
+	for _, o := range options {
+		o(opts)
+	}
+
+	m := &PrometheusExporter{
+		addr: addr,
+		log:  opts.log,
+	}
+
+	return m
+}
+
+// Serve starts prometheus exporter HTTP server, blocking until the specified
+// context is done or some critical error occurs.
+func (m *PrometheusExporter) Serve(ctx context.Context) error {
+	listener, err := net.Listen("tcp", m.addr)
+	if err != nil {
+		return err
+	}
+	defer listener.Close()
+
+	server := &http.Server{Handler: newHandler()}
+
+	wg, ctx := errgroup.WithContext(ctx)
+	wg.Go(func() error {
+		m.log.Infof("starting metrics server on %s", m.addr)
+		defer m.log.Infof("stopped metrics server on %s", m.addr)
+
+		return server.Serve(listener)
+	})
+
+	// Wait for either external context canceled or server fails to serve.
+	<-ctx.Done()
+	server.Close()
+
+	return wg.Wait()
+}
+
+func newHandler() http.Handler {
+	handler := http.NewServeMux()
+	handler.Handle("/metrics", promhttp.Handler())
+
+	return handler
+}

--- a/util/metrics/prometheus.go
+++ b/util/metrics/prometheus.go
@@ -34,10 +34,6 @@ type PrometheusExporter struct {
 }
 
 func NewPrometheusExporter(addr string, options ...Option) *PrometheusExporter {
-	return newPrometheusExporter(addr, options...)
-}
-
-func newPrometheusExporter(addr string, options ...Option) *PrometheusExporter {
 	opts := newOptions()
 	for _, o := range options {
 		o(opts)

--- a/util/util.go
+++ b/util/util.go
@@ -1,11 +1,9 @@
 package util
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"math/big"
-	"net/http"
 	"os"
 	"os/user"
 	"path"
@@ -13,9 +11,6 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/params"
-	log "github.com/noxiouz/zapctx/ctxlog"
-	"github.com/prometheus/client_golang/prometheus/promhttp"
-	"go.uber.org/zap"
 )
 
 const (
@@ -122,13 +117,6 @@ func StringToEtherPrice(s string) (*big.Int, error) {
 	}
 
 	return v, nil
-}
-
-func StartPrometheus(ctx context.Context, listenAddr string) {
-	log.GetLogger(ctx).Info(
-		"starting metrics server", zap.String("metrics_addr", listenAddr))
-	http.Handle("/metrics", promhttp.Handler())
-	http.ListenAndServe(listenAddr, nil)
 }
 
 func BigIntToPaddedString(x *big.Int) string {


### PR DESCRIPTION
This commit allows metrics server (backed with Prometheus) to be run either in secure or insecure modes.
After minor decomposition it is also possible to wire provided context with server's lifetime, which fixes at last some of leaked goroutines.

Now all metrics-related stuff lives in "metrics" namespace. Util must die.