### PR TITLE
perf: fast benchmark mapping

### DIFF
--- a/insonmnia/benchmarks/benchmarks.go
+++ b/insonmnia/benchmarks/benchmarks.go
@@ -30,6 +30,8 @@ const (
 )
 
 type BenchList interface {
+	// Max returns the maximum benchmark ID in the list.
+	Max() uint64
 	ByID() []*pb.Benchmark
 	MapByDeviceType() map[pb.DeviceType][]*pb.Benchmark
 	MapByCode() map[string]*pb.Benchmark
@@ -143,6 +145,17 @@ func NewBenchmarksList(ctx context.Context, cfg Config) (BenchList, error) {
 	}
 
 	return ls, nil
+}
+
+func (bl *benchmarkList) Max() uint64 {
+	max := uint64(0)
+	for _, benchmark := range bl.byID {
+		if benchmark.ID > max {
+			max = benchmark.ID
+		}
+	}
+
+	return max
 }
 
 func (bl *benchmarkList) ByID() []*pb.Benchmark {


### PR DESCRIPTION
Added smart benchmark mapping alrorithm, which indexes benchmarks in a flat map backed with array.
This increases performance of genetic algorithm in 2-4 times.

Before (optimized 450 orders in 4m49.033336829s):
![Alt text](https://sendeyo.com/up/d/0f717e9550?sanitize=true)

After: (optimized 452 orders in 1m20.653263813s):
![Alt text](https://sendeyo.com/up/d/de3568732a?sanitize=true)