### PR TITLE
fix: ignore orders with zero price in Optimus

### DIFF
--- a/etc/optimus.yaml
+++ b/etc/optimus.yaml
@@ -76,6 +76,11 @@ marketplace:
   endpoint: "0xadffcac607a0a1b583c489977eae413a62d4bc73@dwh.livenet.sonm.com:15021"
   # Interval of current orders caching, that are fetched from the marketplace.
   interval: 30s
+  # Minimum price threshold for fetching orders from the marketplace.
+  # Used to prevent regression poisoning.
+  # Optional.
+  # Default value is 0.0001 USD/h, which is nearly about 1 USD per year.
+  min_price: 0.0001 USD/h
 
 # Optimization engine settings.
 optimization:

--- a/optimus/config.go
+++ b/optimus/config.go
@@ -120,6 +120,7 @@ type marketplaceConfig struct {
 	PrivateKey privateKey    `yaml:"ethereum" json:"-"`
 	Endpoint   auth.Addr     `yaml:"endpoint"`
 	Interval   time.Duration `yaml:"interval"`
+	MinPrice   *sonm.Price   `yaml:"min_price" default:"0.0001 USD/h"`
 }
 
 type optimizationConfig struct {

--- a/optimus/engine.go
+++ b/optimus/engine.go
@@ -3,6 +3,7 @@ package optimus
 import (
 	"context"
 	"fmt"
+	"math"
 	"math/big"
 	"sync"
 	"time"
@@ -543,6 +544,15 @@ func (m *GreedyLinearRegressionModel) Optimize(knapsack *Knapsack, orders []*Mar
 
 	exhaustedCounter := 0
 	for _, weightedOrder := range weightedOrders {
+		// Ignore orders with too low relative weight, i.e. orders that have
+		// quotient of its price to predicted price less than 1%.
+		// It may be, for example, when an order has 0 price.
+		// TODO: For now not sure where to perform this filtering. Let it be here.
+		if math.Abs(weightedOrder.Weight) < 0.01 {
+			m.log.Debugf("ignore `%s` order - weight too low: %.6f", weightedOrder.ID().String(), weightedOrder.Weight)
+			continue
+		}
+
 		if _, ok := filter[weightedOrder.ID().String()]; !ok {
 			continue
 		}

--- a/optimus/optimus.go
+++ b/optimus/optimus.go
@@ -40,7 +40,7 @@ func (m *Optimus) Run(ctx context.Context) error {
 		return err
 	}
 
-	marketCache := newMarketCache(newMarketScanner(dwh), m.cfg.Marketplace.Interval)
+	marketCache := newMarketCache(newMarketScanner(m.cfg.Marketplace, dwh), m.cfg.Marketplace.Interval)
 
 	wg := errgroup.Group{}
 	benchmarkMapping, err := benchmarks.NewLoader(m.cfg.Benchmarks.URL).Load(context.Background())


### PR DESCRIPTION
This commit allows to specify the minimum order price filter before fetching active orders from the marketplace. This is required to be able to ignore meaningless orders, that can possibly trick into submission regression model.
Also weight threshold was added to ignore orders that are too far from the predicted price, i.e. has price too much lower than the predicted one.

As a result, Optimus should no longer create ask plans with zero or almost-zero price.