### PR TITLE
fix: properly calculate free devices in Optimus

### DIFF
--- a/optimus/engine.go
+++ b/optimus/engine.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/golang/protobuf/proto"
 	"github.com/sonm-io/core/blockchain"
 	"github.com/sonm-io/core/insonmnia/benchmarks"
 	"github.com/sonm-io/core/insonmnia/hardware"
@@ -60,12 +61,13 @@ func (m *optimizationInput) Price() *sonm.Price {
 }
 
 func (m *optimizationInput) freeDevices(removalVictims map[string]*sonm.AskPlan) (*sonm.DevicesReply, error) {
+	devices := proto.Clone(m.Devices).(*sonm.DevicesReply)
 	workerHardware := hardware.Hardware{
-		CPU:     m.Devices.CPU,
-		GPU:     m.Devices.GPUs,
-		RAM:     m.Devices.RAM,
-		Network: m.Devices.Network,
-		Storage: m.Devices.Storage,
+		CPU:     devices.CPU,
+		GPU:     devices.GPUs,
+		RAM:     devices.RAM,
+		Network: devices.Network,
+		Storage: devices.Storage,
 	}
 	// All resources are free by default.
 	freeResources := workerHardware.AskPlanResources()


### PR DESCRIPTION
This commit fixes a bug where during the calculation of free devices a mutation of meant-to-be-immutable field occurs, which lead to improper free devices state.
As a side effect one could see that Optimus performed invalid optimization in case where the most optimal ask-plans are already exist.