### PR TITLE
fix: support old samba servers

### DIFF
--- a/insonmnia/worker/volume/cifs.go
+++ b/insonmnia/worker/volume/cifs.go
@@ -65,7 +65,9 @@ func NewCIFSVolumeDriver(ctx context.Context, options ...Option) (VolumeDriver, 
 func (d *cifsVolumeDriver) CreateVolume(name string, options map[string]string) (Volume, error) {
 	d.logger.Info("creating volume", zap.String("name", name))
 
-	options[drivers.CifsOpts] = fmt.Sprintf("vers=\"%s\"", options["vers"])
+	if version, ok := options["vers"]; ok {
+		options[drivers.CifsOpts] = fmt.Sprintf("vers=\"%s\"", version)
+	}
 
 	request := &volume.CreateRequest{
 		Name:    name,


### PR DESCRIPTION
This fixes a bug, when specifying "vers" option for CIFS plugin resulted in error (seen in dmesg) that CIFS doesn't support "vers" option. This means that either too old cifs compatibility layer is installed or there is old smb server.
Now we just ignore unspecified "vers" option.