### PR TITLE
fix: proper BTFS initialization

### DIFF
--- a/insonmnia/worker/volume/btfs.go
+++ b/insonmnia/worker/volume/btfs.go
@@ -142,7 +142,7 @@ func NewBTFSDockerDriver(client *docker.Client, log *zap.SugaredLogger) (*BTFSDo
 	ctx := context.Background()
 
 	if err := pullImage(ctx, client, BTFSImage); err != nil {
-
+		return nil, err
 	}
 
 	m := &BTFSDockerDriver{


### PR DESCRIPTION
Well, ` ¯\_(ツ)_/¯`.