### PR TITLE
fix: proper logs following

### DIFF
--- a/cmd/cli/commands/tasks.go
+++ b/cmd/cli/commands/tasks.go
@@ -266,7 +266,7 @@ type logReader struct {
 }
 
 func (m *logReader) Read(p []byte) (n int, err error) {
-	for len(p) > m.buf.Len() && !m.finished {
+	if len(p) > m.buf.Len() && !m.finished {
 		chunk, err := m.cli.Recv()
 		if err == io.EOF {
 			m.finished = true


### PR DESCRIPTION
previously Read was blocked until receiving buffer was filled or EOF was encountered. That broke task logs with --follow flag because buffer was quite large and also that didn't respect io.Reader docs, which state that 
```
If some data is available but not len(p) bytes, Read conventionally
returns what is available instead of waiting for more.
```
This PR fixes this behaviour