### PR TITLE
fix: treat none benchmarks as min

### DIFF
--- a/optimus/devices.go
+++ b/optimus/devices.go
@@ -354,7 +354,14 @@ func (m *DeviceManager) consume(benchmarks []uint64, consumer Consumer) (interfa
 
 	filter := func(id int) (uint64, bool) {
 		if m.mapping.DeviceType(id) == consumer.DeviceType() {
-			if m.mapping.SplittingAlgorithm(id) == consumer.SplittingAlgorithm() {
+			switch m.mapping.SplittingAlgorithm(id) {
+			case sonm.SplittingAlgorithm_NONE, sonm.SplittingAlgorithm_MIN:
+				if deviceBenchmark, ok := consumer.DeviceBenchmark(id); ok {
+					if deviceBenchmark.Result < benchmarks[id] {
+						return deviceBenchmark.Result, true
+					}
+				}
+			case consumer.SplittingAlgorithm():
 				if deviceBenchmark, ok := consumer.DeviceBenchmark(id); ok {
 					return deviceBenchmark.Result, true
 				}

--- a/optimus/devices_test.go
+++ b/optimus/devices_test.go
@@ -748,3 +748,29 @@ func TestConsumeGPUWithZeroCountRequiredStillConsumes(t *testing.T) {
 
 	assert.Equal(t, 2, len(plan.Hashes))
 }
+
+func TestConsumeWithCPUCores(t *testing.T) {
+	devices := newEmptyDevicesReply()
+	devices.CPU.Device.Cores = 2
+	devices.CPU.Benchmarks = map[uint64]*sonm.Benchmark{
+		0: {ID: 0, Result: 1000},
+		1: {ID: 1, Result: 1526},
+		2: {ID: 2, Result: 2},
+	}
+	devices.RAM.Device.Total = 1000000000
+	devices.RAM.Benchmarks = map[uint64]*sonm.Benchmark{
+		3: {ID: 3, Result: 1000000000},
+	}
+
+	controller := gomock.NewController(t)
+	defer controller.Finish()
+
+	manager, err := newDeviceManager(devices, devices, newMappingMock(controller))
+	require.NoError(t, err)
+	require.NotNil(t, manager)
+
+	benchmark := [12]uint64{0, 0, 4}
+	cpuPlan, err := manager.consumeCPU(benchmark[:])
+	require.Error(t, err)
+	require.Nil(t, cpuPlan)
+}


### PR DESCRIPTION
This fixes a bug when Optimus created ask-plan for orders that specified CPU cores benchmark with value greater than on the system.