### PR TITLE
refactor: init everything from config in Optimus

### DIFF
--- a/cmd/optimus/main.go
+++ b/cmd/optimus/main.go
@@ -43,7 +43,7 @@ func run() error {
 	}
 
 	ctx := ctxlog.WithLogger(context.Background(), log)
-	bot, err := optimus.NewOptimus(*cfg, optimus.WithVersion(appVersion), optimus.WithLog(log.Sugar()))
+	bot, err := optimus.NewOptimus(cfg, optimus.WithVersion(appVersion), optimus.WithLog(log.Sugar()))
 	if err != nil {
 		return fmt.Errorf("failed to create Optimus: %v", err)
 	}

--- a/etc/optimus.yaml
+++ b/etc/optimus.yaml
@@ -18,6 +18,122 @@ node:
   # Node trusted endpoint.
   endpoint: 0x83A68C0AEaCA382fC42122f125cbDC64d4b43FdD@[::1]:15030
 
+benchmarks:
+  # URL to download benchmark list, use "file://" schema to load file from a filesystem.
+  url: "https://raw.githubusercontent.com/sonm-io/benchmarks-list/master/list.json"
+
+# Marketplace polling settings.
+marketplace:
+  # Account settings.
+  ethereum: *ethereum
+  # DWH endpoint.
+  endpoint: "0xadffcac607a0a1b583c489977eae413a62d4bc73@dwh.livenet.sonm.com:15021"
+  # Interval of current orders caching, that are fetched from the marketplace.
+  interval: 30s
+  # Minimum price threshold for fetching orders from the marketplace.
+  # Used to prevent regression poisoning.
+  # Optional.
+  # Default value is 0.0001 USD/h, which is nearly about 1 USD per year.
+  min_price: 0.0001 USD/h
+
+# Optimization engine settings.
+optimization: &optimization
+  # Since v0.4.6 Optimus contains all models with predefined well-tuned
+  # settings.
+  # However it is possible to override them. All of them have default
+  # values specified in this config example.
+  # The main thing here is the "model". It must have "type" field and
+  # model-specific settings.
+  # Currently we support the following models: batch, greedy, genetic
+  # and branch_bound.
+  model:
+    # Batch model combines several other models to be able to run them
+    # simultaneously and select the most profitable optimization result.
+    # By default the following logic happens: if the matched orders count
+    # is small enough the branch_bound algorithm is activated, which gives
+    # the optimal solution.
+    type: batch
+    # Brute force model activation settings.
+    brute:
+      # Number of matched orders to activate the following model.
+      # Must be small enough, because brute force models may consume all CPUs
+      # on the machine.
+      match: 128
+      # Model settings.
+      model:
+        # Branch and bound model.
+        type: branch_bound
+        # Maximum tree height. After reaching the specified value the model
+        # returns the best it found.
+        height_limit: 6
+    models:
+        # Greedy algorithm is a fast and simple optimization heuristic, that
+        # can find solution, but possibly not the optimum.
+        # We use linear regression to reduce the number of dimensions, which is
+        # the number of benchmarks, to a single one to be able to apply greedy
+        # technique.
+      - type: greedy
+        # Orders with weight lesser than the specified will be ignored.
+        weight_limit: 1e-3
+        # Stop trying to pack sorted-by-weight orders after reaching the
+        # specified value.
+        exhaustion_limit: 128
+        # Regression type.
+        # Currently supported regressions: linear least squares (lls) and
+        # non-negative least squares (nnls).
+        regression:
+          # Linear least squares regression.
+          type: lls
+          # Specific gradient descent options.
+          # Alpha is the learning rate.
+          # If the learning rate alpha is too small we will have slow
+          # convergence.
+          # If alpha is too large J of theta may not decrease on every
+          # iteration and may not converge.
+          alpha: 1e-6
+          # Regularization term.
+          regularization: 6.0
+          # Maximum number of iterations.
+          max_iterations: 1000
+      - type: greedy
+        # Orders with weight lesser than the specified will be ignored.
+        weight_limit: 1e-3
+        # Stop trying to pack sorted-by-weight orders after reaching the
+        # specified value.
+        exhaustion_limit: 128
+        # Regression type.
+        # Currently supported regressions: linear least squares (lls) and
+        # non-negative least squares (nnls).
+        regression:
+          # Linear non-negative least squares regression.
+          type: nnls
+        # Genetic algorithm is a meta-heuristic that tries to optimize the
+        # worker's knapsack using analogy with biological processes.
+      - type: genetic
+        # Packed genome starts with populations with randomly picked orders.
+        genome: packed
+        # Size of the population. Large populations increases the probability
+        # of more optimized solution, but consumes more CPU.
+        population_size: 256
+        # Maximum number of population generations, after reaching those
+        # evolution process is stopped.
+        max_generations: 128
+        # Maximum algorithm work time.
+        # If reached, the best attempt is selected.
+        max_age: 5m
+      - type: genetic
+        # Decision genome starts with populations with no orders selected.
+        genome: decision
+        # Size of the population. Large populations increases the probability
+        # of more optimized solution, but consumes more CPU.
+        population_size: 512
+        # Maximum number of population generations, after reaching those
+        # evolution process is stopped.
+        max_generations: 64
+        # Maximum algorithm work time.
+        # If reached, the best attempt is selected.
+        max_age: 5m
+
 # Map of workers this bot manages defined by its trusted endpoints with their
 # settings.
 workers:
