### PR TITLE
chore: profile certificates refactoring

### DIFF
--- a/insonmnia/dwh/processor_test.go
+++ b/insonmnia/dwh/processor_test.go
@@ -258,7 +258,7 @@ func testCertificateUpdated(p *L1Processor, certificate *pb.Certificate, commonI
 	// Now create a country certificate.
 	certificate.Attribute = CertificateCountry
 	certificate.Value = []byte("Country")
-	// Check that a  Profile entry is updated after CertificateCreated event.
+	// Check that a Profile entry is updated after CertificateCreated event.
 	if err := p.onCertificateCreated(commonID); err != nil {
 		return fmt.Errorf("onCertificateCreated failed: %v", err)
 	}
@@ -296,7 +296,7 @@ func testCertificateUpdated(p *L1Processor, certificate *pb.Certificate, commonI
 	}
 	if dwhOrder.CreatorIdentityLevel != 3 {
 		return fmt.Errorf("(CertificateCreated) Expected %d, got %d (Order.CreatorIdentityLevel)",
-			2, dwhOrder.CreatorIdentityLevel)
+			3, dwhOrder.CreatorIdentityLevel)
 	}
 	// Check that profile updates resulted in deals updates.
 	if deal, err := p.storage.GetDealByID(newSimpleConn(p.db), commonID); err != nil {

--- a/insonmnia/dwh/setup_test.go
+++ b/insonmnia/dwh/setup_test.go
@@ -429,7 +429,6 @@ func setupTestData(ctx context.Context, db *sql.DB, blockchain bch.API) (*sqlSto
 			"",
 			0,
 			0,
-			[]byte{},
 			0,
 			0,
 		).RunWith(db).Exec()
@@ -446,7 +445,6 @@ func setupTestData(ctx context.Context, db *sql.DB, blockchain bch.API) (*sqlSto
 		"",
 		0,
 		0,
-		byteCerts,
 		10,
 		10,
 	).RunWith(db).Exec()
@@ -460,7 +458,6 @@ func setupTestData(ctx context.Context, db *sql.DB, blockchain bch.API) (*sqlSto
 		"",
 		0,
 		0,
-		byteCerts,
 		10,
 		10,
 	).RunWith(db).Exec()


### PR DESCRIPTION
Currently serialised certificates are stored inside profile records (which duplicates data, because certificates also have their own table). This PR removes serialised certificates from profiles table; certificates are now collected and serialised on the fly when serving `GetProfiles()` requests.

Motivation:
* Current state of affairs is weird;
* It will get even more weird if we [implement](https://sonmio.atlassian.net/projects/DEV/issues/DEV-921?filter=myopenissues) `CertificateUpdated` event processing.