### PR TITLE
feat: simulation mode in Optimus

### DIFF
--- a/etc/optimus.yaml
+++ b/etc/optimus.yaml
@@ -181,6 +181,12 @@ workers:
     prelude_timeout: 30s
     # Optimization engine settings.
     optimization: *optimization
+    # Simulation settings.
+    # When specified Optimus is switched into simulation mode for this worker.
+    # No orders from the marketplace except specified will be fetched.
+    # This mode is required mostly for debugging.
+    #simulation:
+    #  orders: [42, 43]
 
 debug:
   port: 6060

--- a/optimus/config.go
+++ b/optimus/config.go
@@ -61,6 +61,10 @@ func LoadConfig(path string) (*Config, error) {
 	return cfg, nil
 }
 
+type simulationConfig struct {
+	Orders []*sonm.BigInt `yaml:"orders"`
+}
+
 type workerConfig struct {
 	PrivateKey     privateKey         `yaml:"ethereum" json:"-"`
 	Epoch          time.Duration      `yaml:"epoch"`
@@ -71,6 +75,7 @@ type workerConfig struct {
 	StaleThreshold time.Duration      `yaml:"stale_threshold" default:"5m"`
 	PreludeTimeout time.Duration      `yaml:"prelude_timeout" default:"30s"`
 	Optimization   OptimizationConfig `yaml:"optimization"`
+	Simulation     *simulationConfig  `yaml:"simulation"`
 }
 
 func (m *workerConfig) Validate() error {

--- a/optimus/engine.go
+++ b/optimus/engine.go
@@ -103,14 +103,33 @@ type workerEngine struct {
 	masterAddr       common.Address
 	blacklist        Blacklist
 	market           blockchain.MarketAPI
-	marketCache      *MarketCache
+	marketCache      MarketScanner
 	worker           WorkerManagementClientExt
 	benchmarkMapping benchmarks.Mapping
 
 	tagger *Tagger
 }
 
-func newWorkerEngine(cfg *workerConfig, addr, masterAddr common.Address, blacklist Blacklist, worker sonm.WorkerManagementClient, market blockchain.MarketAPI, marketCache *MarketCache, benchmarkMapping benchmarks.Mapping, tagger *Tagger, log *zap.SugaredLogger) (*workerEngine, error) {
+func newWorkerEngine(cfg *workerConfig, addr, masterAddr common.Address, blacklist Blacklist, worker sonm.WorkerManagementClient, market blockchain.MarketAPI, marketCache MarketScanner, benchmarkMapping benchmarks.Mapping, tagger *Tagger, log *zap.SugaredLogger) (*workerEngine, error) {
+	if cfg.DryRun {
+		log.Infof("activated dry-run mode for this worker")
+		worker = NewReadOnlyWorker(worker)
+		log = log.With(zap.String("mode", "dry-run"))
+	}
+
+	if cfg.Simulation != nil {
+		log.Infof("activated simulation mode for this worker")
+
+		var err error
+		marketCache, err = NewPredefinedMarketCache(cfg.Simulation.Orders, market)
+		if err != nil {
+			return nil, err
+		}
+
+		worker = NewReadOnlyWorker(worker)
+		log = log.With(zap.String("mode", "simulation"))
+	}
+
 	m := &workerEngine{
 		cfg: cfg,
 		log: log.With(zap.Stringer("addr", addr)),
@@ -265,10 +284,6 @@ func (m *workerEngine) execute(ctx context.Context) error {
 
 	if len(winners) == 0 {
 		return fmt.Errorf("no plans found")
-	}
-
-	if m.cfg.DryRun {
-		return fmt.Errorf("further worker management has been interrupted: dry-run mode is active")
 	}
 
 	victimIDs := make([]string, 0, len(victims))


### PR DESCRIPTION
This commit allows Optimus to be executed in simulation mode, feching only specified orders from the marketplace.

Also fixed a bug when Optimus removed ask-plans in dry-run mode.