### PR TITLE
aux: allow to pass output to the logger

### DIFF
--- a/cmd/connor/main.go
+++ b/cmd/connor/main.go
@@ -28,7 +28,11 @@ func run() error {
 		return fmt.Errorf("failed to load config file: %s", err)
 	}
 
-	log := logging.BuildLogger(cfg.Log.LogLevel())
+	log, err := logging.BuildLogger(cfg.Log)
+	if err != nil {
+		return fmt.Errorf("failed to build logger instance: %s", err)
+	}
+
 	ctx := ctxlog.WithLogger(context.Background(), log)
 
 	wg, ctx := errgroup.WithContext(ctx)

--- a/cmd/dwh/main.go
+++ b/cmd/dwh/main.go
@@ -32,7 +32,11 @@ func run() error {
 		return fmt.Errorf("failed to load config file: %s", err)
 	}
 
-	logger := logging.BuildLogger(*cfg.Logging.Level)
+	logger, err := logging.BuildLogger(cfg.Logging)
+	if err != nil {
+		return fmt.Errorf("failed to build logger instance: %s", err)
+	}
+
 	ctx := log.WithLogger(context.Background(), logger)
 
 	log.G(ctx).Info("starting with config", zap.Any("config", cfg))

--- a/cmd/node/main.go
+++ b/cmd/node/main.go
@@ -28,7 +28,11 @@ func run() error {
 		return fmt.Errorf("failed to load config file: %s", err)
 	}
 
-	log := logging.BuildLogger(cfg.Log.LogLevel())
+	log, err := logging.BuildLogger(cfg.Log)
+	if err != nil {
+		return fmt.Errorf("failed to build logger instance: %s", err)
+	}
+
 	ctx := ctxlog.WithLogger(context.Background(), log)
 
 	wg, ctx := errgroup.WithContext(ctx)

--- a/cmd/oracle/main.go
+++ b/cmd/oracle/main.go
@@ -26,7 +26,11 @@ func run() error {
 		return fmt.Errorf("failed to load config file: %s", err)
 	}
 
-	logger := logging.BuildLogger(cfg.Log.LogLevel())
+	logger, err := logging.BuildLogger(cfg.Log)
+	if err != nil {
+		return fmt.Errorf("failed to build logger insance: %s", err)
+	}
+
 	ctx := log.WithLogger(context.Background(), logger)
 
 	key, err := cfg.Eth.LoadKey()

--- a/cmd/pandora/common.go
+++ b/cmd/pandora/common.go
@@ -65,5 +65,8 @@ func NewLogger(cfg LoggingConfig) (*zap.Logger, error) {
 		return nil, err
 	}
 
-	return logging.BuildLogger(*level), nil
+	return logging.BuildLogger(logging.Config{
+		Level:  level,
+		Output: logging.StdoutLogOutput,
+	})
 }

--- a/cmd/relay/main.go
+++ b/cmd/relay/main.go
@@ -23,7 +23,12 @@ func start() error {
 		return fmt.Errorf("failed to load config file: %s", err)
 	}
 
-	ctx := log.WithLogger(context.Background(), logging.BuildLogger(cfg.Logging.LogLevel()))
+	logger, err := logging.BuildLogger(cfg.Logging)
+	if err != nil {
+		return fmt.Errorf("failed to build logger instance: %s", err)
+
+	}
+	ctx := log.WithLogger(context.Background(), logger)
 
 	options := []relay.Option{
 		relay.WithLogger(log.G(ctx)),

--- a/cmd/rv/main.go
+++ b/cmd/rv/main.go
@@ -24,7 +24,12 @@ func start() error {
 		return fmt.Errorf("failed to load config file: %s", err)
 	}
 
-	ctx := log.WithLogger(context.Background(), logging.BuildLogger(cfg.Logging.LogLevel()))
+	logger, err := logging.BuildLogger(cfg.Logging)
+	if err != nil {
+		return fmt.Errorf("failed to build logger instance: %s", err)
+	}
+
+	ctx := log.WithLogger(context.Background(), logger)
 
 	certRotator, TLSConfig, err := util.NewHitlessCertRotator(ctx, cfg.PrivateKey)
 	if err != nil {

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -35,7 +35,10 @@ func run() error {
 		return fmt.Errorf("failed to load config file: %s", err)
 	}
 
-	logger := logging.BuildLogger(cfg.Logging.LogLevel())
+	logger, err := logging.BuildLogger(cfg.Logging)
+	if err != nil {
+		return fmt.Errorf("failed to build logger instance: %s", err)
+	}
 	ctx = log.WithLogger(ctx, logger)
 
 	storage, err := state.NewState(ctx, &cfg.Storage)

--- a/insonmnia/dwh/config.go
+++ b/insonmnia/dwh/config.go
@@ -10,7 +10,7 @@ import (
 )
 
 type DWHConfig struct {
-	Logging           LoggingConfig      `yaml:"logging"`
+	Logging           logging.Config     `yaml:"logging"`
 	GRPCListenAddr    string             `yaml:"grpc_address" default:"127.0.0.1:15021"`
 	HTTPListenAddr    string             `yaml:"http_address" default:"127.0.0.1:15022"`
 	Eth               accounts.EthConfig `yaml:"ethereum" required:"true"`
@@ -23,10 +23,6 @@ type DWHConfig struct {
 
 type storageConfig struct {
 	Endpoint string `required:"true" yaml:"endpoint"`
-}
-
-type LoggingConfig struct {
-	Level *logging.Level `required:"true" default:"warn"`
 }
 
 type YAMLConfig struct {

--- a/insonmnia/logging/config.go
+++ b/insonmnia/logging/config.go
@@ -1,10 +1,29 @@
 package logging
 
+import "os"
+
+const (
+	StdoutLogOutput = "stdout"
+	StderrLogOutput = "stderr"
+)
+
 // Config represents a logging config.
 type Config struct {
-	Level *Level `yaml:"level" required:"true" default:"info"`
+	Level  *Level `yaml:"level" required:"true" default:"info"`
+	Output string `yaml:"output" default:"stdout"`
 }
 
 func (m *Config) LogLevel() Level {
 	return *m.Level
+}
+
+func fdFromString(out string) *os.File {
+	switch out {
+	case StderrLogOutput:
+		return os.Stderr
+	case StdoutLogOutput:
+		return os.Stdout
+	default:
+		return nil
+	}
 }

--- a/insonmnia/worker/acl_test.go
+++ b/insonmnia/worker/acl_test.go
@@ -8,21 +8,19 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	log "github.com/noxiouz/zapctx/ctxlog"
 	"github.com/sonm-io/core/insonmnia/auth"
-	"github.com/sonm-io/core/insonmnia/logging"
 	"github.com/sonm-io/core/insonmnia/structs"
 	"github.com/sonm-io/core/proto"
 	pb "github.com/sonm-io/core/proto"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/peer"
 )
 
 func testCtx() context.Context {
-	logger := logging.BuildLogger(*logging.NewLevel(zapcore.DebugLevel))
-	return log.WithLogger(context.Background(), logger)
+	return log.WithLogger(context.Background(), zap.NewNop())
 }
 
 type testDealInfoSupplier struct {


### PR DESCRIPTION
This commit extends logger config with the desired output.
Can be `stdout` (as it previously works), or it can be a path
to log file. Logs are written to the stdout will be colorized.