### PR TITLE
feat: relative price threshold in Optimus

### DIFF
--- a/etc/optimus.yaml
+++ b/etc/optimus.yaml
@@ -162,7 +162,12 @@ workers:
     # Zero value is forbidden, because it leads to spot deals being replaced
     # each epoch.
     # Required.
-    # Possible dimensions are USD/s, USD/h.
+    # Possible dimensions are USD/s, USD/h. May be specified either as absolute
+    # or relative. For example "0.02 USD/h" would mean that Optimus will
+    # reassembly all bids if a new combination gives more than "0.02 USD/h"
+    # profit that the existing one.
+    # If you want to activate relative threshold in percents, specify "%" after
+    # the value, for example "2.5%".
     price_threshold: 0.02 USD/h
     # When activated Optimus will not create ask plans, but continues doing
     # the rest calculations instead. Useful for debugging.

--- a/optimus/config.go
+++ b/optimus/config.go
@@ -71,7 +71,7 @@ type workerConfig struct {
 	OrderPolicy    OrderPolicy        `yaml:"order_policy"`
 	DryRun         bool               `yaml:"dry_run" default:"false"`
 	Identity       sonm.IdentityLevel `yaml:"identity" required:"true"`
-	PriceThreshold sonm.Price         `yaml:"price_threshold" required:"true"`
+	PriceThreshold priceThreshold     `yaml:"price_threshold" required:"true"`
 	StaleThreshold time.Duration      `yaml:"stale_threshold" default:"5m"`
 	PreludeTimeout time.Duration      `yaml:"prelude_timeout" default:"30s"`
 	Optimization   OptimizationConfig `yaml:"optimization"`
@@ -79,10 +79,6 @@ type workerConfig struct {
 }
 
 func (m *workerConfig) Validate() error {
-	if m.PriceThreshold.GetPerSecond().Unwrap().Sign() <= 0 {
-		return fmt.Errorf("price threshold must be a positive number")
-	}
-
 	if m.Optimization.Model.OptimizationMethodFactory == nil {
 		m.Optimization.Model = optimizationMethodFactory{OptimizationMethodFactory: &defaultOptimizationMethodFactory{}}
 	}

--- a/optimus/engine.go
+++ b/optimus/engine.go
@@ -3,7 +3,6 @@ package optimus
 import (
 	"context"
 	"fmt"
-	"math/big"
 	"sync"
 	"time"
 
@@ -318,9 +317,7 @@ func (m *workerEngine) execute(ctx context.Context) error {
 
 	// Compare total USD/s before and after. Remove some plans if the diff is
 	// more than the threshold.
-	priceThreshold := m.cfg.PriceThreshold.GetPerSecond()
-	priceDiff := new(big.Int).Sub(virtualKnapsack.Price().GetPerSecond().Unwrap(), input.Price().GetPerSecond().Unwrap())
-	swingTime := new(big.Int).Sub(priceDiff, priceThreshold.Unwrap()).Sign() >= 0
+	swingTime := m.cfg.PriceThreshold.Exceeds(virtualKnapsack.Price().GetPerSecond().Unwrap(), input.Price().GetPerSecond().Unwrap())
 
 	var winners []*sonm.AskPlan
 	var victims []*sonm.AskPlan

--- a/optimus/price.go
+++ b/optimus/price.go
@@ -101,5 +101,5 @@ func (m *priceThreshold) UnmarshalText(text []byte) error {
 		m.PriceThreshold = threshold
 	}
 
-	return errors.New("invalid price threshold format: must be either `N`, `N USD/s`, `N USD/h` or `N%`, where N - number")
+	return errors.New("invalid price threshold format: must be either `N USD/s`, `N USD/h` or `N%`, where N - number")
 }

--- a/optimus/price.go
+++ b/optimus/price.go
@@ -1,0 +1,105 @@
+package optimus
+
+import (
+	"errors"
+	"fmt"
+	"math/big"
+	"strconv"
+	"strings"
+
+	"github.com/sonm-io/core/proto"
+)
+
+type PriceThreshold interface {
+	// Exceeds returns "true" if the "price" exceeds "otherPrice" according to
+	// the implementation's threshold policy.
+	Exceeds(price, otherPrice *big.Int) bool
+}
+
+type RelativePriceThreshold struct {
+	*big.Int
+}
+
+func NewRelativePriceThreshold(threshold float64) (*RelativePriceThreshold, error) {
+	if threshold <= 0.0 {
+		return nil, errors.New("price threshold must be a positive number")
+	}
+
+	m := &RelativePriceThreshold{
+		Int: big.NewInt(int64(threshold * 1000)),
+	}
+
+	return m, nil
+}
+
+func ParseRelativePriceThreshold(threshold string) (*RelativePriceThreshold, error) {
+	// Drop whitespaces if any.
+	value := strings.Replace(threshold, " ", "", -1)
+	idx := strings.IndexByte(value, '%')
+	if idx == -1 {
+		return nil, errors.New("`%` sign is required")
+	}
+	if idx != len(value)-1 {
+		return nil, errors.New("trailing characters after `%` sign")
+	}
+	percent, err := strconv.ParseFloat(value[:idx], 64)
+	if err != nil {
+		return nil, errors.New("threshold must be a number")
+	}
+
+	return NewRelativePriceThreshold(percent)
+}
+
+func (m *RelativePriceThreshold) Exceeds(price, otherPrice *big.Int) bool {
+	v := new(big.Int).Sub(new(big.Int).Div(new(big.Int).Mul(price, big.NewInt(100000)), otherPrice), big.NewInt(100000))
+	return v.Cmp(m.Int) >= 0
+}
+
+type AbsolutePriceThreshold struct {
+	*sonm.Price
+}
+
+func NewAbsolutePriceThreshold(threshold *sonm.Price) (*AbsolutePriceThreshold, error) {
+	if threshold.GetPerSecond().Unwrap().Sign() <= 0 {
+		return nil, errors.New("price threshold must be a positive number")
+	}
+
+	m := &AbsolutePriceThreshold{
+		Price: threshold,
+	}
+
+	return m, nil
+}
+
+func ParseAbsolutePriceThreshold(threshold string) (*AbsolutePriceThreshold, error) {
+	v := &sonm.Price{}
+	if err := v.UnmarshalText([]byte(threshold)); err != nil {
+		return nil, fmt.Errorf("failed to parse absolute price threshold: %v", err)
+	}
+
+	return NewAbsolutePriceThreshold(v)
+}
+
+func (m *AbsolutePriceThreshold) Exceeds(price, otherPrice *big.Int) bool {
+	diff := new(big.Int).Sub(price, otherPrice)
+	return diff.Cmp(m.PerSecond.Unwrap()) >= 0
+}
+
+type priceThreshold struct {
+	PriceThreshold
+}
+
+func (m *priceThreshold) Exceeds(price, otherPrice *big.Int) bool {
+	return m.PriceThreshold.Exceeds(price, otherPrice)
+}
+
+func (m *priceThreshold) UnmarshalText(text []byte) error {
+	if threshold, err := ParseAbsolutePriceThreshold(string(text)); err == nil {
+		m.PriceThreshold = threshold
+	}
+	if threshold, err := ParseRelativePriceThreshold(string(text)); err == nil {
+		m.PriceThreshold = threshold
+	}
+
+	return errors.New("invalid price threshold format: must be either `N`, `N USD/s`, `N USD/h` or `N%`, where N - number")
+}

--- a/optimus/price_test.go
+++ b/optimus/price_test.go
@@ -1,0 +1,77 @@
+package optimus
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/sonm-io/core/proto"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRelativePriceThresholdExceeds(t *testing.T) {
+	v, err := NewRelativePriceThreshold(1.0)
+	require.NoError(t, err)
+	require.NotNil(t, v)
+
+	assert.True(t, v.Exceeds(big.NewInt(1010), big.NewInt(1000)))
+	assert.False(t, v.Exceeds(big.NewInt(1009), big.NewInt(1000)))
+}
+
+func TestParseRelativePriceThreshold(t *testing.T) {
+	v, err := ParseRelativePriceThreshold("2.0%")
+	require.NoError(t, err)
+	require.NotNil(t, v)
+
+	assert.True(t, v.Exceeds(big.NewInt(1020), big.NewInt(1000)))
+	assert.False(t, v.Exceeds(big.NewInt(1019), big.NewInt(1000)))
+}
+
+func TestErrParseRelativePriceThreshold(t *testing.T) {
+	tests := []struct {
+		name      string
+		threshold string
+	}{
+		{
+			name:      "missing percent",
+			threshold: "1.5",
+		},
+		{
+			name:      "trailing percent",
+			threshold: "1.5%1",
+		},
+		{
+			name:      "not number",
+			threshold: "1.5c%",
+		},
+		{
+			name:      "zero number",
+			threshold: "0.0%",
+		},
+		{
+			name:      "negative number",
+			threshold: "-1.5%",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			v, err := ParseRelativePriceThreshold(test.threshold)
+
+			require.Error(t, err)
+			require.Nil(t, v)
+		})
+	}
+}
+
+func TestAbsolutePriceThresholdExceeds(t *testing.T) {
+	p := &sonm.Price{}
+	err := p.LoadFromString("0.02 USD/h")
+	require.NoError(t, err)
+
+	v, err := NewAbsolutePriceThreshold(p)
+	require.NoError(t, err)
+	require.NotNil(t, v)
+
+	assert.True(t, v.Exceeds(big.NewInt(105555555555556), big.NewInt(100000000000000)))
+	assert.False(t, v.Exceeds(big.NewInt(105555555555554), big.NewInt(100000000000000)))
+}

--- a/optimus/price_test.go
+++ b/optimus/price_test.go
@@ -75,3 +75,48 @@ func TestAbsolutePriceThresholdExceeds(t *testing.T) {
 	assert.True(t, v.Exceeds(big.NewInt(105555555555556), big.NewInt(100000000000000)))
 	assert.False(t, v.Exceeds(big.NewInt(105555555555554), big.NewInt(100000000000000)))
 }
+
+func TestParseAbsolutePriceThreshold(t *testing.T) {
+	v, err := ParseAbsolutePriceThreshold("0.02 USD/h")
+	require.NoError(t, err)
+	require.NotNil(t, v)
+
+	assert.True(t, v.Exceeds(big.NewInt(105555555555556), big.NewInt(100000000000000)))
+	assert.False(t, v.Exceeds(big.NewInt(105555555555554), big.NewInt(100000000000000)))
+}
+
+func TestErrParseAbsolutePriceThreshold(t *testing.T) {
+	tests := []struct {
+		name      string
+		threshold string
+	}{
+		{
+			name:      "missing dimension",
+			threshold: "1.5",
+		},
+		{
+			name:      "invalid dimension",
+			threshold: "1.5 USD/day",
+		},
+		{
+			name:      "not number",
+			threshold: "1.5c USD/h",
+		},
+		{
+			name:      "zero number",
+			threshold: "0.0 USD/h",
+		},
+		{
+			name:      "negative number",
+			threshold: "-1.5 USD/h",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			v, err := ParseAbsolutePriceThreshold(test.threshold)
+
+			require.Error(t, err)
+			require.Nil(t, v)
+		})
+	}
+}

--- a/proto/insonmnia.go
+++ b/proto/insonmnia.go
@@ -157,13 +157,8 @@ func (m *Price) MarshalYAML() (interface{}, error) {
 	return r.Text('g', 10) + " USD/h", nil
 }
 
-func (m *Price) UnmarshalYAML(unmarshal func(interface{}) error) error {
-	var v string
-	if err := unmarshal(&v); err != nil {
-		return err
-	}
-
-	if err := m.LoadFromString(v); err != nil {
+func (m *Price) UnmarshalText(text []byte) error {
+	if err := m.LoadFromString(string(text)); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
This commit allows to specify either absolute or relative price threshold in Optimus.