### PR TITLE
refactor: print Deal's price per hour

### DIFF
--- a/cmd/cli/commands/printers.go
+++ b/cmd/cli/commands/printers.go
@@ -375,15 +375,15 @@ func printDealInfo(cmd *cobra.Command, info *ExtendedDealInfo, flags printerFlag
 		}
 		cmd.Printf("Status:       %s\r\n", deal.GetStatus())
 		if deal.IsSpot() {
-			// for active spot deal we can show only pricePerSecond
-			cmd.Printf("Price:        %s USD/sec\r\n", deal.GetPrice().ToPriceString())
+			// for active spot deal we can show only pricePerHour
+			cmd.Printf("Price:        %s USD/hour\r\n", deal.PricePerHour())
 			if isClosed {
 				// for closed deal we also can *calculate* total duration
 				cmd.Printf("Duration:     %s\r\n", dealDuration.String())
 			}
 		} else {
 			// for non-spot deal we can show duration, total price and pricePerSecond
-			cmd.Printf("Price:        %s USD (%s USD/sec)\r\n", deal.TotalPrice(), deal.GetPrice().ToPriceString())
+			cmd.Printf("Price:        %s USD (%s USD/hour)\r\n", deal.TotalPrice(), deal.PricePerHour())
 			cmd.Printf("Duration:     %s\r\n", dealDuration.String())
 		}
 

--- a/proto/marketplace.go
+++ b/proto/marketplace.go
@@ -133,6 +133,11 @@ func (m *Deal) TotalPrice() string {
 	return formatPriceString(m.GetPrice(), m.GetDuration())
 }
 
+func (m *Deal) PricePerHour() string {
+	secondsInHour := uint64(3600)
+	return formatPriceString(m.GetPrice(), secondsInHour)
+}
+
 func formatPriceString(price *BigInt, duration uint64) string {
 	d := big.NewInt(int64(duration))
 	p := big.NewInt(0).Mul(price.Unwrap(), d)


### PR DESCRIPTION
To be consistent with #1277 we should print all prices as USD per hour.