### PR TITLE
fix: parse BID and ASK strictly

### DIFF
--- a/cmd/cli/task_config/load_order.go
+++ b/cmd/cli/task_config/load_order.go
@@ -1,11 +1,22 @@
 package task_config
 
 import (
-	"github.com/jinzhu/configor"
+	"bytes"
+	"io/ioutil"
+
+	"gopkg.in/yaml.v2"
 )
 
 func LoadFromFile(path string, into interface{}) error {
-	if err := configor.Load(into, path); err != nil {
+	data, err := ioutil.ReadFile(path)
+	if err != nil {
+		return err
+	}
+
+	decoder := yaml.NewDecoder(bytes.NewBuffer(data))
+	decoder.SetStrict(true)
+
+	if err := decoder.Decode(into); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
This commit fixes a bug when a user can accidentally create BID or ASK with fields that are unknown to the Node/Worker. Such behaviour is a source of confusion and frustration, so we just forbid unknown fields when doing "sonmcli order create" and "sonmcli worker ask-plan create".