@@ -63,38 +179,5 @@ workers:
     # Optional.
     # Default value is 30s.
     prelude_timeout: 30s
-
-benchmarks:
-  # URL to download benchmark list, use `file://` schema to load file from a filesystem.
-  url: "https://raw.githubusercontent.com/sonm-io/benchmarks-list/master/list.json"
-
-# Marketplace polling settings.
-marketplace:
-  # Account settings.
-  ethereum: *ethereum
-  # DWH endpoint.
-  endpoint: "0xadffcac607a0a1b583c489977eae413a62d4bc73@dwh.livenet.sonm.com:15021"
-  # Interval of current orders caching, that are fetched from the marketplace.
-  interval: 30s
-  # Minimum price threshold for fetching orders from the marketplace.
-  # Used to prevent regression poisoning.
-  # Optional.
-  # Default value is 0.0001 USD/h, which is nearly about 1 USD per year.
-  min_price: 0.0001 USD/h
-
-# Optimization engine settings.
-optimization:
-  # Interval of time for optimization.
-  # Note that the optimization process may be triggered by other external
-  # conditions.
-  interval: 30s
-  # Orders classification settings.
-  # Optional. By default multidimensional linear regression with non-negative
-  # coefficients model is used.
-  classifier:
-    type: regression
-    model:
-      type: lls
-      alpha: 1e-6
-      regularization: 6.0
-      max_iterations: 1000
+    # Optimization engine settings.
+    optimization: *optimization

--- a/optimus/engine_branch.go
+++ b/optimus/engine_branch.go
@@ -89,6 +89,24 @@ func (m *node) appendLeaf(nodes []*node) []*node {
 	return nodes
 }
 
+type BranchBoundModelConfig struct {
+	HeightLimit int `yaml:"height_limit" default:"6"`
+}
+
+type BranchBoundModelFactory struct {
+	BranchBoundModelConfig
+}
+
+func (m *BranchBoundModelFactory) Config() interface{} {
+	return &m.BranchBoundModelConfig
+}
+
+func (*BranchBoundModelFactory) Create(orders, matchedOrders []*MarketOrder, log *zap.SugaredLogger) OptimizationMethod {
+	return &BranchBoundModel{
+		Log: log.With("model", "BBM"),
+	}
+}
+
 type BranchBoundModel struct {
 	Log *zap.SugaredLogger
 }

