### PR TITLE
refactor: build miner's env for pool and token

### DIFF
--- a/connor/config_test.go
+++ b/connor/config_test.go
@@ -1,0 +1,88 @@
+package connor
+
+import (
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/sonm-io/core/connor/antifraud"
+	"github.com/sonm-io/core/proto"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConfigContainerEnv_Empty(t *testing.T) {
+	cfg := &Config{}
+	env := cfg.containerEnv(sonm.NewBigIntFromInt(1))
+	// empty config with no extra params should provide empty env map
+	assert.Len(t, env, 0)
+}
+
+func TestConfigContainerEnv_KnownParams(t *testing.T) {
+	cfg := &Config{
+		Mining: miningConfig{
+			Token:  "ETH",
+			Wallet: common.HexToAddress("0xB9aF252ec7D84f0feAD1DBB893b02cfD99EF47C6"),
+		},
+		AntiFraud: antifraud.Config{
+			PoolProcessorConfig: antifraud.ProcessorConfig{
+				Format: antifraud.PoolFormatDwarf,
+			},
+		},
+	}
+	env := cfg.containerEnv(sonm.NewBigIntFromInt(1))
+	// config for eth mining on dwarfPool should provide wallet and pool addr
+	assert.Len(t, env, 2)
+	assert.Contains(t, env, "WALLET")
+	assert.Contains(t, env, "POOL")
+}
+
+func TestConfigContainerEnv_ExtraParams(t *testing.T) {
+	cfg := &Config{
+		Mining: miningConfig{
+			Token:  "ETH",
+			Wallet: common.HexToAddress("0xB9aF252ec7D84f0feAD1DBB893b02cfD99EF47C6"),
+		},
+		AntiFraud: antifraud.Config{
+			PoolProcessorConfig: antifraud.ProcessorConfig{
+				Format: antifraud.PoolFormatDwarf,
+			},
+		},
+		Engine: engineConfig{
+			ContainerEnv: map[string]string{
+				"KEY1": "value1",
+				"key2": "value2",
+			},
+		},
+	}
+
+	env := cfg.containerEnv(sonm.NewBigIntFromInt(1))
+	// config should contain params for dwarfpool + two extra params
+	assert.Len(t, env, 4)
+	assert.Contains(t, env, "WALLET")
+	assert.Contains(t, env, "POOL")
+	assert.Contains(t, env, "KEY1")
+	assert.Contains(t, env, "key2")
+}
+
+func TestConfigContainerEnv_OverrideParams(t *testing.T) {
+	cfg := &Config{
+		Mining: miningConfig{
+			Token:  "ETH",
+			Wallet: common.HexToAddress("0xB9aF252ec7D84f0feAD1DBB893b02cfD99EF47C6"),
+		},
+		AntiFraud: antifraud.Config{
+			PoolProcessorConfig: antifraud.ProcessorConfig{
+				Format: antifraud.PoolFormatDwarf,
+			},
+		},
+		Engine: engineConfig{
+			ContainerEnv: map[string]string{"WALLET": "foo"},
+		},
+	}
+
+	env := cfg.containerEnv(sonm.NewBigIntFromInt(1))
+	// wallet should be overriden with extra env-vars
+	assert.Len(t, env, 2)
+	assert.Contains(t, env, "WALLET")
+	assert.Contains(t, env, "POOL")
+	assert.Equal(t, "foo", env["WALLET"])
+}

--- a/connor/engine.go
+++ b/connor/engine.go
@@ -376,18 +376,8 @@ func (e *engine) startTaskOnce(log *zap.Logger, dealID *sonm.BigInt) (*sonm.Star
 	ctx, cancel := context.WithTimeout(e.ctx, e.cfg.Engine.ConnectionTimeout)
 	defer cancel()
 
-	workerID := "c" + dealID.Unwrap().String()
-	ethID := strings.ToLower(e.cfg.Mining.Wallet.Hex())
-	poolAddr := fmt.Sprintf("%s/%s/%s", e.cfg.Mining.PoolReportURL, ethID, workerID)
-	wallet := fmt.Sprintf("%s/%s", ethID, workerID)
-
-	env := map[string]string{
-		"WALLET": wallet,
-		"POOL":   poolAddr,
-	}
-
+	env := e.cfg.containerEnv(dealID)
 	e.log.Debug("starting task", zap.Any("environment", env))
-
 	taskReply, err := e.tasks.Start(ctx, &sonm.StartTaskRequest{
 		DealID: dealID,
 		Spec: &sonm.TaskSpec{

--- a/etc/connor.yaml
+++ b/etc/connor.yaml
@@ -62,6 +62,10 @@ engine:
   # default: 10s
   task_restore_interval: 10s
 
+  # extra parameters for container with miner
+  #container_env:
+  #  my_parameter: "some_string_value"
+
 benchmarks:
   url: "https://raw.githubusercontent.com/sonm-io/benchmarks-list/master/list.json"
 


### PR DESCRIPTION
Chained with #1302

This commit adds method that generates env parameters for the container
according to configured token and mining pool. Also, user can override or extend
parameters using `engine.container_env` section in the config file.
