### PR TITLE
refactor: token parameters for Connors

### DIFF
--- a/connor/engine.go
+++ b/connor/engine.go
@@ -36,18 +36,18 @@ type engine struct {
 	ordersResultsChan chan *Corder
 }
 
-func NewEngine(ctx context.Context, cfg *Config, price price.Provider, log *zap.Logger, cc *grpc.ClientConn) *engine {
+func NewEngine(ctx context.Context, cfg *Config, log *zap.Logger, cc *grpc.ClientConn) *engine {
 	return &engine{
 		ctx:               ctx,
 		cfg:               cfg,
-		priceProvider:     price,
+		priceProvider:     cfg.getTokenParams().priceProvider,
 		log:               log.Named("engine"),
 		market:            sonm.NewMarketClient(cc),
 		deals:             sonm.NewDealManagementClient(cc),
 		tasks:             sonm.NewTaskManagementClient(cc),
 		ordersCreateChan:  make(chan *Corder, concurrency),
 		ordersResultsChan: make(chan *Corder, concurrency),
-		corderFactory:     NewCorderFactory(cfg.Mining.Token),
+		corderFactory:     cfg.getTokenParams().corderFactory,
 		antiFraud:         antifraud.NewAntiFraud(cfg.AntiFraud, log.Named("anti-fraud"), cc),
 	}
 }

--- a/connor/price/price.go
+++ b/connor/price/price.go
@@ -25,30 +25,15 @@ type Provider interface {
 }
 
 type ProviderConfig struct {
-	Token  string
 	Margin float64
 	URL    string
-}
-
-func NewProvider(cfg *ProviderConfig) Provider {
-	switch cfg.Token {
-	case "NULL":
-		return newNullPriceProvider(cfg)
-	case "ETH":
-		return newEthPriceProvider(cfg)
-	case "ZEC":
-		return newZecPriceProvider(cfg)
-	default:
-		// should never happens
-		panic("cannot get price updater for token " + cfg.Token)
-	}
 }
 
 type nullPriceProvider struct {
 	cfg *ProviderConfig
 }
 
-func newNullPriceProvider(cfg *ProviderConfig) Provider {
+func NewNullPriceProvider(cfg *ProviderConfig) Provider {
 	return &nullPriceProvider{cfg: cfg}
 }
 
@@ -67,7 +52,7 @@ type ethPriceProvider struct {
 	cfg   *ProviderConfig
 }
 
-func newEthPriceProvider(cfg *ProviderConfig) Provider {
+func NewEthPriceProvider(cfg *ProviderConfig) Provider {
 	return &ethPriceProvider{cfg: cfg}
 }
 
@@ -121,7 +106,7 @@ type zecPriceProvider struct {
 	price *big.Int
 }
 
-func newZecPriceProvider(_ *ProviderConfig) Provider { return &zecPriceProvider{price: big.NewInt(1)} }
+func NewZecPriceProvider(_ *ProviderConfig) Provider { return &zecPriceProvider{price: big.NewInt(1)} }
 
 func (p *zecPriceProvider) Update(ctx context.Context) error {
 	return nil

--- a/connor/types_test.go
+++ b/connor/types_test.go
@@ -5,30 +5,33 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/sonm-io/core/proto"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
+func newBenchmarksWithGPUMem(mem uint64) Benchmarks {
+	b := Benchmarks{Values: make([]uint64, sonm.MinNumBenchmarks)}
+	b.Values[8] = mem
+	return b
+}
+
 func TestNewCorderFactory(t *testing.T) {
-	c1 := NewCorderFactory("ETH").
-		FromParams(big.NewInt(100), 1000, *newBenchmarkFromMap(map[string]uint64{}))
+
+	c1 := NewCorderFactory("ETH", ethBenchmarkIndex).FromParams(big.NewInt(100), 1000, newZeroBenchmarks())
 
 	assert.Equal(t, c1.GetHashrate(), uint64(1000))
 	assert.Equal(t, c1.Order.GetBenchmarks().GPUEthHashrate(), uint64(1000))
 
-	c2 := NewCorderFactory("NULL").
-		FromParams(big.NewInt(200), 2000, *newBenchmarkFromMap(map[string]uint64{}))
+	c2 := NewCorderFactory("NULL", nullBenchmarkIndex).FromParams(big.NewInt(200), 2000, newZeroBenchmarks())
 	assert.Equal(t, c2.GetHashrate(), uint64(2000))
 	assert.Equal(t, c2.Order.GetBenchmarks().GPURedshift(), uint64(2000))
 }
 
 func TestCorder_AsBID(t *testing.T) {
-	eth := NewCorderFactory("ETH").FromParams(big.NewInt(100), 1000,
-		*newBenchmarkFromMap(map[string]uint64{"gpu-mem": 3000e6}))
-	zec := NewCorderFactory("ZEC").FromParams(big.NewInt(100), 130,
-		*newBenchmarkFromMap(map[string]uint64{"gpu-mem": 900e6}))
-	null := NewCorderFactory("NULL").FromParams(big.NewInt(100), 550,
-		*newBenchmarkFromMap(map[string]uint64{"gpu-mem": 1e6}))
+	eth := NewCorderFactory("ETH", ethBenchmarkIndex).FromParams(big.NewInt(100), 1000, newBenchmarksWithGPUMem(3000e6))
+	zec := NewCorderFactory("ZEC", zecBenchmarkIndex).FromParams(big.NewInt(100), 130, newBenchmarksWithGPUMem(900e6))
+	null := NewCorderFactory("NULL", nullBenchmarkIndex).FromParams(big.NewInt(100), 550, newBenchmarksWithGPUMem(1e6))
 
 	hashrate, ok := eth.AsBID().GetResources().GetBenchmarks()["gpu-eth-hashrate"]
 	gpuMem, ok := eth.AsBID().GetResources().GetBenchmarks()["gpu-mem"]

--- a/connor/x_test.go
+++ b/connor/x_test.go
@@ -10,17 +10,17 @@ import (
 func TestDivideOrders(t *testing.T) {
 	c := &Connor{}
 
-	f := NewCorderFactory("ETH")
+	f := NewCorderFactory("ETH", 0)
 
-	ex1 := f.FromParams(big.NewInt(1), 100, *newBenchmarkFromMap(map[string]uint64{}))
-	ex2 := f.FromParams(big.NewInt(2), 200, *newBenchmarkFromMap(map[string]uint64{}))
-	ex3 := f.FromParams(big.NewInt(3), 300, *newBenchmarkFromMap(map[string]uint64{}))
+	ex1 := f.FromParams(big.NewInt(1), 100, newBenchmarksWithGPUMem(0))
+	ex2 := f.FromParams(big.NewInt(2), 200, newBenchmarksWithGPUMem(0))
+	ex3 := f.FromParams(big.NewInt(3), 300, newBenchmarksWithGPUMem(0))
 
-	req0 := f.FromParams(big.NewInt(1), 50, *newBenchmarkFromMap(map[string]uint64{}))
-	req1 := f.FromParams(big.NewInt(1), 100, *newBenchmarkFromMap(map[string]uint64{}))
-	req2 := f.FromParams(big.NewInt(2), 200, *newBenchmarkFromMap(map[string]uint64{}))
-	req3 := f.FromParams(big.NewInt(3), 300, *newBenchmarkFromMap(map[string]uint64{}))
-	req4 := f.FromParams(big.NewInt(4), 400, *newBenchmarkFromMap(map[string]uint64{}))
+	req0 := f.FromParams(big.NewInt(1), 50, newBenchmarksWithGPUMem(0))
+	req1 := f.FromParams(big.NewInt(1), 100, newBenchmarksWithGPUMem(0))
+	req2 := f.FromParams(big.NewInt(2), 200, newBenchmarksWithGPUMem(0))
+	req3 := f.FromParams(big.NewInt(3), 300, newBenchmarksWithGPUMem(0))
+	req4 := f.FromParams(big.NewInt(4), 400, newBenchmarksWithGPUMem(0))
 
 	existing := []*Corder{ex1, ex2, ex3}
 	required := []*Corder{req0, req1, req2, req3, req4}


### PR DESCRIPTION
This commit aggregates token related params into the config.
The main idea is to keep all mining, pool and price watching interfaces
in the single point of configuration. It will give as an ability to configure
almost everything into a one place, thus adding new tokens can be performed
quickly and clearly.