--- a/optimus/learning.go
+++ b/optimus/learning.go
@@ -6,8 +6,6 @@ import (
 	"math"
 	"math/big"
 	"sort"
-
-	"go.uber.org/zap"
 )
 
 const (
@@ -87,15 +85,7 @@ type OrderClassifier interface {
 }
 
 type regressionClassifier struct {
-	modelFactory modelFactory
-	log          *zap.Logger
-}
-
-func newRegressionClassifier(modelFactory modelFactory, log *zap.Logger) OrderClassifier {
-	return &regressionClassifier{
-		modelFactory: modelFactory,
-		log:          log,
-	}
+	model Model
 }
 
 func (m *regressionClassifier) Classify(orders []*MarketOrder) ([]WeightedOrder, error) {
@@ -116,7 +106,7 @@ func (m *regressionClassifier) ClassifyExt(orders []*MarketOrder) (*OrderClassif
 		return nil, err
 	}
 
-	predictor, err := m.modelFactory(m.log).Train(trainingSet, expectationN)
+	predictor, err := m.model.Train(trainingSet, expectationN)
 	if err != nil {
 		return nil, err
 	}

--- a/optimus/learning_test.go
+++ b/optimus/learning_test.go
@@ -1,6 +1,7 @@
 package optimus
 
 import (
+	"io/ioutil"
 	"math"
 	"math/rand"
 	"testing"
@@ -8,7 +9,6 @@ import (
 	"github.com/sonm-io/core/proto"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap"
 )
 
 func TestSortDescending(t *testing.T) {
@@ -32,11 +32,14 @@ func TestSortDescending(t *testing.T) {
 }
 
 func TestLearning(t *testing.T) {
-	model := newLLSModelFactory(llsModelConfig{
-		Alpha:          1e-6,
-		Regularization: 6.0,
-		MaxIterations:  1000,
-	})
+	model := &llsModel{
+		cfg: llsModelConfig{
+			Alpha:          1e-6,
+			Regularization: 6.0,
+			MaxIterations:  1000,
+		},
+		output: ioutil.Discard,
+	}
 
 	n := 1000
 
@@ -113,8 +116,8 @@ func TestLearning(t *testing.T) {
 		})
 	}
 
-	classifier := newRegressionClassifier(model, zap.NewNop())
-	weightedOrders, err := classifier.Classify(orders)
+	regression := regressionClassifier{model: model}
+	weightedOrders, err := regression.Classify(orders)
 
 	require.NoError(t, err)
 	assert.Equal(t, n, len(weightedOrders))

--- a/optimus/model_lls.go
+++ b/optimus/model_lls.go
@@ -1,0 +1,62 @@
+package optimus
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+
+	"github.com/cdipaolo/goml/base"
+	"github.com/cdipaolo/goml/linear"
+	"go.uber.org/zap"
+)
+
+type llsModelConfig struct {
+	Alpha          float64 `yaml:"alpha" default:"1e-3"`
+	Regularization float64 `yaml:"regularization" default:"6.0"`
+	MaxIterations  int     `yaml:"max_iterations" default:"1000"`
+}
+
+func (m *llsModelConfig) Config() interface{} {
+	return m
+}
+
+func (m *llsModelConfig) Create(log *zap.SugaredLogger) Model {
+	return &llsModel{
+		cfg:    *m,
+		output: ioutil.Discard,
+	}
+}
+
+type llsModel struct {
+	cfg    llsModelConfig
+	output io.Writer
+}
+
+func (m *llsModel) Train(trainingSet [][]float64, expectation []float64) (TrainedModel, error) {
+	model := linear.NewLeastSquares(base.BatchGA, m.cfg.Alpha, m.cfg.Regularization, m.cfg.MaxIterations, trainingSet, expectation)
+	//model.Output = m.output
+	if err := model.Learn(); err != nil {
+		return nil, err
+	}
+
+	return &trainedLLSModel{
+		model: model,
+	}, nil
+}
+
+type trainedLLSModel struct {
+	model *linear.LeastSquares
+}
+
+func (m *trainedLLSModel) Predict(vec []float64) (float64, error) {
+	prediction, err := m.model.Predict(vec)
+	if err != nil {
+		return 0.0, err
+	}
+
+	if len(prediction) == 0 {
+		return 0.0, fmt.Errorf("no prediction made")
+	}
+
+	return prediction[0], nil
+}

--- a/optimus/model_nnls.go
+++ b/optimus/model_nnls.go
@@ -21,12 +21,14 @@ type SCAKKTModel struct {
 	Log           *zap.SugaredLogger
 }
 
-func newSCAKKTModel() modelFactory {
-	return func(log *zap.Logger) Model {
-		return &SCAKKTModel{
-			Log:           log.Sugar(),
-			MaxIterations: 1e7,
-		}
+func (m *SCAKKTModel) Config() interface{} {
+	return m
+}
+
+func (m *SCAKKTModel) Create(log *zap.SugaredLogger) Model {
+	return &SCAKKTModel{
+		MaxIterations: 1e7,
+		Log:           log,
 	}
 }
 

--- a/optimus/optimus.go
+++ b/optimus/optimus.go
@@ -13,12 +13,12 @@ import (
 )
 
 type Optimus struct {
-	cfg     Config
+	cfg     *Config
 	version string
 	log     *zap.SugaredLogger
 }
 
-func NewOptimus(cfg Config, options ...Option) (*Optimus, error) {
+func NewOptimus(cfg *Config, options ...Option) (*Optimus, error) {
 	opts := newOptions()
 	for _, o := range options {
 		o(opts)
@@ -81,8 +81,8 @@ func (m *Optimus) Run(ctx context.Context) error {
 			return err
 		}
 
-		// TODO: Well, 11 parameters seems to be WAT.
-		control, err := newWorkerEngine(cfg, ethAddr, masterAddr, blacklist, worker, market.Market(), marketCache, benchmarkMapping, m.cfg.Optimization, newTagger(m.version), m.log)
+		// TODO: Well, 10 parameters seems to be WAT.
+		control, err := newWorkerEngine(cfg, ethAddr, masterAddr, blacklist, worker, market.Market(), marketCache, benchmarkMapping, newTagger(m.version), m.log)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
This commit allows to init each optimization model directly from the config.

Removed:
- Dropped "optimization.interval" option.