### PR TITLE
fix: show DWH status in worker status

### DIFF
--- a/insonmnia/worker/server.go
+++ b/insonmnia/worker/server.go
@@ -427,6 +427,7 @@ func (m *Worker) Status(ctx context.Context, _ *pb.Empty) (*pb.StatusReply, erro
 		EthAddr:          m.ethAddr().Hex(),
 		TaskCount:        uint32(len(m.CollectTasksStatuses(pb.TaskStatusReply_RUNNING))),
 		RendezvousStatus: rendezvousStatus,
+		DWHStatus:        m.cfg.Endpoint,
 	}
 
 	return reply, nil


### PR DESCRIPTION
Show DWH endpoint in `worker.GetStatus()` reply.