### PR TITLE
fix: load keystore even if `--insecure` flag is set

### DIFF
--- a/cmd/cli/commands/blacklist.go
+++ b/cmd/cli/commands/blacklist.go
@@ -19,7 +19,7 @@ func init() {
 var blacklistRootCmd = &cobra.Command{
 	Use:               "blacklist",
 	Short:             "Manage blacklisted addresses",
-	PersistentPreRunE: loadKeyStoreIfRequired,
+	PersistentPreRunE: loadKeyStoreWrapper,
 }
 
 var blacklistListCmd = &cobra.Command{

--- a/cmd/cli/commands/common.go
+++ b/cmd/cli/commands/common.go
@@ -215,10 +215,10 @@ func initKeystore() (*accounts.MultiKeystore, error) {
 	}, accounts.NewInteractivePassPhraser())
 }
 
-// loadKeyStoreWrapper implemented to match cobra.Command.PreRun signature.
-//
-// Function loads and opens keystore. Also, storing opened key in "sessionKey" var
-// to be able to reuse it into cli during one session.
+// loadKeyStoreWrapper is matching cobra.Command.PreRunE signature.
+// It loads default key from the given keystore and keeps the keystore instance
+// in the global variable `keystore` that available for any CLI's sub-commands.
+// Note that the keystore must be loaded before any command's logic it started to execute.
 func loadKeyStoreWrapper(_ *cobra.Command, _ []string) error {
 	var err error
 	keystore, err = initKeystore()
@@ -241,17 +241,6 @@ func loadKeyStoreWrapper(_ *cobra.Command, _ []string) error {
 		}
 
 		creds = auth.NewWalletAuthenticator(util.NewTLS(TLSConfig), crypto.PubkeyToAddress(sessionKey.PublicKey))
-	}
-
-	return nil
-}
-
-// loadKeyStoreIfRequired loads eth keystore if `insecure` flag is not set.
-// this wrapper is required for any command that not require eth keys implicitly
-// but may use TLS to connect to the Node.
-func loadKeyStoreIfRequired(cmd *cobra.Command, _ []string) error {
-	if !insecureFlag {
-		return loadKeyStoreWrapper(cmd, nil)
 	}
 
 	return nil

--- a/cmd/cli/commands/deals.go
+++ b/cmd/cli/commands/deals.go
@@ -52,7 +52,7 @@ func init() {
 var dealRootCmd = &cobra.Command{
 	Use:               "deal",
 	Short:             "Manage deals",
-	PersistentPreRunE: loadKeyStoreIfRequired,
+	PersistentPreRunE: loadKeyStoreWrapper,
 }
 
 var dealListCmd = &cobra.Command{

--- a/cmd/cli/commands/master.go
+++ b/cmd/cli/commands/master.go
@@ -22,7 +22,7 @@ func init() {
 var masterRootCmd = &cobra.Command{
 	Use:               "master",
 	Short:             "Manage master and workers addresses",
-	PersistentPreRunE: loadKeyStoreIfRequired,
+	PersistentPreRunE: loadKeyStoreWrapper,
 }
 
 var masterListCmd = &cobra.Command{

--- a/cmd/cli/commands/orders.go
+++ b/cmd/cli/commands/orders.go
@@ -27,7 +27,7 @@ func init() {
 var orderRootCmd = &cobra.Command{
 	Use:               "order",
 	Short:             "Manage orders",
-	PersistentPreRunE: loadKeyStoreIfRequired,
+	PersistentPreRunE: loadKeyStoreWrapper,
 }
 
 var orderListCmd = &cobra.Command{

--- a/cmd/cli/commands/profiles.go
+++ b/cmd/cli/commands/profiles.go
@@ -19,7 +19,7 @@ func init() {
 var profileRootCmd = &cobra.Command{
 	Use:               "profile",
 	Short:             "Manage profiles",
-	PersistentPreRunE: loadKeyStoreIfRequired,
+	PersistentPreRunE: loadKeyStoreWrapper,
 }
 
 var profileStatusCmd = &cobra.Command{

--- a/cmd/cli/commands/tasks.go
+++ b/cmd/cli/commands/tasks.go
@@ -51,7 +51,7 @@ var taskPullOutput string
 var taskRootCmd = &cobra.Command{
 	Use:               "task",
 	Short:             "Tasks management",
-	PersistentPreRunE: loadKeyStoreIfRequired,
+	PersistentPreRunE: loadKeyStoreWrapper,
 }
 
 func getActiveDealIDs(ctx context.Context) ([]*big.Int, error) {

--- a/cmd/cli/commands/tokens.go
+++ b/cmd/cli/commands/tokens.go
@@ -31,7 +31,7 @@ func init() {
 var tokenRootCmd = &cobra.Command{
 	Use:               "token",
 	Short:             "Manage tokens",
-	PersistentPreRunE: loadKeyStoreIfRequired,
+	PersistentPreRunE: loadKeyStoreWrapper,
 }
 
 var tokenGetCmd = &cobra.Command{

--- a/cmd/cli/commands/worker.go
+++ b/cmd/cli/commands/worker.go
@@ -22,7 +22,7 @@ var (
 )
 
 func workerPreRunE(cmd *cobra.Command, args []string) error {
-	if err := loadKeyStoreIfRequired(cmd, args); err != nil {
+	if err := loadKeyStoreWrapper(cmd, args); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
This commit fixes a problem when `--insecure` flag is used
with the CLI and some sub-command wants to load a key or
obtain a default eth address from the key store.

Therefore, now we'll load keystore prematurely for any command.
Now if insecure mode is activated, only TLS credentials creation
will be skipped for gRPC's client connection.