### PR TITLE
feat: update deals before removal (DWH)

### DIFF
--- a/etc/dwh.yaml
+++ b/etc/dwh.yaml
@@ -12,11 +12,18 @@ ethereum:
   # passphrase for keystore
   pass_phrase: "any"
 
+# Uncomment to work with a local node + testnet.
 blockchain:
   endpoint: "https://rinkeby.infura.io/00iTrs5PIy0uGODwcsrb"
   sidechain_endpoint: "http://localhost:8545"
   contract_registry: "0xaf1ffd7f652be7e9a0854a42b2d3046f853f80f1"
   blocks_batch_size: 500000
+
+
+# Uncomment to work with livenet.
+#blockchain:
+#  sidechain_endpoint: "https://sidechain.livenet.sonm.com"
+#  blocks_batch_size: 500000
 
 logging:
   # The desired logging level.

--- a/insonmnia/dwh/server.go
+++ b/insonmnia/dwh/server.go
@@ -645,11 +645,12 @@ func (m *DWH) onDealUpdated(dealID *big.Int) error {
 	}
 
 	if deal.Status == pb.DealStatus_DEAL_CLOSED {
-		err = m.storage.DeleteDeal(conn, deal.Id.Unwrap())
-		if err != nil {
+		if err = m.storage.UpdateDeal(conn, deal); err != nil {
+			return fmt.Errorf("failed to update deal before removal: %v", err)
+		}
+		if err = m.storage.DeleteDeal(conn, deal.Id.Unwrap()); err != nil {
 			return fmt.Errorf("failed to delete deal (possibly old log entry): %v", err)
 		}
-
 		if err := m.storage.DeleteOrder(conn, deal.AskID.Unwrap()); err != nil {
 			return fmt.Errorf("failed to deleteOrder: %v", err)
 		}


### PR DESCRIPTION
A weird request came from the guys that develop our telegram notification bot: 

> Please update deals before deleting them.

Looks like they subscribe to postgres events and need deals final state to be written to DB.