### PR TITLE
fix: use cached docker images if they are present

### DIFF
--- a/insonmnia/worker/overseer.go
+++ b/insonmnia/worker/overseer.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -445,6 +446,20 @@ func (o *overseer) Spool(ctx context.Context, d Description) error {
 	}
 	refStr := d.Reference.String()
 	for _, summary := range summaries {
+		for _, digest := range summary.RepoDigests {
+			if strings.HasSuffix(d.Reference.String(), digest) {
+				log.S(ctx).Infof("application image %s is already present in %s", d.Reference.String(), digest)
+				return nil
+			}
+		}
+
+		for _, tag := range summary.RepoTags {
+			if strings.HasSuffix(d.Reference.String(), tag) {
+				log.S(ctx).Infof("application image %s is already present with tag %s", d.Reference.String(), tag)
+				return nil
+			}
+		}
+
 		if summary.ID == refStr {
 			log.S(ctx).Infof("application image %s is already present", d.Reference.String())
 			return nil


### PR DESCRIPTION
Currently we query a list of docker images container summaries and try to find the summary.ID that is matching the String() representation of our Reference. But  that will fail if we try to use reference constructed from something like ```httpd:latest``` or our benchmarks, here is what's what in docker images:

```
REPOSITORY           TAG                                        DIGEST                                                                    IMAGE ID            CREATED             SIZE
sonm/net-bandwidth   <none>                                     sha256:e51c367c5ad56c9ea1dbe1497b4acc7d0839be0832d8b77986b931eedc766fc2   1b4478048371        2 months ago        91.9MB
sonm/cpu-sysbench    <none>                                     sha256:8eeb78e04954c07b2f72f9311ac2f7eb194456a4af77b2c883f99f8949701924   d3d4aef5f95c        2 months ago        96.1MB
httpd                latest                                     sha256:963ecd717afb125c7a867d82d6935930bb93acc5078ea8bc37854d4b4de766d9   2a7d646dbba8        3 weeks ago         177MB
```

What happens in the case of ```httpd:latest``` reference, docker client parses it into ```docker.io/library/httpd:latest``` and what happend to our benchmarks is ```sonm/cpu-sysbench...``` is parsed into ```docker.io/sonm/cpu-sysbench...``` because docker adds ```reference.defaultDomain``` which is ```docker.io```.

So let's try to find our references as suffixes of images already existing in the system:

```
2018-07-19T17:09:32.329+0300	INFO	worker/overseer.go:441	pull the application image
2018-07-19T17:09:32.379+0300	INFO	worker/overseer.go:451	application image docker.io/sonm/net-bandwidth@sha256:e51c367c5ad56c9ea1dbe1497b4acc7d0839be0832d8b77986b931eedc766fc2 is already present in sonm/net-bandwidth@sha256:e51c367c5ad56c9ea1dbe1497b4acc7d0839be0832d8b77986b931eedc766fc2
2018-07-19T17:09:32.379+0300	INFO	worker/container.go:34	start container with application, reference docker.io/sonm/net-bandwidth@sha256:e51c367c5ad56c9ea1dbe1497b4acc7d0839be0832d8b77986b931eedc766fc2
```

and with ```httpd:latest```:

```
2018-07-19T17:20:12.554+0300	INFO	worker/server.go:564	handling StartTask request	{"request": "dealID:<1> spec:<container:<image:\"httpd:latest\" commitOnStop:true > > "}
2018-07-19T17:20:12.896+0300	DEBUG	resource/pool.go:130	consumed task 04f80331-11f4-4b46-889d-be95e7a5996a by scheduler	{"source": "resource_scheduler"}
2018-07-19T17:20:12.896+0300	INFO	worker/server.go:662	spooling an image
{"level":"info","ts":1532010012.8963463,"caller":"worker/overseer.go:441","msg":"pull the application image"}
{"level":"info","ts":1532010012.958386,"caller":"worker/overseer.go:458","msg":"application image docker.io/library/httpd:latest is already present with tag httpd:latest"}
2018-07-19T17:20:12.958+0300	INFO	worker/server.go:670	spawning an image
```

I wonder if there is a saner way.