### PR TITLE
refactor: construct anti-fraud processors with Factory

### DIFF
--- a/connor/antifraud/config.go
+++ b/connor/antifraud/config.go
@@ -2,15 +2,16 @@ package antifraud
 
 import "time"
 
-type LogProcessorConfig struct {
+type ProcessorConfig struct {
+	Format          string        `yaml:"format" required:""`
 	TrackInterval   time.Duration `yaml:"track_interval" default:"10s"`
 	TaskWarmupDelay time.Duration `yaml:"warmup_delay" required:"true"`
 }
 
 type Config struct {
-	TaskQuality          float64            `yaml:"task_quality" required:"true"`
-	QualityCheckInterval time.Duration      `yaml:"quality_check_interval" default:"15s"`
-	ConnectionTimeout    time.Duration      `yaml:"connection_timeout" default:"30s"`
-	LogProcessorConfig   LogProcessorConfig `yaml:"log_processor"`
-	PoolProcessorConfig  LogProcessorConfig `yaml:"pool_processor"`
+	TaskQuality          float64         `yaml:"task_quality" required:"true"`
+	QualityCheckInterval time.Duration   `yaml:"quality_check_interval" default:"15s"`
+	ConnectionTimeout    time.Duration   `yaml:"connection_timeout" default:"30s"`
+	LogProcessorConfig   ProcessorConfig `yaml:"log_processor"`
+	PoolProcessorConfig  ProcessorConfig `yaml:"pool_processor"`
 }

--- a/connor/antifraud/log_processor.go
+++ b/connor/antifraud/log_processor.go
@@ -17,7 +17,7 @@ import (
 	"google.golang.org/grpc"
 )
 
-func NewLogProcessor(cfg *LogProcessorConfig, log *zap.Logger, nodeConnection *grpc.ClientConn, deal *sonm.Deal, taskID string) LogProcessor {
+func newClaymoreLogProcessor(cfg *ProcessorConfig, log *zap.Logger, nodeConnection *grpc.ClientConn, deal *sonm.Deal, taskID string) Processor {
 	taskLogger := log.Named("task-logs").With(zap.String("task_id", taskID), zap.String("deal_id", deal.GetId().Unwrap().String()))
 	return &EthClaymoreLogProcessor{
 		cfg:              cfg,
@@ -32,22 +32,9 @@ func NewLogProcessor(cfg *LogProcessorConfig, log *zap.Logger, nodeConnection *g
 	}
 }
 
-type NilLogProcessor struct{}
-
-func (m *NilLogProcessor) TaskQuality() float64 {
-	return 1.
-}
-
-func (m *NilLogProcessor) Run(ctx context.Context) error {
-	select {
-	case <-ctx.Done():
-		return ctx.Err()
-	}
-}
-
 type EthClaymoreLogProcessor struct {
 	log          *zap.Logger
-	cfg          *LogProcessorConfig
+	cfg          *ProcessorConfig
 	deal         *sonm.Deal
 	taskID       string
 	taskClient   sonm.TaskManagementClient

--- a/connor/antifraud/pool_processor_test.go
+++ b/connor/antifraud/pool_processor_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestPoolProcessorQueue_Decide(t *testing.T) {
-	w := &dwarfPoolWatcher{
+	w := &dwarfPoolProcessor{
 		hashrateQueue: &lane.Queue{Deque: lane.NewCappedDeque(60)},
 	}
 

--- a/connor/antifraud/processor.go
+++ b/connor/antifraud/processor.go
@@ -1,0 +1,95 @@
+package antifraud
+
+import (
+	"context"
+
+	"github.com/sonm-io/core/proto"
+	"go.uber.org/zap"
+	"google.golang.org/grpc"
+)
+
+const (
+	LogFormatClaymore = "claymore"
+	PoolFormatDwarf   = "dwarf"
+)
+
+// Processor is part of AntiFraud module that continuously
+// processing results of container execution (like logs, pool reports, etc)
+// and calculate task quality value.
+type Processor interface {
+	Run(ctx context.Context) error
+	TaskID() string
+	TaskQuality() (accurate bool, quality float64)
+}
+
+// ProcessorFactory builds particular processors for the anti-fraud
+type ProcessorFactory interface {
+	LogProcessor(deal *sonm.Deal, taskID string, opts ...Option) Processor
+	PoolProcessor(deal *sonm.Deal, taskID string, opts ...Option) Processor
+}
+
+func NewProcessorFactory(cfg *Config) ProcessorFactory {
+	var pool, log builderFunc
+
+	switch cfg.PoolProcessorConfig.Format {
+	case PoolFormatDwarf:
+		pool = func(deal *sonm.Deal, taskID string, opts ...Option) Processor {
+			o := &processorOpts{}
+			for _, opt := range opts {
+				opt(o)
+			}
+			return newDwarfPoolProcessor(&cfg.PoolProcessorConfig, o.logger, deal, taskID)
+		}
+	}
+
+	switch cfg.LogProcessorConfig.Format {
+	case LogFormatClaymore:
+		log = func(deal *sonm.Deal, taskID string, opts ...Option) Processor {
+			o := &processorOpts{}
+			for _, opt := range opts {
+				opt(o)
+			}
+			return newClaymoreLogProcessor(&cfg.LogProcessorConfig, o.logger, o.cc, deal, taskID)
+		}
+	}
+
+	return &processorFactory{
+		pool: pool,
+		log:  log,
+	}
+
+}
+
+type processorOpts struct {
+	logger *zap.Logger
+	cc     *grpc.ClientConn
+}
+
+type Option func(options *processorOpts)
+
+func WithLogger(log *zap.Logger) Option {
+	return func(o *processorOpts) {
+		o.logger = log
+	}
+}
+
+func WithClientConn(cc *grpc.ClientConn) Option {
+	return func(o *processorOpts) {
+		o.cc = cc
+	}
+}
+
+type builderFunc func(deal *sonm.Deal, taskID string, opts ...Option) Processor
+
+type processorFactory struct {
+	pool builderFunc
+	log  builderFunc
+}
+
+func (p *processorFactory) LogProcessor(deal *sonm.Deal, taskID string, opts ...Option) Processor {
+	return p.log(deal, taskID, opts...)
+}
+
+func (p *processorFactory) PoolProcessor(deal *sonm.Deal, taskID string, opts ...Option) Processor {
+	return p.pool(deal, taskID, opts...)
+}

--- a/connor/engine.go
+++ b/connor/engine.go
@@ -97,10 +97,11 @@ func New(ctx context.Context, cfg *Config, log *zap.Logger) (*engine, error) {
 		priceProvider: cfg.getTokenParams().priceProvider,
 		corderFactory: cfg.getTokenParams().corderFactory,
 
-		market:    sonm.NewMarketClient(cc),
-		deals:     sonm.NewDealManagementClient(cc),
-		tasks:     sonm.NewTaskManagementClient(cc),
-		antiFraud: antifraud.NewAntiFraud(cfg.AntiFraud, log.Named("anti-fraud"), cc),
+		market: sonm.NewMarketClient(cc),
+		deals:  sonm.NewDealManagementClient(cc),
+		tasks:  sonm.NewTaskManagementClient(cc),
+		// todo: name logger inside AntiFraud's constructor
+		antiFraud: antifraud.NewAntiFraud(cfg.AntiFraud, log.Named("anti-fraud"), cfg.getTokenParams().processorFactory, cc),
 
 		ordersCreateChan:  make(chan *Corder, concurrency),
 		ordersResultsChan: make(chan *Corder, concurrency),

--- a/connor/types.go
+++ b/connor/types.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/sonm-io/core/connor/antifraud"
 	"github.com/sonm-io/core/connor/price"
 	"github.com/sonm-io/core/proto"
 )
@@ -161,11 +162,9 @@ type taskStatus struct {
 }
 
 type tokenParameters struct {
-	corderFactory CorderFactoriy
-	priceProvider price.Provider
-	poolWatcher   interface{}
-	// todo: how to deal with log parser?
-	// the log parser is bound to container?
+	corderFactory    CorderFactoriy
+	priceProvider    price.Provider
+	processorFactory antifraud.ProcessorFactory
 }
 
 type ordersSets struct {

--- a/etc/connor.yaml
+++ b/etc/connor.yaml
@@ -36,10 +36,12 @@ antifraud:
   connection_timeout: 30s
 
   log_processor:
+    format: claymore
     track_interval: 30s
     warmup_delay: 5m
 
   pool_processor:
+    format: dwarf
     track_interval: 1m
     warmup_delay: 15m
 


### PR DESCRIPTION
This commit adds factory that builds log and pool processors.
This change allows us to easily attach new processors for different mining software and different mining pools.

Changes:
- Processor config now accepting the `Format` parameter, then we construct particular log readers and pool trackers according to the known type.
- The antifraud module now keeping ProcessorFactory instance and build processors when the task has been warmed-up.
- NilLogProcessor was dropped because of useless.
- More conveniently naming for existing log and pool processors.