### PR TITLE
fix: avoid global logger in puncher

### DIFF
--- a/insonmnia/npp/options.go
+++ b/insonmnia/npp/options.go
@@ -49,7 +49,7 @@ func WithRendezvous(cfg rendezvous.Config, credentials credentials.TransportCred
 			for _, addr := range cfg.Endpoints {
 				client, err := newRendezvousClient(ctx, addr, credentials)
 				if err == nil {
-					return newNATPuncher(ctx, cfg, client)
+					return newNATPuncher(ctx, cfg, client, o.log)
 				}
 			}
 


### PR DESCRIPTION
This fixes using background "default" logger obtained from the Context. Instead preconfigured logger from options is used.