### PR TITLE
feat: network shaping for BTFS

### DIFF
--- a/insonmnia/worker/overseer.go
+++ b/insonmnia/worker/overseer.go
@@ -93,6 +93,18 @@ func (d *Description) Mounts(source string) []volume.Mount {
 	return d.mounts
 }
 
+func (d *Description) Network() (string, string) {
+	if d.network == nil {
+		return "", ""
+	}
+
+	return d.network.Name, d.network.ID
+}
+
+func (d *Description) DealID() string {
+	return d.DealId
+}
+
 func (d *Description) IsGPURequired() bool {
 	return len(d.GPUDevices) > 0
 }

--- a/insonmnia/worker/volume/driver.go
+++ b/insonmnia/worker/volume/driver.go
@@ -10,6 +10,11 @@ import (
 	"go.uber.org/zap"
 )
 
+const (
+	OptionNetworkName = "NetworkName"
+	OptionNetworkID   = "NetworkID"
+)
+
 // Volume specifies volume interface, that is mounted within Docker
 // containers.
 type Volume interface {


### PR DESCRIPTION
This commit activates network shaping for BTFS volume plugin.
Previously BTFS was run under separate bridge network, which was not connected with the network under which the deal tasks is being executed.
However now we are capable of performing task's network shaping under the constraints specified in supplier's order.
This commit changes the previous behavious with starting BTFS container under the same network with the task it manages, so network limitations should properly work.