### PR TITLE
chore: reduce default price threshold in Optimus

### DIFF
--- a/etc/optimus.yaml
+++ b/etc/optimus.yaml
@@ -47,7 +47,7 @@ workers:
     # each epoch.
     # Required.
     # Possible dimensions are USD/s, USD/h.
-    price_threshold: 0.1 USD/h
+    price_threshold: 0.02 USD/h
     # When activated Optimus will not create ask plans, but continues doing
     # the rest calculations instead. Useful for debugging.
     # Optional.


### PR DESCRIPTION
The new value is equivalent of ~0.48$ per day or 175.2$ per year.