### PR TITLE
feat: BTFS volume plugin for Worker

### DIFF
--- a/etc/worker.yaml
+++ b/etc/worker.yaml
@@ -84,6 +84,7 @@ plugins:
     root: /var/lib/docker-volumes
     drivers:
 #      cifs: {}
+#      btfs: {}
 
   overlay:
     drivers:

--- a/insonmnia/worker/overseer.go
+++ b/insonmnia/worker/overseer.go
@@ -13,6 +13,7 @@ import (
 	"github.com/sonm-io/core/insonmnia/worker/plugin"
 	"github.com/sonm-io/core/insonmnia/worker/volume"
 	"github.com/sonm-io/core/util/multierror"
+	"github.com/sonm-io/core/util/xdocker"
 	"go.uber.org/zap"
 
 	"github.com/docker/distribution/reference"
@@ -496,7 +497,7 @@ func (o *overseer) Spool(ctx context.Context, d Description) error {
 		return err
 	}
 
-	if err = decodeImagePull(body); err != nil {
+	if err = xdocker.DecodeImagePull(body); err != nil {
 		log.G(ctx).Error("failed to pull an image", zap.Error(err))
 		return err
 	}

--- a/insonmnia/worker/plugin/plugin.go
+++ b/insonmnia/worker/plugin/plugin.go
@@ -77,6 +77,7 @@ func NewRepository(ctx context.Context, cfg Config) (*Repository, error) {
 		driver, err := volume.NewVolumeDriver(ctx, ty,
 			volume.WithPluginSocketDir(cfg.SocketDir),
 			volume.WithOptions(options),
+			volume.WithLogger(log.S(ctx)),
 		)
 
 		if err != nil {

--- a/insonmnia/worker/volume/btfs.go
+++ b/insonmnia/worker/volume/btfs.go
@@ -1,0 +1,309 @@
+package volume
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+
+	"bazil.org/fuse"
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/mount"
+	"github.com/docker/docker/api/types/network"
+	docker "github.com/docker/docker/client"
+	"github.com/docker/go-plugins-helpers/volume"
+	"go.uber.org/zap"
+)
+
+const (
+	BTFSDriverName             = "btfs"
+	BTFSImage                  = "sonm/btfs@sha256:b64b4a7849aa742049b039aeabcaff0fa58876c00df9abdf0321d3fff31789a2"
+	DefaultDockerRootDirectory = volume.DefaultDockerRootDirectory
+)
+
+type BTFSDriver struct {
+	server *VolumeServer
+	log    *zap.SugaredLogger
+}
+
+func NewBTFSDriver(options ...Option) (*BTFSDriver, error) {
+	server, err := NewVolumeServer(BTFSDriverName, options...)
+	if err != nil {
+		return nil, err
+	}
+
+	client, err := docker.NewEnvClient()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create Docker client for BTFS volume driver: %v", err)
+	}
+
+	driver := &BTFSDockerDriver{
+		client:       client,
+		mountRootDir: filepath.Join(DefaultDockerRootDirectory, BTFSDriverName, "mnt"),
+		volumes:      map[string]*BTFSDockerVolume{},
+		log:          server.log.With("driver", BTFSDriverName),
+	}
+
+	go server.Serve(driver)
+
+	m := &BTFSDriver{
+		server: server,
+		log:    server.log.With("driver", BTFSDriverName),
+	}
+
+	return m, nil
+}
+
+func (m *BTFSDriver) CreateVolume(name string, options map[string]string) (Volume, error) {
+	m.log.Debugw("handling Worker.CreateVolume request", zap.String("name", name), zap.Any("options", options))
+
+	return &BTFSVolume{Options: options}, nil
+}
+
+func (m *BTFSDriver) RemoveVolume(name string) error {
+	m.log.Debug("handling Worker.RemoveVolume request")
+	return nil
+}
+
+func (m *BTFSDriver) Close() error {
+	return m.server.Close()
+}
+
+type BTFSVolume struct {
+	Options map[string]string
+}
+
+func (m *BTFSVolume) Configure(mnt Mount, cfg *container.HostConfig) error {
+	cfg.Mounts = append(cfg.Mounts, mount.Mount{
+		Type:        mount.TypeVolume,
+		Source:      mnt.Source,
+		Target:      mnt.Target,
+		ReadOnly:    true,
+		Consistency: mount.ConsistencyDefault,
+
+		BindOptions: nil,
+		VolumeOptions: &mount.VolumeOptions{
+			NoCopy: false,
+			Labels: map[string]string{}, // TODO: < DealID?
+			DriverConfig: &mount.Driver{
+				Name:    BTFSDriverName,
+				Options: m.Options,
+			},
+		},
+		TmpfsOptions: nil,
+	})
+
+	return nil
+}
+
+type BTFSDockerVolume struct {
+	Client      *docker.Client
+	MagnetURI   string
+	MountPoint  string
+	ID          string
+	Connections int
+}
+
+type BTFSDockerDriver struct {
+	client       *docker.Client
+	mountRootDir string
+
+	mu      sync.Mutex
+	volumes map[string]*BTFSDockerVolume
+	log     *zap.SugaredLogger
+}
+
+func (m *BTFSDockerDriver) Create(request *volume.CreateRequest) error {
+	m.log.Debugw("handling Volume.Create request", zap.Any("request", request))
+
+	uri, ok := request.Options["magnet"]
+	if !ok {
+		return fmt.Errorf("`magnet` URI is required")
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.volumes[request.Name] = &BTFSDockerVolume{
+		Client:      m.client,
+		MagnetURI:   uri,
+		MountPoint:  filepath.Join(m.mountRootDir, request.Name),
+		Connections: 0,
+	}
+
+	return nil
+}
+
+func (m *BTFSDockerDriver) List() (*volume.ListResponse, error) {
+	m.log.Debug("handling Volume.List request")
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	volumes := make([]*volume.Volume, 0, len(m.volumes))
+
+	for id, v := range m.volumes {
+		volumes = append(volumes, &volume.Volume{
+			Name:       id,
+			Mountpoint: v.MountPoint,
+		})
+	}
+
+	return &volume.ListResponse{Volumes: volumes}, nil
+}
+
+func (m *BTFSDockerDriver) Get(request *volume.GetRequest) (*volume.GetResponse, error) {
+	m.log.Debugw("handling Volume.Get request", zap.Any("request", request))
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	v, ok := m.volumes[request.Name]
+	if !ok {
+		return &volume.GetResponse{}, fmt.Errorf("volume %s not found", request.Name)
+	}
+
+	return &volume.GetResponse{Volume: &volume.Volume{Name: request.Name, Mountpoint: v.MountPoint}}, nil
+}
+
+func (m *BTFSDockerDriver) Remove(request *volume.RemoveRequest) error {
+	m.log.Debugw("handling Volume.Remove request", zap.Any("request", request))
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if v, ok := m.volumes[request.Name]; ok {
+		m.log.Infof("removing `%s` volume on `%s`", request.Name, v.MountPoint)
+		delete(m.volumes, request.Name)
+		return nil
+	}
+
+	return fmt.Errorf("volume `%s` not found", request.Name)
+}
+
+func (m *BTFSDockerDriver) Path(request *volume.PathRequest) (*volume.PathResponse, error) {
+	m.log.Debugw("handling Volume.Path request", zap.Any("request", request))
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if v, ok := m.volumes[request.Name]; ok {
+		return &volume.PathResponse{Mountpoint: v.MountPoint}, nil
+	}
+
+	return nil, fmt.Errorf("volume `%s` not found", request.Name)
+}
+
+func (m *BTFSDockerDriver) Mount(request *volume.MountRequest) (*volume.MountResponse, error) {
+	m.log.Debugw("handling Volume.Mount request", zap.Any("request", request))
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	v, ok := m.volumes[request.Name]
+	if !ok {
+		return nil, fmt.Errorf("volume `%s` not found", request.Name)
+	}
+
+	if v.Connections == 0 {
+		stat, err := os.Lstat(v.MountPoint)
+
+		switch {
+		case os.IsNotExist(err):
+			if err := os.MkdirAll(v.MountPoint, 0755); err != nil {
+				return nil, fmt.Errorf("failed to create %s directories for %s volume: %v", v.MountPoint, request.Name, err)
+			}
+		case err != nil:
+			return nil, fmt.Errorf("failed to perform lstat %s volume: %v", request.Name, err)
+		case stat != nil && !stat.IsDir():
+			return nil, fmt.Errorf("failed to create %s directiries for %s volume: already exist and it's not a directory", v.MountPoint, request.Name)
+		}
+
+		cfg := &container.Config{
+			Image:   BTFSImage,
+			Labels:  map[string]string{},
+			Volumes: map[string]struct{}{},
+			Cmd:     []string{"/usr/bin/btfs", v.MagnetURI, "/root/mnt", "-f"},
+		}
+		hostConfig := &container.HostConfig{
+			CapAdd:          []string{"SYS_ADMIN"},
+			Privileged:      true,
+			SecurityOpt:     []string{"apparmor:unconfined"},
+			PublishAllPorts: true,
+			Mounts: []mount.Mount{
+				{
+					Type:        mount.TypeBind,
+					Source:      v.MountPoint,
+					Target:      "/root/mnt",
+					ReadOnly:    false,
+					Consistency: mount.ConsistencyDefault,
+
+					BindOptions: &mount.BindOptions{
+						Propagation: mount.PropagationRShared,
+					},
+					VolumeOptions: nil,
+					TmpfsOptions:  nil,
+				},
+			},
+		}
+		networkConfig := &network.NetworkingConfig{} // TODO: Assign to deal bridge to enable shaping.
+
+		ctx := context.Background()
+
+		response, err := m.client.ContainerCreate(ctx, cfg, hostConfig, networkConfig, "")
+		if err != nil {
+			return nil, fmt.Errorf("failed to create btfs container for %s volume: %v", request.Name, err)
+		}
+		if err := m.client.ContainerStart(ctx, response.ID, types.ContainerStartOptions{}); err != nil {
+			return nil, fmt.Errorf("failed to start btfs container for %s volume: %v", request.Name, err)
+		}
+
+		v.ID = response.ID
+	}
+
+	v.Connections++
+
+	return &volume.MountResponse{Mountpoint: v.MountPoint}, nil
+}
+
+func (m *BTFSDockerDriver) Unmount(request *volume.UnmountRequest) error {
+	m.log.Debugw("handling Volume.Unmount request", zap.Any("request", request))
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	v, ok := m.volumes[request.Name]
+	if !ok {
+		return fmt.Errorf("volume `%s` not found", request.Name)
+	}
+
+	v.Connections--
+
+	if v.Connections <= 0 {
+		// Weird case when Docker calls "Unmount" before "Mount".
+		v.Connections = 0
+
+		ctx := context.Background()
+		if err := m.client.ContainerStop(ctx, v.ID, nil); err != nil {
+			return fmt.Errorf("failed to stop btfs container for %s volume: %v", request.Name, err)
+		}
+		if err := m.client.ContainerRemove(ctx, v.ID, types.ContainerRemoveOptions{}); err != nil {
+			return fmt.Errorf("failed to clean up btfs container for %s volume: %v", request.Name, err)
+		}
+		if err := fuse.Unmount(v.MountPoint); err != nil {
+			return fmt.Errorf("failed to unmount fuse for %s volume: %v", request.Name, err)
+		}
+	}
+
+	return nil
+}
+
+func (m *BTFSDockerDriver) Capabilities() *volume.CapabilitiesResponse {
+	return &volume.CapabilitiesResponse{
+		Capabilities: volume.Capability{
+			Scope: "local",
+		},
+	}
+}

--- a/insonmnia/worker/volume/cifs.go
+++ b/insonmnia/worker/volume/cifs.go
@@ -29,9 +29,7 @@ type cifsVolumeDriver struct {
 // NewCIFSVolumeDriver constructs and runs a new CIFS volume driver within the
 // provided error group.
 func NewCIFSVolumeDriver(ctx context.Context, options ...Option) (VolumeDriver, error) {
-	opts := &Options{
-		SocketDir: pluginSockDir,
-	}
+	opts := newOptions()
 
 	for _, option := range options {
 		if err := option(opts); err != nil {
@@ -43,7 +41,7 @@ func NewCIFSVolumeDriver(ctx context.Context, options ...Option) (VolumeDriver, 
 	driverName := drivers.CIFS.String()
 
 	rootDir := filepath.Join(baseDir, driverName)
-	socketPath, err := fullSocketPath(opts.SocketDir, driverName)
+	socketPath, err := fullSocketPath(opts.socketDir, driverName)
 	if err != nil {
 		return nil, err
 	}

--- a/insonmnia/worker/volume/driver.go
+++ b/insonmnia/worker/volume/driver.go
@@ -28,6 +28,15 @@ func (nilVolume) Configure(mount Mount, cfg *container.HostConfig) error {
 // create new volumes for containers.
 type VolumeDriver interface {
 	// CreateVolume creates a new volume using specified name and Option.
+	//
+	// This method is called before tuning a new container, so it should
+	// prepare all required stuff such as mounting filesystems, create
+	// subdirectories, etc.
+	// For example for BTFS driver it creates torrent client, mounts FUSE
+	// filesystem and tries to fetch the provided magnet URL.
+	//
+	// Both "name" and "options" parameters are passed directly from the
+	// task specification.
 	CreateVolume(name string, options map[string]string) (Volume, error)
 	// RemoveVolume removes an existing volume.
 	RemoveVolume(name string) error
@@ -64,6 +73,8 @@ func NewVolumeDriver(ctx context.Context, ty string, options ...Option) (VolumeD
 	switch ty {
 	case drivers.CIFS.String():
 		return NewCIFSVolumeDriver(ctx, options...)
+	case BTFSDriverName:
+		return NewBTFSDriver(options...)
 	default:
 		return nil, fmt.Errorf("unknown volume driver: %s", ty)
 	}

--- a/insonmnia/worker/volume/options.go
+++ b/insonmnia/worker/volume/options.go
@@ -2,36 +2,58 @@ package volume
 
 import (
 	"fmt"
+
+	"go.uber.org/zap"
 )
 
 // Option specifies how a Docker plugin can be configured.
 type Option func(options interface{}) error
 
 // Options describes generic volume plugin options.
-type Options struct {
-	SocketDir string
+type options struct {
+	socketDir string
+	log       *zap.SugaredLogger
+}
+
+func newOptions() *options {
+	return &options{
+		socketDir: defaultPluginSockDir,
+		log:       zap.NewNop().Sugar(),
+	}
 }
 
 // WithPluginSocketDir constructs an option that specifies the plugin
 // directory where Unix sockets live.
 func WithPluginSocketDir(path string) Option {
 	return func(o interface{}) error {
-		option, ok := o.(*Options)
+		option, ok := o.(*options)
 		if !ok {
 			return fmt.Errorf("invalid option type: %T", o)
 		}
 
-		option.SocketDir = path
+		option.socketDir = path
+		return nil
+	}
+}
+
+func WithLogger(log *zap.SugaredLogger) Option {
+	return func(o interface{}) error {
+		option, ok := o.(*options)
+		if !ok {
+			return fmt.Errorf("invalid option type: %T", o)
+		}
+
+		option.log = log
 		return nil
 	}
 }
 
 // WithOptions constructs an option that forwards the given generic options
 // to the plugin.
-func WithOptions(options map[string]string) Option {
+func WithOptions(opts map[string]string) Option {
 	return func(o interface{}) error {
 		switch o.(type) {
-		case *Options:
+		case *options:
 			return nil
 		default:
 			return fmt.Errorf("invalid option type: %T", o)

--- a/insonmnia/worker/volume/serve.go
+++ b/insonmnia/worker/volume/serve.go
@@ -1,11 +1,18 @@
 package volume
 
 import (
+	"fmt"
+	"net"
 	"os"
 	"path/filepath"
+	"syscall"
+
+	"github.com/docker/go-connections/sockets"
+	"github.com/docker/go-plugins-helpers/volume"
+	"go.uber.org/zap"
 )
 
-const pluginSockDir = "/run/docker/plugins"
+const defaultPluginSockDir = "/run/docker/plugins"
 
 func fullSocketPath(dir, address string) (string, error) {
 	if err := os.MkdirAll(dir, 0755); err != nil {
@@ -15,4 +22,47 @@ func fullSocketPath(dir, address string) (string, error) {
 		return address, nil
 	}
 	return filepath.Join(dir, address+".sock"), nil
+}
+
+type VolumeServer struct {
+	name     string
+	listener net.Listener
+	log      *zap.SugaredLogger
+}
+
+func NewVolumeServer(name string, options ...Option) (*VolumeServer, error) {
+	opts := newOptions()
+	for _, o := range options {
+		o(opts)
+	}
+
+	if err := os.MkdirAll(opts.socketDir, 0755); err != nil {
+		return nil, fmt.Errorf("failed to create directory for %s plugin: %v", name, err)
+	}
+
+	path := filepath.Join(opts.socketDir, fmt.Sprintf("%s.sock", name))
+
+	listener, err := sockets.NewUnixSocket(path, syscall.Getgid())
+	if err != nil {
+		return nil, err
+	}
+
+	m := &VolumeServer{
+		name:     name,
+		listener: listener,
+		log:      opts.log,
+	}
+
+	return m, nil
+}
+
+func (m *VolumeServer) Serve(driver volume.Driver) error {
+	m.log.Infof("exposing %s volume plugin on %s", m.name, m.listener.Addr())
+	defer m.log.Infof("%s volume plugin has been stopped", m.name)
+
+	return volume.NewHandler(driver).Serve(m.listener)
+}
+
+func (m *VolumeServer) Close() error {
+	return m.listener.Close()
 }

--- a/task.yaml
+++ b/task.yaml
@@ -25,9 +25,14 @@ resources:
 #        password: password
 #        security: ntlm
 #        vers: 3.0
+#    btfs:
+#      type: btfs
+#        options:
+#          magnet: "magnet:?xt=urn:xxxxxxxxxx"
 #  mounts:
 #    - cifs:/mnt:rw
 #    - cifs:/opt:rw
+#    - btfs:/mnt:ro
 # # custom registry settings, optional section
 # registry:
 #   # if not empty, Worker will use given registry to pull an image from, optional param

--- a/util/xdocker/xdocker.go
+++ b/util/xdocker/xdocker.go
@@ -1,4 +1,4 @@
-package worker
+package xdocker
 
 import (
 	"bufio"
@@ -13,14 +13,14 @@ type spoolResponseProtocol struct {
 	Status string `json:"status"`
 }
 
-// decodeImagePull detects Error of an image pulling process
+// DecodeImagePull detects Error of an image pulling process
 // by decoding reply from Docker
 // Although Docker should reply with JSON Encoded items
 // one per line, in different versions it could vary.
 // This decoders can detect error even in mixed replies:
 // {"Status": "OK"}\n{"Status": "OK"}
 // {"Status": "OK"}{"Error": "error"}
-func decodeImagePull(r io.Reader) error {
+func DecodeImagePull(r io.Reader) error {
 	more := true
 
 	rd := bufio.NewReader(r)

--- a/util/xdocker/xdocker_test.go
+++ b/util/xdocker/xdocker_test.go
@@ -1,4 +1,4 @@
-package worker
+package xdocker
 
 import (
 	"bytes"
@@ -13,8 +13,6 @@ import (
 )
 
 func TestImagePullFromMock(t *testing.T) {
-	assert := assert.New(t)
-
 	fixtures := []struct {
 		name string
 		body []byte
@@ -31,12 +29,12 @@ func TestImagePullFromMock(t *testing.T) {
 	}
 
 	for _, fixt := range fixtures {
-		err := decodeImagePull(bytes.NewReader(fixt.body))
-		assert.Equal(fixt.err, err, "invalid error for %v", fixt.name)
+		err := DecodeImagePull(bytes.NewReader(fixt.body))
+		assert.Equal(t, fixt.err, err, "invalid error for %v", fixt.name)
 	}
 }
 
-func TestImagePll(t *testing.T) {
+func TestImagePull(t *testing.T) {
 	dockclient, err := client.NewEnvClient()
 	if err != nil {
 		log.Fatal(err)
@@ -49,7 +47,7 @@ func TestImagePll(t *testing.T) {
 	}
 	defer rd.Close()
 
-	err = decodeImagePull(rd)
+	err = DecodeImagePull(rd)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This commit activates an ability to spawn SONM tasks with torrent
filesystem attached as a volume.

Internally this is achieved by using BTFS application that constructs a
torrent client and mounts itself on a filesystem via fuse. It's the
read-only solution designed to distribute large amount of data across
multiple task without single point of failure - all tasks help each
other to share the data, which reduces network pressure and improves
application scalability.
The contents of the files will be downloaded on-demand as they are read 
by applications. Tools like ls, cat and cp works as expected.

[![asciicast](https://asciinema.org/a/5ZIETLiht4r5SHRxZ19EnQV8n.png)](https://asciinema.org/a/5ZIETLiht4r5SHRxZ19EnQV8n)