### PR TITLE
refactor: orders factory for connor

### DIFF
--- a/connor/engine.go
+++ b/connor/engine.go
@@ -30,6 +30,7 @@ type engine struct {
 	deals         sonm.DealManagementClient
 	tasks         sonm.TaskManagementClient
 	priceProvider price.Provider
+	corderFactory CorderFactoriy
 
 	ordersCreateChan  chan *Corder
 	ordersResultsChan chan *Corder
@@ -46,6 +47,7 @@ func NewEngine(ctx context.Context, cfg *Config, price price.Provider, log *zap.
 		tasks:             sonm.NewTaskManagementClient(cc),
 		ordersCreateChan:  make(chan *Corder, concurrency),
 		ordersResultsChan: make(chan *Corder, concurrency),
+		corderFactory:     NewCorderFactory(cfg.Mining.Token),
 		antiFraud:         antifraud.NewAntiFraud(cfg.AntiFraud, log.Named("anti-fraud"), cc),
 	}
 }
@@ -81,7 +83,7 @@ func (e *engine) processOrderCreate() {
 			continue
 		}
 
-		e.ordersResultsChan <- NewCorderFromOrder(created, bid.token)
+		e.ordersResultsChan <- e.corderFactory.FromOrder(created)
 	}
 }
 

--- a/connor/types_test.go
+++ b/connor/types_test.go
@@ -9,44 +9,26 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestNewCorderFromParams(t *testing.T) {
-	c1, err := NewCorderFromParams("ETH", big.NewInt(100), 1000,
-		newBenchmarkFromMap(map[string]uint64{"gpu-mem": 3000e6}))
-	require.NoError(t, err)
+func TestNewCorderFactory(t *testing.T) {
+	c1 := NewCorderFactory("ETH").
+		FromParams(big.NewInt(100), 1000, *newBenchmarkFromMap(map[string]uint64{}))
 
 	assert.Equal(t, c1.GetHashrate(), uint64(1000))
-	assert.Equal(t, c1.Order.Benchmarks.GPUMem(), uint64(3000e6))
 	assert.Equal(t, c1.Order.GetBenchmarks().GPUEthHashrate(), uint64(1000))
 
-	c2, err := NewCorderFromParams("ZEC", big.NewInt(100), 500,
-		newBenchmarkFromMap(map[string]uint64{"gpu-mem": 900e6}))
-	require.NoError(t, err)
-
-	assert.Equal(t, c2.GetHashrate(), uint64(500))
-	assert.Equal(t, c2.Order.Benchmarks.GPUMem(), uint64(900e6))
-	assert.Equal(t, c2.Order.GetBenchmarks().GPUCashHashrate(), uint64(500))
-
-	c3, err := NewCorderFromParams("NULL", big.NewInt(100), 5000,
-		newBenchmarkFromMap(map[string]uint64{"gpu-mem": 1e6}))
-	require.NoError(t, err)
-
-	assert.Equal(t, c3.GetHashrate(), uint64(5000))
-	assert.Equal(t, c3.Order.Benchmarks.GPUMem(), uint64(1e6))
-	assert.Equal(t, c3.Order.GetBenchmarks().GPURedshift(), uint64(5000))
+	c2 := NewCorderFactory("NULL").
+		FromParams(big.NewInt(200), 2000, *newBenchmarkFromMap(map[string]uint64{}))
+	assert.Equal(t, c2.GetHashrate(), uint64(2000))
+	assert.Equal(t, c2.Order.GetBenchmarks().GPURedshift(), uint64(2000))
 }
 
 func TestCorder_AsBID(t *testing.T) {
-	eth, err := NewCorderFromParams("ETH", big.NewInt(100), 1000,
-		newBenchmarkFromMap(map[string]uint64{"gpu-mem": 3000e6}))
-	require.NoError(t, err)
-
-	zec, err := NewCorderFromParams("ZEC", big.NewInt(100), 130,
-		newBenchmarkFromMap(map[string]uint64{"gpu-mem": 900e6}))
-	require.NoError(t, err)
-
-	null, err := NewCorderFromParams("NULL", big.NewInt(100), 550,
-		newBenchmarkFromMap(map[string]uint64{"gpu-mem": 1e6}))
-	require.NoError(t, err)
+	eth := NewCorderFactory("ETH").FromParams(big.NewInt(100), 1000,
+		*newBenchmarkFromMap(map[string]uint64{"gpu-mem": 3000e6}))
+	zec := NewCorderFactory("ZEC").FromParams(big.NewInt(100), 130,
+		*newBenchmarkFromMap(map[string]uint64{"gpu-mem": 900e6}))
+	null := NewCorderFactory("NULL").FromParams(big.NewInt(100), 550,
+		*newBenchmarkFromMap(map[string]uint64{"gpu-mem": 1e6}))
 
 	hashrate, ok := eth.AsBID().GetResources().GetBenchmarks()["gpu-eth-hashrate"]
 	gpuMem, ok := eth.AsBID().GetResources().GetBenchmarks()["gpu-mem"]

--- a/connor/x_test.go
+++ b/connor/x_test.go
@@ -10,15 +10,17 @@ import (
 func TestDivideOrders(t *testing.T) {
 	c := &Connor{}
 
-	ex1, _ := NewCorderFromParams("ETH", big.NewInt(1), 100, newBenchmarkFromMap(map[string]uint64{}))
-	ex2, _ := NewCorderFromParams("ETH", big.NewInt(2), 200, newBenchmarkFromMap(map[string]uint64{}))
-	ex3, _ := NewCorderFromParams("ETH", big.NewInt(3), 300, newBenchmarkFromMap(map[string]uint64{}))
+	f := NewCorderFactory("ETH")
 
-	req0, _ := NewCorderFromParams("ETH", big.NewInt(1), 50, newBenchmarkFromMap(map[string]uint64{}))
-	req1, _ := NewCorderFromParams("ETH", big.NewInt(1), 100, newBenchmarkFromMap(map[string]uint64{}))
-	req2, _ := NewCorderFromParams("ETH", big.NewInt(2), 200, newBenchmarkFromMap(map[string]uint64{}))
-	req3, _ := NewCorderFromParams("ETH", big.NewInt(3), 300, newBenchmarkFromMap(map[string]uint64{}))
-	req4, _ := NewCorderFromParams("ETH", big.NewInt(4), 400, newBenchmarkFromMap(map[string]uint64{}))
+	ex1 := f.FromParams(big.NewInt(1), 100, *newBenchmarkFromMap(map[string]uint64{}))
+	ex2 := f.FromParams(big.NewInt(2), 200, *newBenchmarkFromMap(map[string]uint64{}))
+	ex3 := f.FromParams(big.NewInt(3), 300, *newBenchmarkFromMap(map[string]uint64{}))
+
+	req0 := f.FromParams(big.NewInt(1), 50, *newBenchmarkFromMap(map[string]uint64{}))
+	req1 := f.FromParams(big.NewInt(1), 100, *newBenchmarkFromMap(map[string]uint64{}))
+	req2 := f.FromParams(big.NewInt(2), 200, *newBenchmarkFromMap(map[string]uint64{}))
+	req3 := f.FromParams(big.NewInt(3), 300, *newBenchmarkFromMap(map[string]uint64{}))
+	req4 := f.FromParams(big.NewInt(4), 400, *newBenchmarkFromMap(map[string]uint64{}))
 
 	existing := []*Corder{ex1, ex2, ex3}
 	required := []*Corder{req0, req1, req2, req3, req4}


### PR DESCRIPTION
This commit replaces corder's constrictor and some internals
that uses weird switch-case logic to control token-related parameters.

Fabric is constructed once when Connor is initializing and keeps
pre-defined params to create new instances if requred.