### PR TITLE
perf: use proper combinations limits

### DIFF
--- a/optimus/devices.go
+++ b/optimus/devices.go
@@ -414,7 +414,7 @@ func (m *DeviceManager) consumeGPU(minCount uint64, benchmarks []uint64) (*sonm.
 	score := float64(math.MaxFloat64)
 	var candidates []*sonm.GPU
 
-	for k := int(minCount); k <= len(m.devices.GPUs); k++ {
+	for k := int(minCount); k <= len(m.freeGPUs); k++ {
 	subsetLoop:
 		for _, subset := range m.combinationsGPU(k) {
 			currentScore := 0.0


### PR DESCRIPTION
It doesn't make sense to building combinations of GPUs with k more than n, which is the length of currently free GPUs.