### PR TITLE
refactor: extract common parts from LogProcessor

### DIFF
--- a/connor/antifraud/log_processor_test.go
+++ b/connor/antifraud/log_processor_test.go
@@ -1,0 +1,46 @@
+package antifraud
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+)
+
+func mklog(n int) string {
+	var s string
+	for i := 0; i < n; i++ {
+		s += fmt.Sprintf("ETH - Total Speed: %d.000 Mh/s, Total Shares: 127, Rejected: 0, Time: 00:02\n", i)
+	}
+	return s
+}
+
+func TestClaymoreLogParser(t *testing.T) {
+	rd := strings.NewReader(`ETH - Total Speed: 100.000 Mh/s, Total Shares: 127, Rejected: 0, Time: 00:02`)
+	p := &commonLogProcessor{log: zap.NewNop()}
+
+	claymoreLogParser(context.Background(), p, rd)
+	assert.Equal(t, float64(100e6), p.hashrate, "new value should be parsed and set")
+}
+
+func TestClaymoreLogParser_InvalidLine(t *testing.T) {
+	rd := strings.NewReader(`Oops! Claymore failed`)
+	p := &commonLogProcessor{log: zap.NewNop(), hashrate: 100500}
+
+	claymoreLogParser(context.Background(), p, rd)
+	assert.Equal(t, float64(100500), p.hashrate, "previous value should be kept")
+}
+
+func TestClaymoreLogParser_ContextCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	rd := strings.NewReader(mklog(1000))
+	p := &commonLogProcessor{log: zap.NewNop(), hashrate: 1.2345}
+	cancel()
+
+	claymoreLogParser(ctx, p, rd)
+	assert.Equal(t, float64(1.2345), p.hashrate, "new value should be parsed and set")
+}

--- a/proto/log_reader.go
+++ b/proto/log_reader.go
@@ -1,0 +1,31 @@
+package sonm
+
+import (
+	"bytes"
+	"io"
+)
+
+type logReader struct {
+	cli      TaskManagement_LogsClient
+	buf      bytes.Buffer
+	finished bool
+}
+
+func NewLogReader(client TaskManagement_LogsClient) io.Reader {
+	return &logReader{cli: client}
+}
+
+func (m *logReader) Read(p []byte) (n int, err error) {
+	if len(p) > m.buf.Len() && !m.finished {
+		chunk, err := m.cli.Recv()
+		if err == io.EOF {
+			m.finished = true
+		} else if err != nil {
+			return 0, err
+		}
+		if chunk != nil && chunk.Data != nil {
+			m.buf.Write(chunk.Data)
+		}
+	}
+	return m.buf.Read(p)
+}


### PR DESCRIPTION
Implementing `Processor` interface for another container forces to do a lot of shameless copy-paste.
Taking into consideration that log parsers one differs from another almost only by logline parsing code,
it will be better to extract reusable parts and be able to swap only the code that directly works with log lines.

As this commit aimed to deal with copy-paste, I'd also move log reader to the separated package.
I cannot put logReader into the `utils` neither `xgrpc`, what would look pretty logical.
But we'll face an issue with cycle imports in that case.