### PR TITLE
fix: gradually decrease blacklisting in Connor

### DIFF
--- a/connor/antifraud/blacklist_watcher.go
+++ b/connor/antifraud/blacklist_watcher.go
@@ -11,57 +11,80 @@ import (
 )
 
 const (
-	minStep = time.Hour
-	maxStep = time.Hour * 24 * 7
+	minStep            = time.Hour
+	maxStep            = time.Hour * 24 * 7
+	unBlacklistTimeout = 30 * time.Second
 )
 
 type blacklistWatcher struct {
-	address     common.Address
-	till        time.Time
-	currentStep time.Duration
-	client      sonm.BlacklistClient
-	log         *zap.Logger
+	log     *zap.Logger
+	address common.Address
+	client  sonm.BlacklistClient
+
+	nextPeriod    time.Duration
+	unBlacklistAt time.Time
+	lastSuccess   time.Time
 }
 
 func NewBlacklistWatcher(addr common.Address, cc *grpc.ClientConn, log *zap.Logger) *blacklistWatcher {
 	return &blacklistWatcher{
-		log:         log.Named("blacklist").With(zap.String("wallet", addr.Hex())),
-		address:     addr,
-		currentStep: minStep,
-		client:      sonm.NewBlacklistClient(cc),
+		log:        log.Named("blacklist").With(zap.String("wallet", addr.Hex())),
+		address:    addr,
+		nextPeriod: minStep,
+		client:     sonm.NewBlacklistClient(cc),
 	}
 }
 
+// Failure track task failure by quality.
+// Also doubles the next period of blacklisting.
 func (m *blacklistWatcher) Failure() {
-	m.till = time.Now().Add(m.currentStep)
-	m.currentStep *= 2
-	if m.currentStep > maxStep {
-		m.currentStep = maxStep
+	m.unBlacklistAt = time.Now().Add(m.nextPeriod)
+	m.lastSuccess = time.Time{}
+
+	m.nextPeriod *= 2
+	if m.nextPeriod > maxStep {
+		m.nextPeriod = maxStep
 	}
-	m.log.Debug("failure", zap.Duration("step", m.currentStep))
+
+	m.log.Debug("failure", zap.Duration("step", m.nextPeriod))
 }
 
+// Success tracks successful task check is passed,
+// and decreases the period of blacklisting by the amount of time
+// the task is successfully worked and gives profit.
 func (m *blacklistWatcher) Success() {
-	m.currentStep /= 2
-	if m.currentStep < minStep {
-		m.currentStep = minStep
+	if m.lastSuccess.IsZero() {
+		m.lastSuccess = time.Now()
+		return
 	}
-	m.log.Debug("success", zap.Duration("step", m.currentStep))
+
+	d := time.Now().Sub(m.lastSuccess)
+	m.nextPeriod -= d
+	if m.nextPeriod < minStep {
+		m.nextPeriod = minStep
+	}
+	m.lastSuccess = time.Now()
+	m.log.Debug("success", zap.Duration("step", m.nextPeriod))
 }
 
-func (m *blacklistWatcher) Blacklisted() bool {
-	return time.Now().Before(m.till)
+func (m *blacklistWatcher) isBlacklisted() bool {
+	return time.Now().Before(m.unBlacklistAt)
 }
 
 func (m *blacklistWatcher) TryUnblacklist(ctx context.Context) error {
-	if m.Blacklisted() {
+	if m.isBlacklisted() || m.unBlacklistAt.IsZero() {
 		return nil
 	}
 
-	m.till = time.Time{}
-
 	m.log.Info("removing from blacklist on market")
-	_, err := m.client.Remove(ctx, sonm.NewEthAddress(m.address))
-	return err
+	ctx, cancel := context.WithTimeout(ctx, unBlacklistTimeout)
+	defer cancel()
+	if _, err := m.client.Remove(ctx, sonm.NewEthAddress(m.address)); err != nil {
+		m.log.Warn("cannot remove address from blacklist", zap.Error(err))
+		return err
+	}
+
+	m.unBlacklistAt = time.Time{}
+	return nil
 
 }

--- a/connor/antifraud/config.go
+++ b/connor/antifraud/config.go
@@ -9,9 +9,10 @@ type ProcessorConfig struct {
 }
 
 type Config struct {
-	TaskQuality          float64         `yaml:"task_quality" required:"true"`
-	QualityCheckInterval time.Duration   `yaml:"quality_check_interval" default:"15s"`
-	ConnectionTimeout    time.Duration   `yaml:"connection_timeout" default:"30s"`
-	LogProcessorConfig   ProcessorConfig `yaml:"log_processor"`
-	PoolProcessorConfig  ProcessorConfig `yaml:"pool_processor"`
+	TaskQuality            float64         `yaml:"task_quality" required:"true"`
+	QualityCheckInterval   time.Duration   `yaml:"quality_check_interval" default:"15s"`
+	BlacklistCheckInterval time.Duration   `yaml:"blacklist_check_interval" default:"5m"`
+	ConnectionTimeout      time.Duration   `yaml:"connection_timeout" default:"30s"`
+	LogProcessorConfig     ProcessorConfig `yaml:"log_processor"`
+	PoolProcessorConfig    ProcessorConfig `yaml:"pool_processor"`
 }

--- a/etc/connor.yaml
+++ b/etc/connor.yaml
@@ -46,6 +46,7 @@ mining:
 antifraud:
   task_quality: 0.75
   quality_check_interval: 30s
+  blacklist_check_interval: 5m
   connection_timeout: 30s
 
   log_processor:


### PR DESCRIPTION
This commit fixes worker unblacklisting in the following way:
each tracked success decreasing the next possible blacklist step by the value of time in which task was correctly worked.
Each failure doubles a period of time in which a worker will be placed on the blacklist.

So if a worker is unblacklisted after the previous failure (1hr) and correctly work for 30 minutes, then, next blacklist time is 2hr minus 30 minutes.