### PR TITLE
feat: SSH into containers through Node

### DIFF
--- a/insonmnia/node/config.go
+++ b/insonmnia/node/config.go
@@ -9,6 +9,7 @@ import (
 	"github.com/sonm-io/core/insonmnia/logging"
 	"github.com/sonm-io/core/insonmnia/matcher"
 	"github.com/sonm-io/core/insonmnia/npp"
+	"github.com/sonm-io/core/insonmnia/ssh"
 	"github.com/sonm-io/core/optimus"
 	"github.com/sonm-io/core/util/debug"
 )
@@ -31,6 +32,7 @@ type Config struct {
 	Matcher           *matcher.YAMLConfig      `yaml:"matcher"`
 	Predictor         *optimus.PredictorConfig `yaml:"predictor"`
 	Debug             *debug.Config            `yaml:"debug"`
+	SSH               *ssh.ProxyServerConfig   `yaml:"ssh"`
 }
 
 // NewConfig loads localNode config from given .yaml file

--- a/insonmnia/node/mod.go
+++ b/insonmnia/node/mod.go
@@ -62,6 +62,10 @@ func New(ctx context.Context, cfg *Config, options ...Option) (*Node, error) {
 		)
 	}
 
+	if cfg.SSH != nil {
+		serverOptions = append(serverOptions, WithSSH(*cfg.SSH, transportCredentials, remoteOptions.eth.Market(), log.Sugar()))
+	}
+
 	server, err := newServer(cfg.Node, services, serverOptions...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to build Node instance: %s", err)

--- a/insonmnia/npp/dial.go
+++ b/insonmnia/npp/dial.go
@@ -4,6 +4,7 @@ package npp
 
 import (
 	"context"
+	"fmt"
 	"net"
 	"time"
 
@@ -103,6 +104,11 @@ func (m *Dialer) DialContext(ctx context.Context, addr auth.Addr) (net.Conn, err
 		case <-nppCtx.Done():
 			log.Warn("failed to connect using NPP", zap.Error(nppCtx.Err()))
 		}
+	}
+
+	if m.relayDialer == nil {
+		log.Warn("failed to connect using NPP - all methods failed")
+		return nil, fmt.Errorf("failed to connect using NPP - all methods failed")
 	}
 
 	log.Debug("connecting using Relay")

--- a/insonmnia/npp/options.go
+++ b/insonmnia/npp/options.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/sonm-io/core/insonmnia/npp/relay"
 	"github.com/sonm-io/core/insonmnia/npp/rendezvous"
+	"github.com/sonm-io/core/proto"
 	"go.uber.org/zap"
 	"google.golang.org/grpc/credentials"
 )
@@ -23,6 +24,7 @@ type options struct {
 	nppMaxBackoffInterval time.Duration
 	relayListener         *relay.Listener
 	relayDialer           *relay.Dialer
+	protocol              string
 }
 
 func newOptions() *options {
@@ -31,6 +33,7 @@ func newOptions() *options {
 		nppBacklog:            128,
 		nppMinBackoffInterval: 500 * time.Millisecond,
 		nppMaxBackoffInterval: 8000 * time.Millisecond,
+		protocol:              sonm.DefaultNPPProtocol,
 	}
 }
 
@@ -49,7 +52,7 @@ func WithRendezvous(cfg rendezvous.Config, credentials credentials.TransportCred
 			for _, addr := range cfg.Endpoints {
 				client, err := newRendezvousClient(ctx, addr, credentials)
 				if err == nil {
-					return newNATPuncher(ctx, cfg, client, o.log)
+					return newNATPuncher(ctx, cfg, client, o.protocol, o.log)
 				}
 			}
 
@@ -109,6 +112,13 @@ func WithRelayListener(listener *relay.Listener) Option {
 func WithRelayDialer(dialer *relay.Dialer) Option {
 	return func(o *options) error {
 		o.relayDialer = dialer
+		return nil
+	}
+}
+
+func WithProtocol(protocol string) Option {
+	return func(o *options) error {
+		o.protocol = protocol
 		return nil
 	}
 }

--- a/insonmnia/ssh/config.go
+++ b/insonmnia/ssh/config.go
@@ -1,0 +1,11 @@
+package ssh
+
+import (
+	"github.com/sonm-io/core/insonmnia/npp"
+)
+
+// ProxyServerConfig specifies SSH proxy server configuration.
+type ProxyServerConfig struct {
+	Addr string     `yaml:"endpoint" required:"true"`
+	NPP  npp.Config `yaml:"npp" required:"true"`
+}

--- a/insonmnia/ssh/proxy.go
+++ b/insonmnia/ssh/proxy.go
@@ -1,0 +1,331 @@
+package ssh
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"math/big"
+	"net"
+	"os"
+	"strings"
+
+	"github.com/sonm-io/core/blockchain"
+	"github.com/sonm-io/core/insonmnia/auth"
+	"github.com/sonm-io/core/insonmnia/npp"
+	"github.com/sonm-io/core/proto"
+	"go.uber.org/zap"
+	"golang.org/x/crypto/ssh"
+	"golang.org/x/crypto/ssh/agent"
+	"golang.org/x/sync/errgroup"
+	"google.golang.org/grpc/credentials"
+
+	sshd "github.com/gliderlabs/ssh"
+)
+
+const (
+	proto            = "ssh"
+	sshAgentSockName = "SSH_AUTH_SOCK"
+)
+
+type NilSSHProxyServer struct{}
+
+func (m *NilSSHProxyServer) Serve(ctx context.Context) error {
+	return nil
+}
+
+type SSHProxyServer struct {
+	cfg     ProxyServerConfig
+	market  blockchain.MarketAPI
+	options []npp.Option
+	log     *zap.SugaredLogger
+}
+
+func convertHostSigners(v []ssh.Signer) []sshd.Signer {
+	var converted []sshd.Signer
+	for id := range v {
+		converted = append(converted, v[id])
+	}
+
+	return converted
+}
+
+// NewSSHProxyServer constructs a new SSH proxy server that will serve SSH
+// connections in remote containers by smart-forwarding traffic via itself.
+//
+// The server requires SSH agent running on the host system with appropriate
+// keys loaded in it. While running it will NOT modify the data within the
+// agent.
+//
+// Example of external usage: "ssh <DealID>.<TaskID>@<host> -p <port>".
+func NewSSHProxyServer(cfg ProxyServerConfig, credentials credentials.TransportCredentials, market blockchain.MarketAPI, log *zap.SugaredLogger) (*SSHProxyServer, error) {
+	options := []npp.Option{
+		npp.WithProtocol(proto),
+		npp.WithRendezvous(cfg.NPP.Rendezvous, credentials),
+		// TODO: Activate relay, but for now disable for rendezvous testing.
+		npp.WithLogger(log.Desugar()),
+	}
+
+	m := &SSHProxyServer{
+		cfg:     cfg,
+		market:  market,
+		options: options,
+		log:     log,
+	}
+
+	return m, nil
+}
+
+// Serve starts serving the SSH proxy server until the specified context is
+// canceled or a critical error occurs.
+func (m *SSHProxyServer) Serve(ctx context.Context) error {
+	m.log.Infof("exposing SSH server on %s", m.cfg.Addr)
+	defer m.log.Infof("stopped SSH server on %s", m.cfg.Addr)
+
+	agentSock, err := net.Dial("unix", os.Getenv(sshAgentSockName))
+	if err != nil {
+		return fmt.Errorf("failed to open ssh agent socket: %v", err)
+	}
+	defer agentSock.Close()
+
+	hostSigners, err := agent.NewClient(agentSock).Signers()
+	if err != nil {
+		return fmt.Errorf("failed to extract signers from ssh agent: %v", err)
+	}
+	if len(hostSigners) == 0 {
+		return fmt.Errorf("failed to extract signers from ssh agent: no identities known to the agent")
+	}
+
+	nppDialer, err := npp.NewDialer(m.options...)
+	if err != nil {
+		return err
+	}
+	defer nppDialer.Close()
+
+	connHandler := &connHandler{
+		market:      m.market,
+		nppDialer:   nppDialer,
+		hostSigners: hostSigners,
+		log:         m.log,
+	}
+
+	server := &sshd.Server{
+		Addr:        m.cfg.Addr,
+		Handler:     connHandler.onHandle,
+		HostSigners: convertHostSigners(hostSigners),
+	}
+
+	wg, ctx := errgroup.WithContext(ctx)
+	wg.Go(func() error {
+		return server.ListenAndServe()
+	})
+
+	<-ctx.Done()
+	server.Close()
+
+	return wg.Wait()
+}
+
+type connHandler struct {
+	market      blockchain.MarketAPI
+	nppDialer   *npp.Dialer
+	hostSigners []ssh.Signer
+	log         *zap.SugaredLogger
+}
+
+func (m *connHandler) onHandle(session sshd.Session) {
+	defer session.Close()
+
+	if err := m.handle(session); err != nil {
+		session.Write(formatErr(err))
+		session.Exit(1)
+		return
+	}
+
+	session.Exit(0)
+}
+
+func (m *connHandler) handle(session sshd.Session) error {
+	m.log.Infof("accepted SSH connection from %s", session.RemoteAddr())
+
+	pty, windows, isTty := session.Pty()
+	m.log.Debugw("handling SSH connection",
+		zap.Bool("tty", isTty),
+		zap.String("user", session.User()),
+		zap.String("terminal", pty.Term),
+		zap.String("publicKey", safeFingerprintSHA256(session.PublicKey())),
+	)
+
+	user, err := parseUserIdentity(session.User())
+	if err != nil {
+		return err
+	}
+
+	m.log.Debugw("resolving worker remote using passed user identity", zap.Any("user", user))
+	addr, err := m.resolve(session.Context(), user.DealID)
+	if err != nil {
+		return err
+	}
+
+	m.log.Debugf("resolved remote: %s", addr.String())
+
+	conn, err := m.nppDialer.Dial(*addr)
+	if err != nil {
+		return err
+	}
+
+	m.log.Debugf("connected to remote endpoint %s", conn.RemoteAddr())
+
+	cfg := &ssh.ClientConfig{
+		User: user.TaskID,
+		Auth: []ssh.AuthMethod{
+			ssh.PublicKeys(m.hostSigners...),
+		},
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+	}
+
+	clientConn, channels, requests, err := ssh.NewClientConn(conn, addr.String(), cfg)
+	if err != nil {
+		return err
+	}
+
+	client := ssh.NewClient(clientConn, channels, requests)
+	defer client.Close()
+
+	remoteSession, err := client.NewSession()
+	if err != nil {
+		return err
+	}
+	defer remoteSession.Close()
+
+	if isTty {
+		if err := remoteSession.RequestPty(pty.Term, pty.Window.Height, pty.Window.Width, ssh.TerminalModes{}); err != nil {
+			return err
+		}
+	}
+
+	for _, env := range session.Environ() {
+		parts := strings.SplitN(env, "=", 2)
+		if len(parts) != 2 {
+			return fmt.Errorf("invalid environment variable: %s", env)
+		}
+
+		remoteSession.Setenv(parts[0], parts[1])
+	}
+
+	stdin, err := remoteSession.StdinPipe()
+	if err != nil {
+		return err
+	}
+	stdout, err := remoteSession.StdoutPipe()
+	if err != nil {
+		return err
+	}
+	stderr, err := remoteSession.StderrPipe()
+	if err != nil {
+		return err
+	}
+	if err := remoteSession.Start(strings.Join(session.Command(), " ")); err != nil {
+		return err
+	}
+
+	m.log.Infof("opened SSH tunnel between %s -> %s, version %s", session.LocalAddr(), clientConn.RemoteAddr(), clientConn.ClientVersion())
+
+	forwardFunc := func(direction string, rd io.Reader, wr io.Writer) error {
+		m.log.Infof("forwarding %s", direction)
+
+		written, err := io.Copy(wr, rd)
+		if err != nil {
+			m.log.With(zap.Error(err)).Warnf("failed to forward %s", direction)
+			return err
+		}
+
+		m.log.Infof("finished forwarding %s: %d bytes written", direction, written)
+
+		return nil
+	}
+
+	wg, ctx := errgroup.WithContext(session.Context())
+	wg.Go(func() error {
+		return forwardFunc("-> stdin", session, stdin)
+	})
+	// TODO: stdout/stderr intermixing is possible. How to get with it?
+	wg.Go(func() error {
+		return forwardFunc("<- stdout", stdout, session)
+	})
+	wg.Go(func() error {
+		return forwardFunc("<- stderr", stderr, session)
+	})
+	wg.Go(func() error {
+		for window := range windows {
+			m.log.Debugf("detected window change: %dx%d", window.Height, window.Width)
+			if err := remoteSession.WindowChange(window.Height, window.Width); err != nil {
+				return err
+			}
+		}
+
+		return nil
+	})
+	wg.Go(func() error {
+		// When we're closing session first.
+		<-ctx.Done()
+		remoteSession.Close()
+		return nil
+	})
+	wg.Go(func() error {
+		// When remote session is finished.
+		err := remoteSession.Wait()
+		remoteSession.Close()
+		session.Close()
+		return err
+	})
+
+	return wg.Wait()
+}
+
+func (m *connHandler) resolve(ctx context.Context, dealID *big.Int) (*auth.Addr, error) {
+	deal, err := m.market.GetDealInfo(ctx, dealID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve `%s` deal into ETH address: %v", dealID.String(), err)
+	}
+
+	if deal.Status == sonm.DealStatus_DEAL_CLOSED {
+		return nil, fmt.Errorf("failed to resolve `%s` deal into ETH address: deal is closed", dealID.String())
+	}
+
+	return auth.NewAddr(deal.GetSupplierID().Unwrap().Hex())
+}
+
+type userIdentity struct {
+	DealID *big.Int
+	TaskID string
+}
+
+func parseUserIdentity(user string) (*userIdentity, error) {
+	parts := strings.Split(user, ".")
+
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("user identity must be in format <DealID>.<TaskID>, but received `%s`", user)
+	}
+
+	dealID, ok := new(big.Int).SetString(parts[0], 10)
+	if !ok {
+		return nil, fmt.Errorf("deal ID must be a number, but received `%s`", parts[0])
+	}
+
+	return &userIdentity{
+		DealID: dealID,
+		TaskID: parts[1],
+	}, nil
+}
+
+func formatErr(err error) []byte {
+	return []byte(fmt.Sprintf("Failed to ssh: %s.\n", err.Error()))
+}
+
+func safeFingerprintSHA256(publicKey ssh.PublicKey) string {
+	if publicKey == nil {
+		return ""
+	}
+
+	return ssh.FingerprintSHA256(publicKey)
+}

