### PR TITLE
feat: pre-request logging interceptor

### DIFF
--- a/insonmnia/node/master.go
+++ b/insonmnia/node/master.go
@@ -22,7 +22,6 @@ func newMasterManagementAPI(opts *remoteOptions) sonm.MasterManagementServer {
 }
 
 func (m *masterMgmtAPI) WorkersList(ctx context.Context, address *sonm.EthAddress) (*sonm.WorkerListReply, error) {
-	m.log.Info("handling WorkersList request") // TODO: Pre-interceptor time.
 	// TODO: pagination
 	reply, err := m.remotes.dwh.GetWorkers(ctx, &sonm.WorkersRequest{MasterID: address})
 	if err != nil {
@@ -34,7 +33,6 @@ func (m *masterMgmtAPI) WorkersList(ctx context.Context, address *sonm.EthAddres
 }
 
 func (m *masterMgmtAPI) WorkerConfirm(ctx context.Context, address *sonm.EthAddress) (*sonm.Empty, error) {
-	m.log.Info("handling WorkersConfirm request")
 	err := m.remotes.eth.Market().ConfirmWorker(ctx, m.remotes.key, address.Unwrap())
 	if err != nil {
 		return nil, fmt.Errorf("could not confirm dependant worker in blockchain: %s", err)
@@ -43,7 +41,6 @@ func (m *masterMgmtAPI) WorkerConfirm(ctx context.Context, address *sonm.EthAddr
 }
 
 func (m *masterMgmtAPI) WorkerRemove(ctx context.Context, request *sonm.WorkerRemoveRequest) (*sonm.Empty, error) {
-	m.log.Info("handling WorkersRemove request")
 	err := m.remotes.eth.Market().RemoveWorker(ctx, m.remotes.key, request.GetMaster().Unwrap(), request.GetWorker().Unwrap())
 	if err != nil {
 		return nil, fmt.Errorf("could not remove dependant worker from blockchain: %s", err)

--- a/insonmnia/node/server.go
+++ b/insonmnia/node/server.go
@@ -112,6 +112,7 @@ func newServer(cfg nodeConfig, services Services, options ...ServerOption) (*Ser
 	if opts.allowGRPC {
 		options := append([]xgrpc.ServerOption{
 			xgrpc.DefaultTraceInterceptor(),
+			xgrpc.RequestLogInterceptor(m.log.Desugar()),
 			xgrpc.VerifyInterceptor(),
 			xgrpc.UnaryServerInterceptor(services.Interceptor()),
 		}, opts.optionsGRPC...)

--- a/insonmnia/node/tasks.go
+++ b/insonmnia/node/tasks.go
@@ -143,8 +143,6 @@ func (t *tasksAPI) PushTask(clientStream pb.TaskManagement_PushTaskServer) error
 		return err
 	}
 
-	t.log.Infow("handling PushTask request", zap.String("deal_id", meta.dealID))
-
 	workerClient, cc, err := t.remotes.getWorkerClientForDeal(meta.ctx, meta.dealID)
 	if err != nil {
 		return err

--- a/util/xgrpc/method.go
+++ b/util/xgrpc/method.go
@@ -1,0 +1,28 @@
+package xgrpc
+
+import (
+	"strings"
+)
+
+type methodInfo struct {
+	Service string
+	Method  string
+}
+
+func (m *methodInfo) IntoTuple() (string, string) {
+	return m.Service, m.Method
+}
+
+func MethodInfo(fullMethod string) *methodInfo {
+	parts := strings.SplitN(fullMethod, "/", 3)
+	if len(parts) != 3 {
+		return nil
+	}
+
+	m := &methodInfo{
+		Service: parts[1],
+		Method:  parts[2],
+	}
+
+	return m
+}


### PR DESCRIPTION
This commit activates automatic request logging for gRPC services. This includes logging service and request names with tracing attributes if activated. Both unary and streaming API are supported.

Internally this is done by using gRPC request interceptors, that are invoked before the actual method called.