### PR TITLE
fix: init matcher properly in worker

### DIFF
--- a/insonmnia/worker/options.go
+++ b/insonmnia/worker/options.go
@@ -229,6 +229,7 @@ func (m *options) setupMatcher() error {
 				Eth:        m.eth,
 				PollDelay:  m.cfg.Matcher.PollDelay,
 				QueryLimit: m.cfg.Matcher.QueryLimit,
+				Log:        ctxlog.S(m.ctx),
 			})
 			if err != nil {
 				return fmt.Errorf("cannot create matcher: %v", err)


### PR DESCRIPTION
This fixes a bug introduced in #1202.