--- a/insonmnia/worker/config.go
+++ b/insonmnia/worker/config.go
@@ -16,11 +16,6 @@ import (
 	"github.com/sonm-io/core/util/debug"
 )
 
-type SSHConfig struct {
-	BindEndpoint   string `required:"true" yaml:"bind"`
-	PrivateKeyPath string `required:"true" yaml:"private_key_path"`
-}
-
 type ResourcesConfig struct {
 	Cgroup    string                `required:"true" yaml:"cgroup"`
 	Resources *specs.LinuxResources `required:"false" yaml:"resources"`

--- a/insonmnia/worker/container.go
+++ b/insonmnia/worker/container.go
@@ -172,7 +172,7 @@ func (c *containerDescriptor) execCommand(ctx context.Context, cmd []string, env
 				if !ok {
 					return
 				}
-				c.log.Info("resizing tty to %dx%d", w.Height, w.Width)
+				c.log.Infof("resizing tty to %dx%d", w.Height, w.Width)
 				err = c.client.ContainerExecResize(ctx, execId.ID, types.ResizeOptions{Height: uint(w.Height), Width: uint(w.Width)})
 				if err != nil {
 					log.G(ctx).Warn("ContainerExecResize finished with error", zap.Error(err))

--- a/insonmnia/worker/options.go
+++ b/insonmnia/worker/options.go
@@ -106,10 +106,6 @@ func (m *options) SetupDefaults() error {
 		return err
 	}
 
-	if err := m.setupSSH(); err != nil {
-		return err
-	}
-
 	if err := m.setupOverseer(); err != nil {
 		return err
 	}
@@ -276,7 +272,16 @@ func (m *options) setupNetworkOptions() error {
 	return nil
 }
 
-func (m *options) setupSSH() error {
+func (m *options) setupSSH(view OverseerView) error {
+	if m.cfg.SSH != nil {
+		ssh, err := NewSSHServer(*m.cfg.SSH, m.creds, view, ctxlog.S(m.ctx))
+		if err != nil {
+			return err
+		}
+		m.ssh = ssh
+		return nil
+	}
+
 	if m.ssh == nil {
 		m.ssh = nilSSH{}
 	}

--- a/insonmnia/worker/server.go
+++ b/insonmnia/worker/server.go
@@ -20,6 +20,7 @@ import (
 	"github.com/docker/go-connections/nat"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/gliderlabs/ssh"
 	"github.com/gogo/protobuf/proto"
 	"github.com/grpc-ecosystem/go-grpc-prometheus"
 	log "github.com/noxiouz/zapctx/ctxlog"
@@ -72,6 +73,31 @@ var (
 		workerAPIPrefix + "PurgeBenchmarks",
 	}
 )
+
+type overseerView struct {
+	worker *Worker
+}
+
+func (m *overseerView) ContainerInfo(id string) (*ContainerInfo, bool) {
+	return m.worker.GetContainerInfo(id)
+}
+
+func (m *overseerView) IdentityLevel(id string) (pb.IdentityLevel, error) {
+	plan, err := m.worker.AskPlanByTaskID(id)
+	if err != nil {
+		return pb.IdentityLevel_UNKNOWN, err
+	}
+
+	return plan.Identity, nil
+}
+
+func (m *overseerView) ExecIdentity() pb.IdentityLevel {
+	return m.worker.cfg.SSH.Identity
+}
+
+func (m *overseerView) Exec(ctx context.Context, id string, cmd []string, env []string, isTty bool, wCh <-chan ssh.Window) (types.HijackedResponse, error) {
+	return m.worker.ovs.Exec(ctx, id, cmd, env, isTty, wCh)
+}
 
 // Worker holds information about jobs, make orders to Observer and communicates with Worker
 type Worker struct {
@@ -155,20 +181,25 @@ func NewWorker(opts ...Option) (m *Worker, err error) {
 		return nil, err
 	}
 
+	if err := m.setupSSH(&overseerView{worker: m}); err != nil {
+		m.Close()
+		return nil, err
+	}
+
 	return m, nil
 }
 
 // Serve starts handling incoming API gRPC requests
 func (m *Worker) Serve() error {
-	defer m.Close()
-
 	m.startTime = time.Now()
 	if err := m.waitMasterApproved(); err != nil {
+		m.Close()
 		return err
 	}
 
 	relayListener, err := relay.NewListener(m.cfg.NPP.Relay.Endpoints, m.key, log.G(m.ctx))
 	if err != nil {
+		m.Close()
 		return err
 	}
 
@@ -181,14 +212,26 @@ func (m *Worker) Serve() error {
 	)
 	if err != nil {
 		log.G(m.ctx).Error("failed to listen", zap.String("address", m.cfg.Endpoint), zap.Error(err))
+		m.Close()
 		return err
 	}
 	m.listener = listener
 
-	log.G(m.ctx).Info("listening for gRPC API connections", zap.Stringer("address", listener.Addr()))
-	err = m.externalGrpc.Serve(listener)
+	wg, ctx := errgroup.WithContext(m.ctx)
+	wg.Go(func() error {
+		return m.RunSSH(ctx)
+	})
+	wg.Go(func() error {
+		log.S(m.ctx).Infof("listening for gRPC API connections on %s", listener.Addr())
+		defer log.S(m.ctx).Infof("finished listening for gRPC API connections on %s", listener.Addr())
 
-	return err
+		return m.externalGrpc.Serve(listener)
+	})
+
+	<-ctx.Done()
+	m.Close()
+
+	return wg.Wait()
 }
 
 func (m *Worker) waitMasterApproved() error {
@@ -393,17 +436,6 @@ func (m *Worker) GetContainerInfo(id string) (*ContainerInfo, bool) {
 	defer m.mu.Unlock()
 	info, ok := m.containers[id]
 	return info, ok
-}
-
-func (m *Worker) getContainerIdByTaskId(id string) (string, bool) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
-	info, ok := m.containers[id]
-	if ok {
-		return info.ID, ok
-	}
-	return "", ok
 }
 
 func (m *Worker) Devices(ctx context.Context, request *pb.Empty) (*pb.DevicesReply, error) {
@@ -801,7 +833,8 @@ func (m *Worker) TaskLogs(request *pb.TaskLogsRequest, server pb.Worker_TaskLogs
 	if err := m.eventAuthorization.Authorize(server.Context(), auth.Event(taskAPIPrefix+"TaskLogs"), request); err != nil {
 		return err
 	}
-	cid, ok := m.getContainerIdByTaskId(request.Id)
+	log.G(m.ctx).Info("handling TaskLogs request", zap.Any("request", request))
+	containerInfo, ok := m.GetContainerInfo(request.Id)
 	if !ok {
 		return status.Errorf(codes.NotFound, "no job with id %s", request.Id)
 	}
@@ -814,7 +847,7 @@ func (m *Worker) TaskLogs(request *pb.TaskLogsRequest, server pb.Worker_TaskLogs
 		Tail:       request.Tail,
 		Details:    request.Details,
 	}
-	reader, err := m.ovs.Logs(server.Context(), cid, opts)
+	reader, err := m.ovs.Logs(server.Context(), containerInfo.ID, opts)
 	if err != nil {
 		return err
 	}
@@ -877,8 +910,8 @@ func (m *Worker) TaskStatus(ctx context.Context, req *pb.ID) (*pb.TaskStatusRepl
 	return reply, nil
 }
 
-func (m *Worker) RunSSH() error {
-	return m.ssh.Run()
+func (m *Worker) RunSSH(ctx context.Context) error {
+	return m.ssh.Run(ctx)
 }
 
 // RunBenchmarks perform benchmarking of Worker's resources.

--- a/insonmnia/worker/ssh.go
+++ b/insonmnia/worker/ssh.go
@@ -1,104 +1,131 @@
 package worker
 
 import (
+	"context"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"net"
+	"strings"
 
+	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/pkg/stdcopy"
-	"github.com/gliderlabs/ssh"
-	log "github.com/noxiouz/zapctx/ctxlog"
+	"github.com/sonm-io/core/insonmnia/npp"
+	"github.com/sonm-io/core/proto"
 	"go.uber.org/zap"
-	gossh "golang.org/x/crypto/ssh"
+	"golang.org/x/crypto/ssh"
+	"google.golang.org/grpc/credentials"
+
+	sshd "github.com/gliderlabs/ssh"
 )
 
+const (
+	sshStatusOK          sshStatus = 0
+	sshStatusServerError           = 255
+)
+
+type sshStatus int
+
+type SSHConfig struct {
+	Endpoint       string             `yaml:"endpoint" required:"true"`
+	PrivateKeyPath string             `yaml:"private_key_path" required:"true"`
+	NPP            npp.Config         `yaml:"npp"`
+	Identity       sonm.IdentityLevel `yaml:"identity" default:"identified"`
+}
+
 type SSH interface {
-	Run() error
-	Close()
+	Run(ctx context.Context) error
+	Close() error
 }
 
 type nilSSH struct{}
 
-func (nilSSH) Run() error {
+func (nilSSH) Run(ctx context.Context) error { return nil }
+func (nilSSH) Close() error                  { return nil }
+
+// OverseerView is a bridge between keeping "Worker" as a parameter and
+// slightly more decomposed architecture.
+type OverseerView interface {
+	ContainerInfo(id string) (*ContainerInfo, bool)
+	IdentityLevel(id string) (sonm.IdentityLevel, error)
+	ExecIdentity() sonm.IdentityLevel
+	Exec(ctx context.Context, id string, cmd []string, env []string, isTty bool, wCh <-chan sshd.Window) (types.HijackedResponse, error)
+}
+
+type connHandler struct {
+	overseer OverseerView
+	log      *zap.SugaredLogger
+}
+
+func newConnHandler(overseer OverseerView, log *zap.SugaredLogger) *connHandler {
+	return &connHandler{
+		overseer: overseer,
+		log:      log,
+	}
+}
+
+func (m *connHandler) Verify(ctx sshd.Context, key sshd.PublicKey) bool {
+	if err := m.verify(ctx.User(), key); err != nil {
+		m.log.Warnw("verification failed", zap.Error(err))
+		return false
+	}
+
+	return true
+}
+
+func (m *connHandler) verify(taskID string, key sshd.PublicKey) error {
+	m.log.Debugf("public key %s verification from user %s", ssh.FingerprintSHA256(key), taskID)
+
+	containerInfo, ok := m.overseer.ContainerInfo(taskID)
+	if !ok {
+		return fmt.Errorf("container `%s` not found", taskID)
+	}
+
+	if !sshd.KeysEqual(containerInfo.PublicKey, key) {
+		return fmt.Errorf("provided public key `%s` is not equal with the specified key `%s`", ssh.FingerprintSHA256(key), ssh.FingerprintSHA256(containerInfo.PublicKey))
+	}
+
 	return nil
 }
 
-func (nilSSH) Close() {}
-
-type sshServer struct {
-	worker         *Worker
-	laddr          string
-	privateKeyPath string
-	listener       net.Listener
-	server         *ssh.Server
-}
-
-func NewSSH(worker *Worker, config *SSHConfig) (SSH, error) {
-	ret := sshServer{
-		laddr:          config.BindEndpoint,
-		privateKeyPath: config.PrivateKeyPath,
-		worker:         worker,
-	}
-	return &ret, nil
-}
-
-func (s *sshServer) Run() error {
-	l, err := net.Listen("tcp", s.laddr)
+func (m *connHandler) onSession(session sshd.Session) {
+	status, err := m.process(session)
 	if err != nil {
-		return err
+		session.Write([]byte(capitalize(err.Error()) + "\n"))
+		m.log.Warnw("failed to process ssh session", zap.Error(err))
 	}
-	s.listener = l
-	s.server = &ssh.Server{}
-	if len(s.privateKeyPath) != 0 {
-		pkeyData, err := ioutil.ReadFile(s.privateKeyPath)
-		if err != nil {
-			return err
-		}
-		pkey, err := gossh.ParsePrivateKey(pkeyData)
-		if err != nil {
-			return err
-		}
-		s.server.HostSigners = append(s.server.HostSigners, pkey)
-	}
-	s.server.Handle(s.onSession)
-	s.server.PublicKeyHandler = s.verify
-	return s.server.Serve(s.listener)
+
+	session.Exit(int(status))
+
+	m.log.Infof("finished processing ssh session with %d status", int(status))
 }
 
-func (s *sshServer) verify(ctx ssh.Context, key ssh.PublicKey) bool {
-	cinfo, ok := s.worker.GetContainerInfo(ctx.User())
-	if !ok {
-		return false
-	}
-	log.G(s.worker.ctx).Info("verifying public key")
-	return ssh.KeysEqual(cinfo.PublicKey, key)
-}
-
-func (s *sshServer) onSession(session ssh.Session) {
-	status := s.process(session)
-	session.Exit(status)
-	log.G(s.worker.ctx).Info("finished processing ssh session", zap.Int("status", status))
-}
-
-func (s *sshServer) process(session ssh.Session) (status int) {
-	status = 255
+func (m *connHandler) process(session sshd.Session) (sshStatus, error) {
+	m.log.Debugf("processing %v", session.RemoteAddr())
 	_, wCh, isTty := session.Pty()
 
 	cmd := session.Command()
 	if len(cmd) == 0 {
-		cmd = append(cmd, "login", "-f", "root")
+		cmd = []string{"login", "-f", "root"}
 	}
-	cid, ok := s.worker.getContainerIdByTaskId(session.User())
-	if !ok {
-		msg := "could not find container by task " + string(session.User()+"\n")
-		session.Write([]byte(msg))
-		log.G(s.worker.ctx).Warn(msg)
-		return
-	}
-	stream, err := s.worker.ovs.Exec(s.worker.ctx, cid, cmd, session.Environ(), isTty, wCh)
+
+	identity, err := m.overseer.IdentityLevel(session.User())
 	if err != nil {
-		session.Write([]byte(err.Error()))
-		return
+		return sshStatusServerError, fmt.Errorf("failed to extract identity level for task `%s`: %v", session.User(), err)
+	}
+
+	if identity < m.overseer.ExecIdentity() {
+		return sshStatusServerError, fmt.Errorf("identity level `%s` does not allow to exec ssh: must be `%s` or higher", identity.String(), m.overseer.ExecIdentity())
+	}
+
+	containerInfo, ok := m.overseer.ContainerInfo(session.User())
+	if !ok {
+		return sshStatusServerError, fmt.Errorf("failed to find container for task `%s`", session.User())
+	}
+
+	stream, err := m.overseer.Exec(session.Context(), containerInfo.ID, cmd, session.Environ(), isTty, wCh)
+	if err != nil {
+		return sshStatusServerError, err
 	}
 	defer stream.Close()
 	outputErr := make(chan error)
@@ -120,24 +147,82 @@ func (s *sshServer) process(session ssh.Session) (status int) {
 
 	err = <-outputErr
 	if err != nil {
-		status = 0
-	} else {
-		log.G(s.worker.ctx).Warn("io error during ssh session:", zap.Error(err))
+		m.log.Warnw("I/O error during SSH session", zap.Error(err))
+		return sshStatusServerError, nil
 	}
-	return
+
+	return sshStatusOK, nil
 }
 
-func (s *sshServer) Close() {
-	if s.server != nil {
-		log.G(s.worker.ctx).Info("closing ssh server")
-		s.server.Close()
+type sshServer struct {
+	cfg         SSHConfig
+	credentials credentials.TransportCredentials
+	server      *sshd.Server
+	log         *zap.SugaredLogger
+}
+
+func NewSSHServer(cfg SSHConfig, credentials credentials.TransportCredentials, overseer OverseerView, log *zap.SugaredLogger) (*sshServer, error) {
+	privateKeyData, err := ioutil.ReadFile(cfg.PrivateKeyPath)
+	if err != nil {
+		return nil, err
 	}
+
+	privateKey, err := ssh.ParsePrivateKey(privateKeyData)
+	if err != nil {
+		return nil, err
+	}
+
+	connHandler := newConnHandler(overseer, log)
+
+	server := &sshd.Server{
+		Handler:          connHandler.onSession,
+		HostSigners:      []sshd.Signer{privateKey},
+		PublicKeyHandler: connHandler.Verify,
+	}
+
+	m := &sshServer{
+		cfg:         cfg,
+		credentials: credentials,
+		server:      server,
+		log:         log,
+	}
+
+	return m, nil
+}
+
+func (m *sshServer) Run(ctx context.Context) error {
+	m.log.Info("running ssh server")
+	defer m.log.Info("stopped ssh server")
+
+	listener, err := m.newListener(ctx)
+	if err != nil {
+		return err
+	}
+	defer listener.Close()
+
+	return m.server.Serve(listener)
+}
+
+func (m *sshServer) newListener(ctx context.Context) (net.Listener, error) {
+	nppOptions := []npp.Option{
+		npp.WithProtocol("ssh"),
+		npp.WithRendezvous(m.cfg.NPP.Rendezvous, m.credentials),
+		// TODO: Relay.
+		npp.WithLogger(m.log.Desugar()),
+	}
+
+	return npp.NewListener(ctx, m.cfg.Endpoint, nppOptions...)
+}
+
+func (m *sshServer) Close() error {
+	m.log.Info("closing ssh server")
+
+	return m.server.Close()
 }
 
 func parsePublicKey(key string) (ssh.PublicKey, error) {
 	var publicKey ssh.PublicKey
 	if len(key) != 0 {
-		var err error
 		k, _, _, _, err := ssh.ParseAuthorizedKey([]byte(key))
 		if err != nil {
 			return nil, err
@@ -146,4 +231,12 @@ func parsePublicKey(key string) (ssh.PublicKey, error) {
 	}
 
 	return publicKey, nil
+}
+
+func capitalize(s string) string {
+	if len(s) == 0 {
+		return s
+	}
+
+	return strings.ToUpper(s[:1]) + s[1:]
 }

--- a/vendor/golang.org/x/crypto/ssh/agent/client.go
+++ b/vendor/golang.org/x/crypto/ssh/agent/client.go
@@ -1,0 +1,683 @@
+// Copyright 2012 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package agent implements the ssh-agent protocol, and provides both
+// a client and a server. The client can talk to a standard ssh-agent
+// that uses UNIX sockets, and one could implement an alternative
+// ssh-agent process using the sample server.
+//
+// References:
+//  [PROTOCOL.agent]:    http://cvsweb.openbsd.org/cgi-bin/cvsweb/src/usr.bin/ssh/PROTOCOL.agent?rev=HEAD
+package agent // import "golang.org/x/crypto/ssh/agent"
+
+import (
+	"bytes"
+	"crypto/dsa"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rsa"
+	"encoding/base64"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"math/big"
+	"sync"
+
+	"golang.org/x/crypto/ed25519"
+	"golang.org/x/crypto/ssh"
+)
+
+// Agent represents the capabilities of an ssh-agent.
+type Agent interface {
+	// List returns the identities known to the agent.
+	List() ([]*Key, error)
+
+	// Sign has the agent sign the data using a protocol 2 key as defined
+	// in [PROTOCOL.agent] section 2.6.2.
+	Sign(key ssh.PublicKey, data []byte) (*ssh.Signature, error)
+
+	// Add adds a private key to the agent.
+	Add(key AddedKey) error
+
+	// Remove removes all identities with the given public key.
+	Remove(key ssh.PublicKey) error
+
+	// RemoveAll removes all identities.
+	RemoveAll() error
+
+	// Lock locks the agent. Sign and Remove will fail, and List will empty an empty list.
+	Lock(passphrase []byte) error
+
+	// Unlock undoes the effect of Lock
+	Unlock(passphrase []byte) error
+
+	// Signers returns signers for all the known keys.
+	Signers() ([]ssh.Signer, error)
+}
+
+// ConstraintExtension describes an optional constraint defined by users.
+type ConstraintExtension struct {
+	// ExtensionName consist of a UTF-8 string suffixed by the
+	// implementation domain following the naming scheme defined
+	// in Section 4.2 of [RFC4251], e.g.  "foo@example.com".
+	ExtensionName string
+	// ExtensionDetails contains the actual content of the extended
+	// constraint.
+	ExtensionDetails []byte
+}
+
+// AddedKey describes an SSH key to be added to an Agent.
+type AddedKey struct {
+	// PrivateKey must be a *rsa.PrivateKey, *dsa.PrivateKey or
+	// *ecdsa.PrivateKey, which will be inserted into the agent.
+	PrivateKey interface{}
+	// Certificate, if not nil, is communicated to the agent and will be
+	// stored with the key.
+	Certificate *ssh.Certificate
+	// Comment is an optional, free-form string.
+	Comment string
+	// LifetimeSecs, if not zero, is the number of seconds that the
+	// agent will store the key for.
+	LifetimeSecs uint32
+	// ConfirmBeforeUse, if true, requests that the agent confirm with the
+	// user before each use of this key.
+	ConfirmBeforeUse bool
+	// ConstraintExtensions are the experimental or private-use constraints
+	// defined by users.
+	ConstraintExtensions []ConstraintExtension
+}
+
+// See [PROTOCOL.agent], section 3.
+const (
+	agentRequestV1Identities   = 1
+	agentRemoveAllV1Identities = 9
+
+	// 3.2 Requests from client to agent for protocol 2 key operations
+	agentAddIdentity         = 17
+	agentRemoveIdentity      = 18
+	agentRemoveAllIdentities = 19
+	agentAddIDConstrained    = 25
+
+	// 3.3 Key-type independent requests from client to agent
+	agentAddSmartcardKey            = 20
+	agentRemoveSmartcardKey         = 21
+	agentLock                       = 22
+	agentUnlock                     = 23
+	agentAddSmartcardKeyConstrained = 26
+
+	// 3.7 Key constraint identifiers
+	agentConstrainLifetime  = 1
+	agentConstrainConfirm   = 2
+	agentConstrainExtension = 3
+)
+
+// maxAgentResponseBytes is the maximum agent reply size that is accepted. This
+// is a sanity check, not a limit in the spec.
+const maxAgentResponseBytes = 16 << 20
+
+// Agent messages:
+// These structures mirror the wire format of the corresponding ssh agent
+// messages found in [PROTOCOL.agent].
+
+// 3.4 Generic replies from agent to client
+const agentFailure = 5
+
+type failureAgentMsg struct{}
+
+const agentSuccess = 6
+
+type successAgentMsg struct{}
+
+// See [PROTOCOL.agent], section 2.5.2.
+const agentRequestIdentities = 11
+
+type requestIdentitiesAgentMsg struct{}
+
+// See [PROTOCOL.agent], section 2.5.2.
+const agentIdentitiesAnswer = 12
+
+type identitiesAnswerAgentMsg struct {
+	NumKeys uint32 `sshtype:"12"`
+	Keys    []byte `ssh:"rest"`
+}
+
+// See [PROTOCOL.agent], section 2.6.2.
+const agentSignRequest = 13
+
+type signRequestAgentMsg struct {
+	KeyBlob []byte `sshtype:"13"`
+	Data    []byte
+	Flags   uint32
+}
+
+// See [PROTOCOL.agent], section 2.6.2.
+
+// 3.6 Replies from agent to client for protocol 2 key operations
+const agentSignResponse = 14
+
+type signResponseAgentMsg struct {
+	SigBlob []byte `sshtype:"14"`
+}
+
+type publicKey struct {
+	Format string
+	Rest   []byte `ssh:"rest"`
+}
+
+// 3.7 Key constraint identifiers
+type constrainLifetimeAgentMsg struct {
+	LifetimeSecs uint32 `sshtype:"1"`
+}
+
+type constrainExtensionAgentMsg struct {
+	ExtensionName    string `sshtype:"3"`
+	ExtensionDetails []byte
+
+	// Rest is a field used for parsing, not part of message
+	Rest []byte `ssh:"rest"`
+}
+
+// Key represents a protocol 2 public key as defined in
+// [PROTOCOL.agent], section 2.5.2.
+type Key struct {
+	Format  string
+	Blob    []byte
+	Comment string
+}
+
+func clientErr(err error) error {
+	return fmt.Errorf("agent: client error: %v", err)
+}
+
+// String returns the storage form of an agent key with the format, base64
+// encoded serialized key, and the comment if it is not empty.
+func (k *Key) String() string {
+	s := string(k.Format) + " " + base64.StdEncoding.EncodeToString(k.Blob)
+
+	if k.Comment != "" {
+		s += " " + k.Comment
+	}
+
+	return s
+}
+
+// Type returns the public key type.
+func (k *Key) Type() string {
+	return k.Format
+}
+
+// Marshal returns key blob to satisfy the ssh.PublicKey interface.
+func (k *Key) Marshal() []byte {
+	return k.Blob
+}
+
+// Verify satisfies the ssh.PublicKey interface.
+func (k *Key) Verify(data []byte, sig *ssh.Signature) error {
+	pubKey, err := ssh.ParsePublicKey(k.Blob)
+	if err != nil {
+		return fmt.Errorf("agent: bad public key: %v", err)
+	}
+	return pubKey.Verify(data, sig)
+}
+
+type wireKey struct {
+	Format string
+	Rest   []byte `ssh:"rest"`
+}
+
+func parseKey(in []byte) (out *Key, rest []byte, err error) {
+	var record struct {
+		Blob    []byte
+		Comment string
+		Rest    []byte `ssh:"rest"`
+	}
+
+	if err := ssh.Unmarshal(in, &record); err != nil {
+		return nil, nil, err
+	}
+
+	var wk wireKey
+	if err := ssh.Unmarshal(record.Blob, &wk); err != nil {
+		return nil, nil, err
+	}
+
+	return &Key{
+		Format:  wk.Format,
+		Blob:    record.Blob,
+		Comment: record.Comment,
+	}, record.Rest, nil
+}
+
+// client is a client for an ssh-agent process.
+type client struct {
+	// conn is typically a *net.UnixConn
+	conn io.ReadWriter
+	// mu is used to prevent concurrent access to the agent
+	mu sync.Mutex
+}
+
+// NewClient returns an Agent that talks to an ssh-agent process over
+// the given connection.
+func NewClient(rw io.ReadWriter) Agent {
+	return &client{conn: rw}
+}
+
+// call sends an RPC to the agent. On success, the reply is
+// unmarshaled into reply and replyType is set to the first byte of
+// the reply, which contains the type of the message.
+func (c *client) call(req []byte) (reply interface{}, err error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	msg := make([]byte, 4+len(req))
+	binary.BigEndian.PutUint32(msg, uint32(len(req)))
+	copy(msg[4:], req)
+	if _, err = c.conn.Write(msg); err != nil {
+		return nil, clientErr(err)
+	}
+
+	var respSizeBuf [4]byte
+	if _, err = io.ReadFull(c.conn, respSizeBuf[:]); err != nil {
+		return nil, clientErr(err)
+	}
+	respSize := binary.BigEndian.Uint32(respSizeBuf[:])
+	if respSize > maxAgentResponseBytes {
+		return nil, clientErr(err)
+	}
+
+	buf := make([]byte, respSize)
+	if _, err = io.ReadFull(c.conn, buf); err != nil {
+		return nil, clientErr(err)
+	}
+	reply, err = unmarshal(buf)
+	if err != nil {
+		return nil, clientErr(err)
+	}
+	return reply, err
+}
+
+func (c *client) simpleCall(req []byte) error {
+	resp, err := c.call(req)
+	if err != nil {
+		return err
+	}
+	if _, ok := resp.(*successAgentMsg); ok {
+		return nil
+	}
+	return errors.New("agent: failure")
+}
+
+func (c *client) RemoveAll() error {
+	return c.simpleCall([]byte{agentRemoveAllIdentities})
+}
+
+func (c *client) Remove(key ssh.PublicKey) error {
+	req := ssh.Marshal(&agentRemoveIdentityMsg{
+		KeyBlob: key.Marshal(),
+	})
+	return c.simpleCall(req)
+}
+
+func (c *client) Lock(passphrase []byte) error {
+	req := ssh.Marshal(&agentLockMsg{
+		Passphrase: passphrase,
+	})
+	return c.simpleCall(req)
+}
+
+func (c *client) Unlock(passphrase []byte) error {
+	req := ssh.Marshal(&agentUnlockMsg{
+		Passphrase: passphrase,
+	})
+	return c.simpleCall(req)
+}
+
+// List returns the identities known to the agent.
+func (c *client) List() ([]*Key, error) {
+	// see [PROTOCOL.agent] section 2.5.2.
+	req := []byte{agentRequestIdentities}
+
+	msg, err := c.call(req)
+	if err != nil {
+		return nil, err
+	}
+
+	switch msg := msg.(type) {
+	case *identitiesAnswerAgentMsg:
+		if msg.NumKeys > maxAgentResponseBytes/8 {
+			return nil, errors.New("agent: too many keys in agent reply")
+		}
+		keys := make([]*Key, msg.NumKeys)
+		data := msg.Keys
+		for i := uint32(0); i < msg.NumKeys; i++ {
+			var key *Key
+			var err error
+			if key, data, err = parseKey(data); err != nil {
+				return nil, err
+			}
+			keys[i] = key
+		}
+		return keys, nil
+	case *failureAgentMsg:
+		return nil, errors.New("agent: failed to list keys")
+	}
+	panic("unreachable")
+}
+
+// Sign has the agent sign the data using a protocol 2 key as defined
+// in [PROTOCOL.agent] section 2.6.2.
+func (c *client) Sign(key ssh.PublicKey, data []byte) (*ssh.Signature, error) {
+	req := ssh.Marshal(signRequestAgentMsg{
+		KeyBlob: key.Marshal(),
+		Data:    data,
+	})
+
+	msg, err := c.call(req)
+	if err != nil {
+		return nil, err
+	}
+
+	switch msg := msg.(type) {
+	case *signResponseAgentMsg:
+		var sig ssh.Signature
+		if err := ssh.Unmarshal(msg.SigBlob, &sig); err != nil {
+			return nil, err
+		}
+
+		return &sig, nil
+	case *failureAgentMsg:
+		return nil, errors.New("agent: failed to sign challenge")
+	}
+	panic("unreachable")
+}
+
+// unmarshal parses an agent message in packet, returning the parsed
+// form and the message type of packet.
+func unmarshal(packet []byte) (interface{}, error) {
+	if len(packet) < 1 {
+		return nil, errors.New("agent: empty packet")
+	}
+	var msg interface{}
+	switch packet[0] {
+	case agentFailure:
+		return new(failureAgentMsg), nil
+	case agentSuccess:
+		return new(successAgentMsg), nil
+	case agentIdentitiesAnswer:
+		msg = new(identitiesAnswerAgentMsg)
+	case agentSignResponse:
+		msg = new(signResponseAgentMsg)
+	case agentV1IdentitiesAnswer:
+		msg = new(agentV1IdentityMsg)
+	default:
+		return nil, fmt.Errorf("agent: unknown type tag %d", packet[0])
+	}
+	if err := ssh.Unmarshal(packet, msg); err != nil {
+		return nil, err
+	}
+	return msg, nil
+}
+
+type rsaKeyMsg struct {
+	Type        string `sshtype:"17|25"`
+	N           *big.Int
+	E           *big.Int
+	D           *big.Int
+	Iqmp        *big.Int // IQMP = Inverse Q Mod P
+	P           *big.Int
+	Q           *big.Int
+	Comments    string
+	Constraints []byte `ssh:"rest"`
+}
+
+type dsaKeyMsg struct {
+	Type        string `sshtype:"17|25"`
+	P           *big.Int
+	Q           *big.Int
+	G           *big.Int
+	Y           *big.Int
+	X           *big.Int
+	Comments    string
+	Constraints []byte `ssh:"rest"`
+}
+
+type ecdsaKeyMsg struct {
+	Type        string `sshtype:"17|25"`
+	Curve       string
+	KeyBytes    []byte
+	D           *big.Int
+	Comments    string
+	Constraints []byte `ssh:"rest"`
+}
+
+type ed25519KeyMsg struct {
+	Type        string `sshtype:"17|25"`
+	Pub         []byte
+	Priv        []byte
+	Comments    string
+	Constraints []byte `ssh:"rest"`
+}
+
+// Insert adds a private key to the agent.
+func (c *client) insertKey(s interface{}, comment string, constraints []byte) error {
+	var req []byte
+	switch k := s.(type) {
+	case *rsa.PrivateKey:
+		if len(k.Primes) != 2 {
+			return fmt.Errorf("agent: unsupported RSA key with %d primes", len(k.Primes))
+		}
+		k.Precompute()
+		req = ssh.Marshal(rsaKeyMsg{
+			Type:        ssh.KeyAlgoRSA,
+			N:           k.N,
+			E:           big.NewInt(int64(k.E)),
+			D:           k.D,
+			Iqmp:        k.Precomputed.Qinv,
+			P:           k.Primes[0],
+			Q:           k.Primes[1],
+			Comments:    comment,
+			Constraints: constraints,
+		})
+	case *dsa.PrivateKey:
+		req = ssh.Marshal(dsaKeyMsg{
+			Type:        ssh.KeyAlgoDSA,
+			P:           k.P,
+			Q:           k.Q,
+			G:           k.G,
+			Y:           k.Y,
+			X:           k.X,
+			Comments:    comment,
+			Constraints: constraints,
+		})
+	case *ecdsa.PrivateKey:
+		nistID := fmt.Sprintf("nistp%d", k.Params().BitSize)
+		req = ssh.Marshal(ecdsaKeyMsg{
+			Type:        "ecdsa-sha2-" + nistID,
+			Curve:       nistID,
+			KeyBytes:    elliptic.Marshal(k.Curve, k.X, k.Y),
+			D:           k.D,
+			Comments:    comment,
+			Constraints: constraints,
+		})
+	case *ed25519.PrivateKey:
+		req = ssh.Marshal(ed25519KeyMsg{
+			Type:        ssh.KeyAlgoED25519,
+			Pub:         []byte(*k)[32:],
+			Priv:        []byte(*k),
+			Comments:    comment,
+			Constraints: constraints,
+		})
+	default:
+		return fmt.Errorf("agent: unsupported key type %T", s)
+	}
+
+	// if constraints are present then the message type needs to be changed.
+	if len(constraints) != 0 {
+		req[0] = agentAddIDConstrained
+	}
+
+	resp, err := c.call(req)
+	if err != nil {
+		return err
+	}
+	if _, ok := resp.(*successAgentMsg); ok {
+		return nil
+	}
+	return errors.New("agent: failure")
+}
+
+type rsaCertMsg struct {
+	Type        string `sshtype:"17|25"`
+	CertBytes   []byte
+	D           *big.Int
+	Iqmp        *big.Int // IQMP = Inverse Q Mod P
+	P           *big.Int
+	Q           *big.Int
+	Comments    string
+	Constraints []byte `ssh:"rest"`
+}
+
+type dsaCertMsg struct {
+	Type        string `sshtype:"17|25"`
+	CertBytes   []byte
+	X           *big.Int
+	Comments    string
+	Constraints []byte `ssh:"rest"`
+}
+
+type ecdsaCertMsg struct {
+	Type        string `sshtype:"17|25"`
+	CertBytes   []byte
+	D           *big.Int
+	Comments    string
+	Constraints []byte `ssh:"rest"`
+}
+
+type ed25519CertMsg struct {
+	Type        string `sshtype:"17|25"`
+	CertBytes   []byte
+	Pub         []byte
+	Priv        []byte
+	Comments    string
+	Constraints []byte `ssh:"rest"`
+}
+
+// Add adds a private key to the agent. If a certificate is given,
+// that certificate is added instead as public key.
+func (c *client) Add(key AddedKey) error {
+	var constraints []byte
+
+	if secs := key.LifetimeSecs; secs != 0 {
+		constraints = append(constraints, ssh.Marshal(constrainLifetimeAgentMsg{secs})...)
+	}
+
+	if key.ConfirmBeforeUse {
+		constraints = append(constraints, agentConstrainConfirm)
+	}
+
+	cert := key.Certificate
+	if cert == nil {
+		return c.insertKey(key.PrivateKey, key.Comment, constraints)
+	}
+	return c.insertCert(key.PrivateKey, cert, key.Comment, constraints)
+}
+
+func (c *client) insertCert(s interface{}, cert *ssh.Certificate, comment string, constraints []byte) error {
+	var req []byte
+	switch k := s.(type) {
+	case *rsa.PrivateKey:
+		if len(k.Primes) != 2 {
+			return fmt.Errorf("agent: unsupported RSA key with %d primes", len(k.Primes))
+		}
+		k.Precompute()
+		req = ssh.Marshal(rsaCertMsg{
+			Type:        cert.Type(),
+			CertBytes:   cert.Marshal(),
+			D:           k.D,
+			Iqmp:        k.Precomputed.Qinv,
+			P:           k.Primes[0],
+			Q:           k.Primes[1],
+			Comments:    comment,
+			Constraints: constraints,
+		})
+	case *dsa.PrivateKey:
+		req = ssh.Marshal(dsaCertMsg{
+			Type:        cert.Type(),
+			CertBytes:   cert.Marshal(),
+			X:           k.X,
+			Comments:    comment,
+			Constraints: constraints,
+		})
+	case *ecdsa.PrivateKey:
+		req = ssh.Marshal(ecdsaCertMsg{
+			Type:        cert.Type(),
+			CertBytes:   cert.Marshal(),
+			D:           k.D,
+			Comments:    comment,
+			Constraints: constraints,
+		})
+	case *ed25519.PrivateKey:
+		req = ssh.Marshal(ed25519CertMsg{
+			Type:        cert.Type(),
+			CertBytes:   cert.Marshal(),
+			Pub:         []byte(*k)[32:],
+			Priv:        []byte(*k),
+			Comments:    comment,
+			Constraints: constraints,
+		})
+	default:
+		return fmt.Errorf("agent: unsupported key type %T", s)
+	}
+
+	// if constraints are present then the message type needs to be changed.
+	if len(constraints) != 0 {
+		req[0] = agentAddIDConstrained
+	}
+
+	signer, err := ssh.NewSignerFromKey(s)
+	if err != nil {
+		return err
+	}
+	if bytes.Compare(cert.Key.Marshal(), signer.PublicKey().Marshal()) != 0 {
+		return errors.New("agent: signer and cert have different public key")
+	}
+
+	resp, err := c.call(req)
+	if err != nil {
+		return err
+	}
+	if _, ok := resp.(*successAgentMsg); ok {
+		return nil
+	}
+	return errors.New("agent: failure")
+}
+
+// Signers provides a callback for client authentication.
+func (c *client) Signers() ([]ssh.Signer, error) {
+	keys, err := c.List()
+	if err != nil {
+		return nil, err
+	}
+
+	var result []ssh.Signer
+	for _, k := range keys {
+		result = append(result, &agentKeyringSigner{c, k})
+	}
+	return result, nil
+}
+
+type agentKeyringSigner struct {
+	agent *client
+	pub   ssh.PublicKey
+}
+
+func (s *agentKeyringSigner) PublicKey() ssh.PublicKey {
+	return s.pub
+}
+
+func (s *agentKeyringSigner) Sign(rand io.Reader, data []byte) (*ssh.Signature, error) {
+	// The agent has its own entropy source, so the rand argument is ignored.
+	return s.agent.Sign(s.pub, data)
+}

--- a/vendor/golang.org/x/crypto/ssh/agent/forward.go
+++ b/vendor/golang.org/x/crypto/ssh/agent/forward.go
@@ -1,0 +1,103 @@
+// Copyright 2014 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package agent
+
+import (
+	"errors"
+	"io"
+	"net"
+	"sync"
+
+	"golang.org/x/crypto/ssh"
+)
+
+// RequestAgentForwarding sets up agent forwarding for the session.
+// ForwardToAgent or ForwardToRemote should be called to route
+// the authentication requests.
+func RequestAgentForwarding(session *ssh.Session) error {
+	ok, err := session.SendRequest("auth-agent-req@openssh.com", true, nil)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return errors.New("forwarding request denied")
+	}
+	return nil
+}
+
+// ForwardToAgent routes authentication requests to the given keyring.
+func ForwardToAgent(client *ssh.Client, keyring Agent) error {
+	channels := client.HandleChannelOpen(channelType)
+	if channels == nil {
+		return errors.New("agent: already have handler for " + channelType)
+	}
+
+	go func() {
+		for ch := range channels {
+			channel, reqs, err := ch.Accept()
+			if err != nil {
+				continue
+			}
+			go ssh.DiscardRequests(reqs)
+			go func() {
+				ServeAgent(keyring, channel)
+				channel.Close()
+			}()
+		}
+	}()
+	return nil
+}
+
+const channelType = "auth-agent@openssh.com"
+
+// ForwardToRemote routes authentication requests to the ssh-agent
+// process serving on the given unix socket.
+func ForwardToRemote(client *ssh.Client, addr string) error {
+	channels := client.HandleChannelOpen(channelType)
+	if channels == nil {
+		return errors.New("agent: already have handler for " + channelType)
+	}
+	conn, err := net.Dial("unix", addr)
+	if err != nil {
+		return err
+	}
+	conn.Close()
+
+	go func() {
+		for ch := range channels {
+			channel, reqs, err := ch.Accept()
+			if err != nil {
+				continue
+			}
+			go ssh.DiscardRequests(reqs)
+			go forwardUnixSocket(channel, addr)
+		}
+	}()
+	return nil
+}
+
+func forwardUnixSocket(channel ssh.Channel, addr string) {
+	conn, err := net.Dial("unix", addr)
+	if err != nil {
+		return
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		io.Copy(conn, channel)
+		conn.(*net.UnixConn).CloseWrite()
+		wg.Done()
+	}()
+	go func() {
+		io.Copy(channel, conn)
+		channel.CloseWrite()
+		wg.Done()
+	}()
+
+	wg.Wait()
+	conn.Close()
+	channel.Close()
+}

--- a/vendor/golang.org/x/crypto/ssh/agent/keyring.go
+++ b/vendor/golang.org/x/crypto/ssh/agent/keyring.go
@@ -1,0 +1,215 @@
+// Copyright 2014 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package agent
+
+import (
+	"bytes"
+	"crypto/rand"
+	"crypto/subtle"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"golang.org/x/crypto/ssh"
+)
+
+type privKey struct {
+	signer  ssh.Signer
+	comment string
+	expire  *time.Time
+}
+
+type keyring struct {
+	mu   sync.Mutex
+	keys []privKey
+
+	locked     bool
+	passphrase []byte
+}
+
+var errLocked = errors.New("agent: locked")
+
+// NewKeyring returns an Agent that holds keys in memory.  It is safe
+// for concurrent use by multiple goroutines.
+func NewKeyring() Agent {
+	return &keyring{}
+}
+
+// RemoveAll removes all identities.
+func (r *keyring) RemoveAll() error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.locked {
+		return errLocked
+	}
+
+	r.keys = nil
+	return nil
+}
+
+// removeLocked does the actual key removal. The caller must already be holding the
+// keyring mutex.
+func (r *keyring) removeLocked(want []byte) error {
+	found := false
+	for i := 0; i < len(r.keys); {
+		if bytes.Equal(r.keys[i].signer.PublicKey().Marshal(), want) {
+			found = true
+			r.keys[i] = r.keys[len(r.keys)-1]
+			r.keys = r.keys[:len(r.keys)-1]
+			continue
+		} else {
+			i++
+		}
+	}
+
+	if !found {
+		return errors.New("agent: key not found")
+	}
+	return nil
+}
+
+// Remove removes all identities with the given public key.
+func (r *keyring) Remove(key ssh.PublicKey) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.locked {
+		return errLocked
+	}
+
+	return r.removeLocked(key.Marshal())
+}
+
+// Lock locks the agent. Sign and Remove will fail, and List will return an empty list.
+func (r *keyring) Lock(passphrase []byte) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.locked {
+		return errLocked
+	}
+
+	r.locked = true
+	r.passphrase = passphrase
+	return nil
+}
+
+// Unlock undoes the effect of Lock
+func (r *keyring) Unlock(passphrase []byte) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if !r.locked {
+		return errors.New("agent: not locked")
+	}
+	if len(passphrase) != len(r.passphrase) || 1 != subtle.ConstantTimeCompare(passphrase, r.passphrase) {
+		return fmt.Errorf("agent: incorrect passphrase")
+	}
+
+	r.locked = false
+	r.passphrase = nil
+	return nil
+}
+
+// expireKeysLocked removes expired keys from the keyring. If a key was added
+// with a lifetimesecs contraint and seconds >= lifetimesecs seconds have
+// ellapsed, it is removed. The caller *must* be holding the keyring mutex.
+func (r *keyring) expireKeysLocked() {
+	for _, k := range r.keys {
+		if k.expire != nil && time.Now().After(*k.expire) {
+			r.removeLocked(k.signer.PublicKey().Marshal())
+		}
+	}
+}
+
+// List returns the identities known to the agent.
+func (r *keyring) List() ([]*Key, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.locked {
+		// section 2.7: locked agents return empty.
+		return nil, nil
+	}
+
+	r.expireKeysLocked()
+	var ids []*Key
+	for _, k := range r.keys {
+		pub := k.signer.PublicKey()
+		ids = append(ids, &Key{
+			Format:  pub.Type(),
+			Blob:    pub.Marshal(),
+			Comment: k.comment})
+	}
+	return ids, nil
+}
+
+// Insert adds a private key to the keyring. If a certificate
+// is given, that certificate is added as public key. Note that
+// any constraints given are ignored.
+func (r *keyring) Add(key AddedKey) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.locked {
+		return errLocked
+	}
+	signer, err := ssh.NewSignerFromKey(key.PrivateKey)
+
+	if err != nil {
+		return err
+	}
+
+	if cert := key.Certificate; cert != nil {
+		signer, err = ssh.NewCertSigner(cert, signer)
+		if err != nil {
+			return err
+		}
+	}
+
+	p := privKey{
+		signer:  signer,
+		comment: key.Comment,
+	}
+
+	if key.LifetimeSecs > 0 {
+		t := time.Now().Add(time.Duration(key.LifetimeSecs) * time.Second)
+		p.expire = &t
+	}
+
+	r.keys = append(r.keys, p)
+
+	return nil
+}
+
+// Sign returns a signature for the data.
+func (r *keyring) Sign(key ssh.PublicKey, data []byte) (*ssh.Signature, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.locked {
+		return nil, errLocked
+	}
+
+	r.expireKeysLocked()
+	wanted := key.Marshal()
+	for _, k := range r.keys {
+		if bytes.Equal(k.signer.PublicKey().Marshal(), wanted) {
+			return k.signer.Sign(rand.Reader, data)
+		}
+	}
+	return nil, errors.New("not found")
+}
+
+// Signers returns signers for all the known keys.
+func (r *keyring) Signers() ([]ssh.Signer, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.locked {
+		return nil, errLocked
+	}
+
+	r.expireKeysLocked()
+	s := make([]ssh.Signer, 0, len(r.keys))
+	for _, k := range r.keys {
+		s = append(s, k.signer)
+	}
+	return s, nil
+}

--- a/vendor/golang.org/x/crypto/ssh/agent/server.go
+++ b/vendor/golang.org/x/crypto/ssh/agent/server.go
@@ -1,0 +1,523 @@
+// Copyright 2012 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package agent
+
+import (
+	"crypto/dsa"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rsa"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"math/big"
+
+	"golang.org/x/crypto/ed25519"
+	"golang.org/x/crypto/ssh"
+)
+
+// Server wraps an Agent and uses it to implement the agent side of
+// the SSH-agent, wire protocol.
+type server struct {
+	agent Agent
+}
+
+func (s *server) processRequestBytes(reqData []byte) []byte {
+	rep, err := s.processRequest(reqData)
+	if err != nil {
+		if err != errLocked {
+			// TODO(hanwen): provide better logging interface?
+			log.Printf("agent %d: %v", reqData[0], err)
+		}
+		return []byte{agentFailure}
+	}
+
+	if err == nil && rep == nil {
+		return []byte{agentSuccess}
+	}
+
+	return ssh.Marshal(rep)
+}
+
+func marshalKey(k *Key) []byte {
+	var record struct {
+		Blob    []byte
+		Comment string
+	}
+	record.Blob = k.Marshal()
+	record.Comment = k.Comment
+
+	return ssh.Marshal(&record)
+}
+
+// See [PROTOCOL.agent], section 2.5.1.
+const agentV1IdentitiesAnswer = 2
+
+type agentV1IdentityMsg struct {
+	Numkeys uint32 `sshtype:"2"`
+}
+
+type agentRemoveIdentityMsg struct {
+	KeyBlob []byte `sshtype:"18"`
+}
+
+type agentLockMsg struct {
+	Passphrase []byte `sshtype:"22"`
+}
+
+type agentUnlockMsg struct {
+	Passphrase []byte `sshtype:"23"`
+}
+
+func (s *server) processRequest(data []byte) (interface{}, error) {
+	switch data[0] {
+	case agentRequestV1Identities:
+		return &agentV1IdentityMsg{0}, nil
+
+	case agentRemoveAllV1Identities:
+		return nil, nil
+
+	case agentRemoveIdentity:
+		var req agentRemoveIdentityMsg
+		if err := ssh.Unmarshal(data, &req); err != nil {
+			return nil, err
+		}
+
+		var wk wireKey
+		if err := ssh.Unmarshal(req.KeyBlob, &wk); err != nil {
+			return nil, err
+		}
+
+		return nil, s.agent.Remove(&Key{Format: wk.Format, Blob: req.KeyBlob})
+
+	case agentRemoveAllIdentities:
+		return nil, s.agent.RemoveAll()
+
+	case agentLock:
+		var req agentLockMsg
+		if err := ssh.Unmarshal(data, &req); err != nil {
+			return nil, err
+		}
+
+		return nil, s.agent.Lock(req.Passphrase)
+
+	case agentUnlock:
+		var req agentUnlockMsg
+		if err := ssh.Unmarshal(data, &req); err != nil {
+			return nil, err
+		}
+		return nil, s.agent.Unlock(req.Passphrase)
+
+	case agentSignRequest:
+		var req signRequestAgentMsg
+		if err := ssh.Unmarshal(data, &req); err != nil {
+			return nil, err
+		}
+
+		var wk wireKey
+		if err := ssh.Unmarshal(req.KeyBlob, &wk); err != nil {
+			return nil, err
+		}
+
+		k := &Key{
+			Format: wk.Format,
+			Blob:   req.KeyBlob,
+		}
+
+		sig, err := s.agent.Sign(k, req.Data) //  TODO(hanwen): flags.
+		if err != nil {
+			return nil, err
+		}
+		return &signResponseAgentMsg{SigBlob: ssh.Marshal(sig)}, nil
+
+	case agentRequestIdentities:
+		keys, err := s.agent.List()
+		if err != nil {
+			return nil, err
+		}
+
+		rep := identitiesAnswerAgentMsg{
+			NumKeys: uint32(len(keys)),
+		}
+		for _, k := range keys {
+			rep.Keys = append(rep.Keys, marshalKey(k)...)
+		}
+		return rep, nil
+
+	case agentAddIDConstrained, agentAddIdentity:
+		return nil, s.insertIdentity(data)
+	}
+
+	return nil, fmt.Errorf("unknown opcode %d", data[0])
+}
+
+func parseConstraints(constraints []byte) (lifetimeSecs uint32, confirmBeforeUse bool, extensions []ConstraintExtension, err error) {
+	for len(constraints) != 0 {
+		switch constraints[0] {
+		case agentConstrainLifetime:
+			lifetimeSecs = binary.BigEndian.Uint32(constraints[1:5])
+			constraints = constraints[5:]
+		case agentConstrainConfirm:
+			confirmBeforeUse = true
+			constraints = constraints[1:]
+		case agentConstrainExtension:
+			var msg constrainExtensionAgentMsg
+			if err = ssh.Unmarshal(constraints, &msg); err != nil {
+				return 0, false, nil, err
+			}
+			extensions = append(extensions, ConstraintExtension{
+				ExtensionName:    msg.ExtensionName,
+				ExtensionDetails: msg.ExtensionDetails,
+			})
+			constraints = msg.Rest
+		default:
+			return 0, false, nil, fmt.Errorf("unknown constraint type: %d", constraints[0])
+		}
+	}
+	return
+}
+
+func setConstraints(key *AddedKey, constraintBytes []byte) error {
+	lifetimeSecs, confirmBeforeUse, constraintExtensions, err := parseConstraints(constraintBytes)
+	if err != nil {
+		return err
+	}
+
+	key.LifetimeSecs = lifetimeSecs
+	key.ConfirmBeforeUse = confirmBeforeUse
+	key.ConstraintExtensions = constraintExtensions
+	return nil
+}
+
+func parseRSAKey(req []byte) (*AddedKey, error) {
+	var k rsaKeyMsg
+	if err := ssh.Unmarshal(req, &k); err != nil {
+		return nil, err
+	}
+	if k.E.BitLen() > 30 {
+		return nil, errors.New("agent: RSA public exponent too large")
+	}
+	priv := &rsa.PrivateKey{
+		PublicKey: rsa.PublicKey{
+			E: int(k.E.Int64()),
+			N: k.N,
+		},
+		D:      k.D,
+		Primes: []*big.Int{k.P, k.Q},
+	}
+	priv.Precompute()
+
+	addedKey := &AddedKey{PrivateKey: priv, Comment: k.Comments}
+	if err := setConstraints(addedKey, k.Constraints); err != nil {
+		return nil, err
+	}
+	return addedKey, nil
+}
+
+func parseEd25519Key(req []byte) (*AddedKey, error) {
+	var k ed25519KeyMsg
+	if err := ssh.Unmarshal(req, &k); err != nil {
+		return nil, err
+	}
+	priv := ed25519.PrivateKey(k.Priv)
+
+	addedKey := &AddedKey{PrivateKey: &priv, Comment: k.Comments}
+	if err := setConstraints(addedKey, k.Constraints); err != nil {
+		return nil, err
+	}
+	return addedKey, nil
+}
+
+func parseDSAKey(req []byte) (*AddedKey, error) {
+	var k dsaKeyMsg
+	if err := ssh.Unmarshal(req, &k); err != nil {
+		return nil, err
+	}
+	priv := &dsa.PrivateKey{
+		PublicKey: dsa.PublicKey{
+			Parameters: dsa.Parameters{
+				P: k.P,
+				Q: k.Q,
+				G: k.G,
+			},
+			Y: k.Y,
+		},
+		X: k.X,
+	}
+
+	addedKey := &AddedKey{PrivateKey: priv, Comment: k.Comments}
+	if err := setConstraints(addedKey, k.Constraints); err != nil {
+		return nil, err
+	}
+	return addedKey, nil
+}
+
+func unmarshalECDSA(curveName string, keyBytes []byte, privScalar *big.Int) (priv *ecdsa.PrivateKey, err error) {
+	priv = &ecdsa.PrivateKey{
+		D: privScalar,
+	}
+
+	switch curveName {
+	case "nistp256":
+		priv.Curve = elliptic.P256()
+	case "nistp384":
+		priv.Curve = elliptic.P384()
+	case "nistp521":
+		priv.Curve = elliptic.P521()
+	default:
+		return nil, fmt.Errorf("agent: unknown curve %q", curveName)
+	}
+
+	priv.X, priv.Y = elliptic.Unmarshal(priv.Curve, keyBytes)
+	if priv.X == nil || priv.Y == nil {
+		return nil, errors.New("agent: point not on curve")
+	}
+
+	return priv, nil
+}
+
+func parseEd25519Cert(req []byte) (*AddedKey, error) {
+	var k ed25519CertMsg
+	if err := ssh.Unmarshal(req, &k); err != nil {
+		return nil, err
+	}
+	pubKey, err := ssh.ParsePublicKey(k.CertBytes)
+	if err != nil {
+		return nil, err
+	}
+	priv := ed25519.PrivateKey(k.Priv)
+	cert, ok := pubKey.(*ssh.Certificate)
+	if !ok {
+		return nil, errors.New("agent: bad ED25519 certificate")
+	}
+
+	addedKey := &AddedKey{PrivateKey: &priv, Certificate: cert, Comment: k.Comments}
+	if err := setConstraints(addedKey, k.Constraints); err != nil {
+		return nil, err
+	}
+	return addedKey, nil
+}
+
+func parseECDSAKey(req []byte) (*AddedKey, error) {
+	var k ecdsaKeyMsg
+	if err := ssh.Unmarshal(req, &k); err != nil {
+		return nil, err
+	}
+
+	priv, err := unmarshalECDSA(k.Curve, k.KeyBytes, k.D)
+	if err != nil {
+		return nil, err
+	}
+
+	addedKey := &AddedKey{PrivateKey: priv, Comment: k.Comments}
+	if err := setConstraints(addedKey, k.Constraints); err != nil {
+		return nil, err
+	}
+	return addedKey, nil
+}
+
+func parseRSACert(req []byte) (*AddedKey, error) {
+	var k rsaCertMsg
+	if err := ssh.Unmarshal(req, &k); err != nil {
+		return nil, err
+	}
+
+	pubKey, err := ssh.ParsePublicKey(k.CertBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	cert, ok := pubKey.(*ssh.Certificate)
+	if !ok {
+		return nil, errors.New("agent: bad RSA certificate")
+	}
+
+	// An RSA publickey as marshaled by rsaPublicKey.Marshal() in keys.go
+	var rsaPub struct {
+		Name string
+		E    *big.Int
+		N    *big.Int
+	}
+	if err := ssh.Unmarshal(cert.Key.Marshal(), &rsaPub); err != nil {
+		return nil, fmt.Errorf("agent: Unmarshal failed to parse public key: %v", err)
+	}
+
+	if rsaPub.E.BitLen() > 30 {
+		return nil, errors.New("agent: RSA public exponent too large")
+	}
+
+	priv := rsa.PrivateKey{
+		PublicKey: rsa.PublicKey{
+			E: int(rsaPub.E.Int64()),
+			N: rsaPub.N,
+		},
+		D:      k.D,
+		Primes: []*big.Int{k.Q, k.P},
+	}
+	priv.Precompute()
+
+	addedKey := &AddedKey{PrivateKey: &priv, Certificate: cert, Comment: k.Comments}
+	if err := setConstraints(addedKey, k.Constraints); err != nil {
+		return nil, err
+	}
+	return addedKey, nil
+}
+
+func parseDSACert(req []byte) (*AddedKey, error) {
+	var k dsaCertMsg
+	if err := ssh.Unmarshal(req, &k); err != nil {
+		return nil, err
+	}
+	pubKey, err := ssh.ParsePublicKey(k.CertBytes)
+	if err != nil {
+		return nil, err
+	}
+	cert, ok := pubKey.(*ssh.Certificate)
+	if !ok {
+		return nil, errors.New("agent: bad DSA certificate")
+	}
+
+	// A DSA publickey as marshaled by dsaPublicKey.Marshal() in keys.go
+	var w struct {
+		Name       string
+		P, Q, G, Y *big.Int
+	}
+	if err := ssh.Unmarshal(cert.Key.Marshal(), &w); err != nil {
+		return nil, fmt.Errorf("agent: Unmarshal failed to parse public key: %v", err)
+	}
+
+	priv := &dsa.PrivateKey{
+		PublicKey: dsa.PublicKey{
+			Parameters: dsa.Parameters{
+				P: w.P,
+				Q: w.Q,
+				G: w.G,
+			},
+			Y: w.Y,
+		},
+		X: k.X,
+	}
+
+	addedKey := &AddedKey{PrivateKey: priv, Certificate: cert, Comment: k.Comments}
+	if err := setConstraints(addedKey, k.Constraints); err != nil {
+		return nil, err
+	}
+	return addedKey, nil
+}
+
+func parseECDSACert(req []byte) (*AddedKey, error) {
+	var k ecdsaCertMsg
+	if err := ssh.Unmarshal(req, &k); err != nil {
+		return nil, err
+	}
+
+	pubKey, err := ssh.ParsePublicKey(k.CertBytes)
+	if err != nil {
+		return nil, err
+	}
+	cert, ok := pubKey.(*ssh.Certificate)
+	if !ok {
+		return nil, errors.New("agent: bad ECDSA certificate")
+	}
+
+	// An ECDSA publickey as marshaled by ecdsaPublicKey.Marshal() in keys.go
+	var ecdsaPub struct {
+		Name string
+		ID   string
+		Key  []byte
+	}
+	if err := ssh.Unmarshal(cert.Key.Marshal(), &ecdsaPub); err != nil {
+		return nil, err
+	}
+
+	priv, err := unmarshalECDSA(ecdsaPub.ID, ecdsaPub.Key, k.D)
+	if err != nil {
+		return nil, err
+	}
+
+	addedKey := &AddedKey{PrivateKey: priv, Certificate: cert, Comment: k.Comments}
+	if err := setConstraints(addedKey, k.Constraints); err != nil {
+		return nil, err
+	}
+	return addedKey, nil
+}
+
+func (s *server) insertIdentity(req []byte) error {
+	var record struct {
+		Type string `sshtype:"17|25"`
+		Rest []byte `ssh:"rest"`
+	}
+
+	if err := ssh.Unmarshal(req, &record); err != nil {
+		return err
+	}
+
+	var addedKey *AddedKey
+	var err error
+
+	switch record.Type {
+	case ssh.KeyAlgoRSA:
+		addedKey, err = parseRSAKey(req)
+	case ssh.KeyAlgoDSA:
+		addedKey, err = parseDSAKey(req)
+	case ssh.KeyAlgoECDSA256, ssh.KeyAlgoECDSA384, ssh.KeyAlgoECDSA521:
+		addedKey, err = parseECDSAKey(req)
+	case ssh.KeyAlgoED25519:
+		addedKey, err = parseEd25519Key(req)
+	case ssh.CertAlgoRSAv01:
+		addedKey, err = parseRSACert(req)
+	case ssh.CertAlgoDSAv01:
+		addedKey, err = parseDSACert(req)
+	case ssh.CertAlgoECDSA256v01, ssh.CertAlgoECDSA384v01, ssh.CertAlgoECDSA521v01:
+		addedKey, err = parseECDSACert(req)
+	case ssh.CertAlgoED25519v01:
+		addedKey, err = parseEd25519Cert(req)
+	default:
+		return fmt.Errorf("agent: not implemented: %q", record.Type)
+	}
+
+	if err != nil {
+		return err
+	}
+	return s.agent.Add(*addedKey)
+}
+
+// ServeAgent serves the agent protocol on the given connection. It
+// returns when an I/O error occurs.
+func ServeAgent(agent Agent, c io.ReadWriter) error {
+	s := &server{agent}
+
+	var length [4]byte
+	for {
+		if _, err := io.ReadFull(c, length[:]); err != nil {
+			return err
+		}
+		l := binary.BigEndian.Uint32(length[:])
+		if l > maxAgentResponseBytes {
+			// We also cap requests.
+			return fmt.Errorf("agent: request too large: %d", l)
+		}
+
+		req := make([]byte, l)
+		if _, err := io.ReadFull(c, req); err != nil {
+			return err
+		}
+
+		repData := s.processRequestBytes(req)
+		if len(repData) > maxAgentResponseBytes {
+			return fmt.Errorf("agent: reply too large: %d bytes", len(repData))
+		}
+
+		binary.BigEndian.PutUint32(length[:], uint32(len(repData)))
+		if _, err := c.Write(length[:]); err != nil {
+			return err
+		}
+		if _, err := c.Write(repData); err != nil {
+			return err
+		}
+	}
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -2008,6 +2008,12 @@
 			"revisionTime": "2018-04-10T17:26:10Z"
 		},
 		{
+			"checksumSHA1": "NMRX0onGReaL9IfLr0XQ3kl5Id0=",
+			"path": "golang.org/x/crypto/ssh/agent",
+			"revision": "f70185d77e8278766928032ee1355e3da47e7181",
+			"revisionTime": "2018-04-10T17:26:10Z"
+		},
+		{
 			"checksumSHA1": "BGm8lKZmvJbf/YOJLeL1rw2WVjA=",
 			"path": "golang.org/x/crypto/ssh/terminal",
 			"revision": "f70185d77e8278766928032ee1355e3da47e7181",


### PR DESCRIPTION
This allows to perform SSH'ing into containers by specifying only deal
and task identifiers independing of whereever those containers are being
run.

This is done by proxying the traffic through local Node.

The idea is to hijack to incoming TCP connection with further resolving
the real endpoint of a Worker where a container is being run by deal ID
using NPP with further traffic forwarding directly into it. The Worker
may not be having a public IP address.
