### PR TITLE
fix: use flags to control blacklisting

### DIFF
--- a/connor/antifraud/antifraud.go
+++ b/connor/antifraud/antifraud.go
@@ -31,7 +31,7 @@ type AntiFraud interface {
 	Run(ctx context.Context) error
 	DealOpened(deal *sonm.Deal) error
 	TrackTask(ctx context.Context, deal *sonm.Deal, taskID string) error
-	FinishDeal(ctx context.Context, deal *sonm.Deal) error
+	FinishDeal(ctx context.Context, deal *sonm.Deal, optsFlags flags) error
 }
 
 type dealMeta struct {
@@ -201,9 +201,12 @@ func (m *antiFraud) DealOpened(deal *sonm.Deal) error {
 	return nil
 }
 
-func (m *antiFraud) FinishDeal(ctx context.Context, deal *sonm.Deal) error {
-	whoToBlacklist := m.whoToBlacklist(deal)
-	return m.finishDealWithRetry(ctx, deal, whoToBlacklist)
+func (m *antiFraud) FinishDeal(ctx context.Context, deal *sonm.Deal, optsFlags flags) error {
+	who := sonm.BlacklistType_BLACKLIST_NOBODY
+	if !optsFlags.SkipBlacklist() {
+		who = m.whoToBlacklist(deal)
+	}
+	return m.finishDealWithRetry(ctx, deal, who)
 }
 
 func (m *antiFraud) finishDealWithRetry(ctx context.Context, deal *sonm.Deal, blacklistType sonm.BlacklistType) error {

--- a/connor/antifraud/flags.go
+++ b/connor/antifraud/flags.go
@@ -1,0 +1,12 @@
+package antifraud
+
+const (
+	AllChecks = iota
+	SkipBlacklisting
+)
+
+type flags int
+
+func (f flags) SkipBlacklist() bool {
+	return int(f)&SkipBlacklisting == 1
+}

--- a/connor/antifraud/flags_test.go
+++ b/connor/antifraud/flags_test.go
@@ -1,0 +1,15 @@
+package antifraud
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFlags(t *testing.T) {
+	var f flags = SkipBlacklisting
+	assert.True(t, f.SkipBlacklist())
+
+	f = AllChecks
+	assert.False(t, f.SkipBlacklist())
+}

--- a/connor/engine.go
+++ b/connor/engine.go
@@ -330,7 +330,7 @@ func (e *engine) processDeal(ctx context.Context, deal *sonm.Deal) {
 	defer log.Debug("stop deal processing")
 
 	e.antiFraud.DealOpened(deal)
-	defer e.antiFraud.FinishDeal(ctx, deal)
+	defer e.antiFraud.FinishDeal(ctx, deal, antifraud.AllChecks)
 
 	taskID, err := e.restoreTasks(ctx, log, deal.GetId())
 	if err != nil {
@@ -499,7 +499,7 @@ func (e *engine) checkDealStatus(ctx context.Context, log *zap.Logger, dealID *s
 				zap.String("actual_price", e.priceProvider.GetPrice().String()),
 				zap.String("current_price", deal.restorePrice().String()))
 
-			if err := e.antiFraud.FinishDeal(ctx, deal.Unwrap()); err != nil {
+			if err := e.antiFraud.FinishDeal(ctx, deal.Unwrap(), antifraud.SkipBlacklisting); err != nil {
 				log.Warn("failed to finish deal", zap.Error(err))
 			}
 


### PR DESCRIPTION
This commit adds extendable flags to control the antifraud behavior
in different cases. Also, it fixes a problem when we blacklisting a worker
which picks-up a deal which we decide to re-create due to price changes.