### PR TITLE
fix: ignore conflicts on AddedToBlacklist events (DWH)

### DIFF
--- a/insonmnia/dwh/sql.go
+++ b/insonmnia/dwh/sql.go
@@ -765,7 +765,8 @@ func (m *sqlStorage) GetMasterByWorker(conn queryConn, slaveID common.Address) (
 }
 
 func (m *sqlStorage) InsertBlacklistEntry(conn queryConn, adderID, addeeID common.Address) error {
-	query, args, err := m.builder().Insert("Blacklists").Values(adderID.Hex(), addeeID.Hex()).ToSql()
+	query, args, err := m.builder().Insert("Blacklists").Values(adderID.Hex(), addeeID.Hex()).
+		Suffix("ON CONFLICT (AdderID, AddeeID) DO NOTHING").ToSql()
 	_, err = conn.Exec(query, args...)
 	return err
 }


### PR DESCRIPTION
Adding duplicate entries to blacklist resulted in an error and a costly retry cycle. This PR makes DWH ignore such duplicates.