### PR TITLE
chore: drop sqlite3 (DWH)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@ env:
 
 services:
     - "docker"
-    - "postgresql"
 
 before_install:
   - sudo apt-get update

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ env:
 
 services:
     - "docker"
+    - "postgresql"
 
 before_install:
   - sudo apt-get update

--- a/Makefile
+++ b/Makefile
@@ -136,7 +136,8 @@ test: mock
 	@echo "+ $@"
 	${GO} test -tags nocgo $(shell go list ./... | grep -vE 'vendor|blockchain')
 
-test/unit: mock
+# Everything except DWH tests.
+test/lite: mock
 	@echo "+ $@"
 	${GO} test -tags nocgo $(shell go list ./... | grep -vE 'vendor|blockchain|dwh')
 

--- a/Makefile
+++ b/Makefile
@@ -136,6 +136,10 @@ test: mock
 	@echo "+ $@"
 	${GO} test -tags nocgo $(shell go list ./... | grep -vE 'vendor|blockchain')
 
+test/unit: mock
+	@echo "+ $@"
+	${GO} test -tags nocgo $(shell go list ./... | grep -vE 'vendor|blockchain|dwh')
+
 contracts:
 	@$(MAKE) -C blockchain/source all
 

--- a/etc/dwh.yaml
+++ b/etc/dwh.yaml
@@ -2,10 +2,6 @@ grpc_address: ":15021"
 
 http_address: ":15022"
 
-#storage:
-#  driver: "sqlite3"
-#  endpoint: "/var/lib/sonm/dwh.db"
-
 storage:
   driver: "postgres"
   endpoint: "postgresql://localhost:5432/dwh?user=dwh&password=dwh&sslmode=disable"

--- a/etc/dwh.yaml
+++ b/etc/dwh.yaml
@@ -3,7 +3,6 @@ grpc_address: ":15021"
 http_address: ":15022"
 
 storage:
-  driver: "postgres"
   endpoint: "postgresql://localhost:5432/dwh?user=dwh&password=dwh&sslmode=disable"
 
 # blockchain-specific settings.

--- a/insonmnia/dwh/config.go
+++ b/insonmnia/dwh/config.go
@@ -22,7 +22,6 @@ type Config struct {
 }
 
 type storageConfig struct {
-	Backend  string `required:"true" yaml:"driver"`
 	Endpoint string `required:"true" yaml:"endpoint"`
 }
 

--- a/insonmnia/dwh/server_test.go
+++ b/insonmnia/dwh/server_test.go
@@ -47,12 +47,12 @@ func TestMain(m *testing.M) {
 	cli, containerID, err := startPostgresContainer(ctx)
 	if err != nil {
 		fmt.Println(err)
-		os.Exit(1)
+		os.Exit(testsReturnCode)
 	}
 
 	if err := checkPostgresReadiness(containerID); err != nil {
 		fmt.Println(err)
-		return
+		os.Exit(testsReturnCode)
 	}
 
 	defer func() {

--- a/insonmnia/dwh/server_test.go
+++ b/insonmnia/dwh/server_test.go
@@ -27,12 +27,14 @@ import (
 )
 
 var (
-	globalDWH      *DWH
-	monitorDWH     *DWH
-	dbUser         = "dwh_tester"
-	dbUserPassword = "dwh_tester"
-	globalDBName   = "dwh_test_global"
-	monitorDBName  = "dwh_test_monitor"
+	globalDWH         *DWH
+	monitorDWH        *DWH
+	dbUser            = "dwh_tester"
+	dbUserPassword    = "dwh_tester"
+	globalDBName      = "dwh_test_global"
+	monitorDBName     = "dwh_test_monitor"
+	postgresPort      = "15432"
+	serviceConnString = fmt.Sprintf("postgresql://localhost:%s/template1?user=postgres&sslmode=disable", postgresPort)
 )
 
 func TestMain(m *testing.M) {
@@ -118,7 +120,7 @@ func startPostgresContainer(ctx context.Context) (cli *client.Client, containerI
 	}
 	hostCfg := &container.HostConfig{
 		PortBindings: map[nat.Port][]nat.PortBinding{
-			nat.Port("5432"): {{HostIP: "localhost", HostPort: "5432"}},
+			nat.Port("5432"): {{HostIP: "localhost", HostPort: postgresPort}},
 		},
 	}
 	resp, err := cli.ContainerCreate(ctx, containerCfg, hostCfg, nil, "dwh-postgres-test")
@@ -156,7 +158,7 @@ func checkPostgresReadiness(containerID string) error {
 }
 
 func setupDB() error {
-	db, err := sql.Open("postgres", "postgresql://localhost:5432/template1?user=postgres&sslmode=disable")
+	db, err := sql.Open("postgres", serviceConnString)
 	if err != nil {
 		return fmt.Errorf("failed to connect to template1: %s", err)
 	}
@@ -186,7 +188,7 @@ func setupDB() error {
 }
 
 func tearDownDB() error {
-	db, err := sql.Open("postgres", "postgresql://localhost:5432/template1?user=postgres&sslmode=disable")
+	db, err := sql.Open("postgres", serviceConnString)
 	if err != nil {
 		return fmt.Errorf("failed to connect to template1: %s", err)
 	}
@@ -202,7 +204,7 @@ func tearDownDB() error {
 }
 
 func getConnString(database, user, password string) string {
-	return fmt.Sprintf("postgresql://localhost:5432/%s?user=%s&password=%s&sslmode=disable", database, user, password)
+	return fmt.Sprintf("postgresql://localhost:15432/%s?user=%s&password=%s&sslmode=disable", database, user, password)
 }
 
 func getTestDWH(dbEndpoint string) (*DWH, error) {

--- a/insonmnia/dwh/server_test.go
+++ b/insonmnia/dwh/server_test.go
@@ -42,7 +42,7 @@ func TestMain(m *testing.M) {
 		ctx             = context.Background()
 	)
 
-	cli, containerID, err := runPostgresContainer(ctx)
+	cli, containerID, err := startPostgresContainer(ctx)
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)
@@ -99,7 +99,7 @@ func TestMain(m *testing.M) {
 	testsReturnCode = m.Run()
 }
 
-func runPostgresContainer(ctx context.Context) (cli *client.Client, containerID string, err error) {
+func startPostgresContainer(ctx context.Context) (cli *client.Client, containerID string, err error) {
 	cli, err = client.NewEnvClient()
 	if err != nil {
 		return nil, "", fmt.Errorf("failed to setup Docker client: %s", err)

--- a/insonmnia/dwh/sql.go
+++ b/insonmnia/dwh/sql.go
@@ -10,7 +10,6 @@ import (
 	sq "github.com/Masterminds/squirrel"
 	"github.com/ethereum/go-ethereum/common"
 	_ "github.com/lib/pq"
-	_ "github.com/mattn/go-sqlite3"
 	"github.com/sonm-io/core/blockchain"
 	pb "github.com/sonm-io/core/proto"
 	"github.com/sonm-io/core/util"
@@ -531,7 +530,7 @@ func (m *sqlStorage) GetProfiles(conn queryConn, r *pb.ProfilesRequest) ([]*pb.P
 	case pb.ProfileRole_Consumer:
 		builder = builder.Where("ActiveBids >= 1")
 	}
-	builder = builder.Where("IdentityLevel >= ?", r.IdentityLevel)
+	builder = builder.Where("p.IdentityLevel >= ?", r.IdentityLevel)
 	if len(r.Country) > 0 {
 		builder = builder.Where(sq.Eq{"Country": r.Country})
 	}
@@ -541,23 +540,25 @@ func (m *sqlStorage) GetProfiles(conn queryConn, r *pb.ProfilesRequest) ([]*pb.P
 			sq.Expr("lower(UserID) LIKE lower(?)", r.Identifier),
 		})
 	}
-	if r.BlacklistQuery != nil && !r.BlacklistQuery.OwnerID.IsZero() {
-		ownerBuilder := m.builder().Select("AddeeID").From("Blacklists").
-			Where("AdderID = ?", r.BlacklistQuery.OwnerID.Unwrap().Hex()).Where("AddeeID = p.UserID")
+
+	bQuery := r.BlacklistQuery
+	if bQuery != nil && !bQuery.OwnerID.IsZero() {
+		ownerBuilder := sq.Select("AddeeID").From("Blacklists").Where("AdderID = ?", bQuery.OwnerID.Unwrap().Hex()).
+			Where("AddeeID = p.UserID")
 		ownerQuery, _, _ := ownerBuilder.ToSql()
-		if r.BlacklistQuery != nil && r.BlacklistQuery.OwnerID != nil {
+		if bQuery.OwnerID != nil {
 			switch r.BlacklistQuery.Option {
 			case pb.BlacklistOption_WithoutMatching:
-				builder = builder.Where(fmt.Sprintf("UserID NOT IN (%s)", ownerQuery))
+				builder = builder.Where(fmt.Sprintf("p.UserID NOT IN (%s)", ownerQuery))
 			case pb.BlacklistOption_OnlyMatching:
-				builder = builder.Where(fmt.Sprintf("UserID IN (%s)", ownerQuery))
+				builder = builder.Where(fmt.Sprintf("p.UserID IN (%s)", ownerQuery))
 			}
 		}
 	}
 	builder = m.builderWithSortings(builder, r.Sortings)
 	query, args, _ := m.builderWithOffsetLimit(builder, r.Limit, r.Offset).ToSql()
 
-	if r.BlacklistQuery != nil && !r.BlacklistQuery.OwnerID.IsZero() {
+	if bQuery != nil && bQuery.Option != pb.BlacklistOption_IncludeAndMark && !bQuery.OwnerID.IsZero() {
 		args = append(args, r.BlacklistQuery.OwnerID.Unwrap().Hex())
 	}
 
@@ -2072,157 +2073,6 @@ func newPostgresStorage(numBenchmarks uint64) *sqlStorage {
 		tablesInfo:    tInfo,
 		builder: func() sq.StatementBuilderType {
 			return sq.StatementBuilder.PlaceholderFormat(sq.Dollar)
-		},
-	}
-
-	return storage
-}
-
-func newSQLiteStorage(numBenchmarks uint64) *sqlStorage {
-	tInfo := newTablesInfo(numBenchmarks)
-	storage := &sqlStorage{
-		setupCommands: &sqlSetupCommands{
-			// Incomplete, modified during setup.
-			createTableDeals: makeTableWithBenchmarks(`
-	CREATE TABLE IF NOT EXISTS Deals (
-		Id						TEXT UNIQUE NOT NULL,
-		SupplierID				TEXT NOT NULL,
-		ConsumerID				TEXT NOT NULL,
-		MasterID				TEXT NOT NULL,
-		AskID					TEXT NOT NULL,
-		BidID					TEXT NOT NULL,
-		Duration 				INTEGER NOT NULL,
-		Price					TEXT NOT NULL,
-		StartTime				INTEGER NOT NULL,
-		EndTime					INTEGER NOT NULL,
-		Status					INTEGER NOT NULL,
-		BlockedBalance			TEXT NOT NULL,
-		TotalPayout				TEXT NOT NULL,
-		LastBillTS				INTEGER NOT NULL,
-		Netflags				INTEGER NOT NULL,
-		AskIdentityLevel		INTEGER NOT NULL,
-		BidIdentityLevel		INTEGER NOT NULL,
-		SupplierCertificates    BLOB NOT NULL,
-		ConsumerCertificates    BLOB NOT NULL,
-		ActiveChangeRequest     INTEGER NOT NULL`, `INTEGER DEFAULT 0`),
-			createTableDealConditions: `
-	CREATE TABLE IF NOT EXISTS DealConditions (
-		Id							INTEGER PRIMARY KEY AUTOINCREMENT,
-		SupplierID					TEXT NOT NULL,
-		ConsumerID					TEXT NOT NULL,
-		MasterID					TEXT NOT NULL,
-		Duration 					INTEGER NOT NULL,
-		Price						TEXT NOT NULL,
-		StartTime					INTEGER NOT NULL,
-		EndTime						INTEGER NOT NULL,
-		TotalPayout					TEXT NOT NULL,
-		DealID						TEXT NOT NULL,
-		FOREIGN KEY (DealID)		REFERENCES Deals(Id) ON DELETE CASCADE
-	)`,
-			createTableDealPayments: `
-	CREATE TABLE IF NOT EXISTS DealPayments (
-		BillTS						INTEGER NOT NULL,
-		PaidAmount					TEXT NOT NULL,
-		DealID						TEXT NOT NULL,
-		UNIQUE						(BillTS, PaidAmount, DealID),
-		FOREIGN KEY (DealID) 		REFERENCES Deals(Id) ON DELETE CASCADE
-	)`,
-			createTableChangeRequests: `
-	CREATE TABLE IF NOT EXISTS DealChangeRequests (
-		Id 							TEXT UNIQUE NOT NULL,
-		CreatedTS					INTEGER NOT NULL,
-		RequestType					TEXT NOT NULL,
-		Duration 					INTEGER NOT NULL,
-		Price						TEXT NOT NULL,
-		Status						INTEGER NOT NULL,
-		DealID						TEXT NOT NULL,
-		FOREIGN KEY (DealID)		REFERENCES Deals(Id) ON DELETE CASCADE
-	)`,
-			// Incomplete, modified during setup.
-			createTableOrders: makeTableWithBenchmarks(`
-	CREATE TABLE IF NOT EXISTS Orders (
-		Id						TEXT UNIQUE NOT NULL,
-		MasterID				TEXT NOT NULL,
-		CreatedTS				INTEGER NOT NULL,
-		DealID					TEXT NOT NULL,
-		Type					INTEGER NOT NULL,
-		Status					INTEGER NOT NULL,
-		AuthorID				TEXT NOT NULL,
-		CounterpartyID			TEXT NOT NULL,
-		Duration 				INTEGER NOT NULL,
-		Price					TEXT NOT NULL,
-		Netflags				INTEGER NOT NULL,
-		IdentityLevel			INTEGER NOT NULL,
-		Blacklist				TEXT NOT NULL,
-		Tag						BLOB NOT NULL,
-		FrozenSum				TEXT NOT NULL,
-		CreatorIdentityLevel	INTEGER NOT NULL,
-		CreatorName				TEXT NOT NULL,
-		CreatorCountry			TEXT NOT NULL,
-		CreatorCertificates		BLOB NOT NULL`, `INTEGER DEFAULT 0`),
-			createTableWorkers: `
-	CREATE TABLE IF NOT EXISTS Workers (
-		MasterID					TEXT NOT NULL,
-		WorkerID					TEXT NOT NULL,
-		Confirmed					INTEGER NOT NULL,
-		UNIQUE						(MasterID, WorkerID)
-	)`,
-			createTableBlacklists: `
-	CREATE TABLE IF NOT EXISTS Blacklists (
-		AdderID						TEXT NOT NULL,
-		AddeeID						TEXT NOT NULL,
-		UNIQUE						(AdderID, AddeeID)
-	)`,
-			createTableValidators: `
-	CREATE TABLE IF NOT EXISTS Validators (
-		Id							TEXT UNIQUE NOT NULL,
-		Level						INTEGER NOT NULL,
-		Name						TEXT NOT NULL DEFAULT '',
-		KYC_icon					TEXT NOT NULL DEFAULT '',
-		KYC_URL						TEXT NOT NULL DEFAULT '',
-		Description					TEXT NOT NULL DEFAULT '',
-		KYC_Price					TEXT NOT NULL DEFAULT '0'
-	)`,
-			createTableCertificates: `
-	CREATE TABLE IF NOT EXISTS Certificates (
-	    Id						    TEXT NOT NULL, 
-		OwnerID						TEXT NOT NULL,
-		Attribute					INTEGER NOT NULL,
-		AttributeLevel				INTEGER NOT NULL,
-		Value						BLOB NOT NULL,
-		ValidatorID					TEXT NOT NULL,
-		FOREIGN KEY (ValidatorID)	REFERENCES Validators(Id) ON DELETE CASCADE
-	)`,
-			createTableProfiles: `
-	CREATE TABLE IF NOT EXISTS Profiles (
-		Id							INTEGER PRIMARY KEY AUTOINCREMENT,
-		UserID						TEXT UNIQUE NOT NULL,
-		IdentityLevel				INTEGER NOT NULL,
-		Name						TEXT NOT NULL,
-		Country						TEXT NOT NULL,
-		IsCorporation				INTEGER NOT NULL,
-		IsProfessional				INTEGER NOT NULL,
-		Certificates				BLOB NOT NULL,
-		ActiveAsks					INTEGER NOT NULL,
-		ActiveBids					INTEGER NOT NULL
-	)`,
-			createTableStaleIDs: `
-	CREATE TABLE IF NOT EXISTS StaleIDs (
-		Id 							TEXT NOT NULL
-	)`,
-			createTableMisc: `
-	CREATE TABLE IF NOT EXISTS Misc (
-		BlockNumber 				INTEGER NOT NULL,
-		TxIndex						INTEGER NOT NULL,
-		ReceiptIndex				INTEGER NOT NULL
-	)`,
-			createIndexCmd: `CREATE INDEX IF NOT EXISTS %s_%s ON %s (%s)`,
-			tablesInfo:     tInfo,
-		},
-		numBenchmarks: numBenchmarks,
-		tablesInfo:    tInfo,
-		builder: func() sq.StatementBuilderType {
-			return sq.StatementBuilder.PlaceholderFormat(sq.Question)
 		},
 	}
 

--- a/insonmnia/dwh/storage.go
+++ b/insonmnia/dwh/storage.go
@@ -3,69 +3,9 @@ package dwh
 import (
 	"database/sql"
 	"fmt"
-	"math/big"
 
-	"github.com/ethereum/go-ethereum/common"
-	"github.com/sonm-io/core/blockchain"
-	pb "github.com/sonm-io/core/proto"
 	"go.uber.org/zap"
 )
-
-type storage interface {
-	CreateIndices(db *sql.DB) error
-	InsertDeal(conn queryConn, deal *pb.Deal) error
-	UpdateDeal(conn queryConn, deal *pb.Deal) error
-	UpdateDealsSupplier(conn queryConn, profile *pb.Profile) error
-	UpdateDealsConsumer(conn queryConn, profile *pb.Profile) error
-	UpdateDealPayout(conn queryConn, dealID, payout *big.Int, billTS uint64) error
-	DeleteDeal(conn queryConn, dealID *big.Int) error
-	GetDealByID(conn queryConn, dealID *big.Int) (*pb.DWHDeal, error)
-	GetDeals(conn queryConn, request *pb.DealsRequest) ([]*pb.DWHDeal, uint64, error)
-	GetDealConditions(conn queryConn, request *pb.DealConditionsRequest) ([]*pb.DealCondition, uint64, error)
-	InsertOrder(conn queryConn, order *pb.DWHOrder) error
-	UpdateOrderStatus(conn queryConn, orderID *big.Int, status pb.OrderStatus) error
-	UpdateOrders(conn queryConn, profile *pb.Profile) error
-	DeleteOrder(conn queryConn, orderID *big.Int) error
-	GetOrderByID(conn queryConn, orderID *big.Int) (*pb.DWHOrder, error)
-	GetOrders(conn queryConn, request *pb.OrdersRequest) ([]*pb.DWHOrder, uint64, error)
-	GetMatchingOrders(conn queryConn, request *pb.MatchingOrdersRequest) ([]*pb.DWHOrder, uint64, error)
-	GetProfiles(conn queryConn, request *pb.ProfilesRequest) ([]*pb.Profile, uint64, error)
-	InsertDealChangeRequest(conn queryConn, changeRequest *pb.DealChangeRequest) error
-	UpdateDealChangeRequest(conn queryConn, changeRequest *pb.DealChangeRequest) error
-	DeleteDealChangeRequest(conn queryConn, changeRequestID *big.Int) error
-	GetDealChangeRequests(conn queryConn, changeRequest *pb.DealChangeRequest) ([]*pb.DealChangeRequest, error)
-	GetDealChangeRequestsByDealID(conn queryConn, changeRequestID *big.Int) ([]*pb.DealChangeRequest, error)
-	InsertDealCondition(conn queryConn, condition *pb.DealCondition) error
-	UpdateDealConditionPayout(conn queryConn, dealConditionID uint64, payout *big.Int) error
-	UpdateDealConditionEndTime(conn queryConn, dealConditionID, eventTS uint64) error
-	CheckWorkerExists(conn queryConn, masterID, workerID common.Address) (bool, error)
-	InsertWorker(conn queryConn, masterID, workerID common.Address) error
-	UpdateWorker(conn queryConn, masterID, workerID common.Address) error
-	DeleteWorker(conn queryConn, masterID, workerID common.Address) error
-	GetMasterByWorker(conn queryConn, workerID common.Address) (common.Address, error)
-	InsertBlacklistEntry(conn queryConn, adderID, addeeID common.Address) error
-	DeleteBlacklistEntry(conn queryConn, removerID, removeeID common.Address) error
-	GetBlacklist(conn queryConn, request *pb.BlacklistRequest) (*pb.BlacklistReply, error)
-	GetBlacklistsContainingUser(conn queryConn, request *pb.BlacklistRequest) (*pb.BlacklistsContainingUserReply, error)
-	InsertOrUpdateValidator(conn queryConn, validator *pb.Validator) error
-	DeactivateValidator(conn queryConn, validatorID common.Address) error
-	GetValidator(conn queryConn, validatorID common.Address) (*pb.DWHValidator, error)
-	UpdateValidator(conn queryConn, validatorID common.Address, field string, value interface{}) error
-	InsertCertificate(conn queryConn, certificate *pb.Certificate) error
-	GetCertificates(conn queryConn, ownerID common.Address) ([]*pb.Certificate, error)
-	InsertProfileUserID(conn queryConn, profile *pb.Profile) error
-	GetProfileByID(conn queryConn, userID common.Address) (*pb.Profile, error)
-	GetValidators(conn queryConn, request *pb.ValidatorsRequest) ([]*pb.DWHValidator, uint64, error)
-	GetWorkers(conn queryConn, request *pb.WorkersRequest) ([]*pb.DWHWorker, uint64, error)
-	UpdateProfile(conn queryConn, userID common.Address, field string, value interface{}) error
-	UpdateProfileStats(conn queryConn, userID common.Address, field string, value int) error
-	InsertLastEvent(conn queryConn, event *blockchain.Event) error
-	UpdateLastEvent(conn queryConn, event *blockchain.Event) error
-	GetLastEvent(conn queryConn) (*blockchain.Event, error)
-	StoreStaleID(conn queryConn, id *big.Int, entity string) error
-	RemoveStaleID(conn queryConn, id *big.Int, entity string) error
-	CheckStaleID(conn queryConn, id *big.Int, entity string) (bool, error)
-}
 
 type queryConn interface {
 	Exec(query string, args ...interface{}) (sql.Result, error)


### PR DESCRIPTION
This PR removes `sqlite3` support from DWH.
Postgres for tests runs in a docker container.
A new target (`make test/lite`) is added to `Makefile`, it runs tests **without** DWH tests. Old target `make test` sets up a docker container with `postgres` and runs **all** tests (including DWH).