### PR TITLE
fix: proper task start in Connor

### DIFF
--- a/connor/config.go
+++ b/connor/config.go
@@ -64,6 +64,7 @@ type engineConfig struct {
 	ConnectionTimeout   time.Duration     `yaml:"connection_timeout" default:"30s"`
 	OrderWatchInterval  time.Duration     `yaml:"order_watch_interval" default:"10s"`
 	TaskStartInterval   time.Duration     `yaml:"task_start_interval" default:"15s"`
+	TaskStartTimeout    time.Duration     `yaml:"task_start_timeout" default:"3m"`
 	TaskTrackInterval   time.Duration     `yaml:"task_track_interval" default:"15s"`
 	TaskRestoreInterval time.Duration     `yaml:"task_restore_interval" default:"10s"`
 	ContainerEnv        map[string]string `yaml:"container_env"`

--- a/etc/connor.yaml
+++ b/etc/connor.yaml
@@ -69,6 +69,10 @@ engine:
   # interval between task starting retries
   # default: 15s
   task_start_interval: 15s
+  # connection timeout for task start method,
+  # increase this value if image size is large
+  # default: 3m
+  task_start_timeout: 3m
   # interval between task status tracking calls
   # default: 15s
   task_track_interval: 15s


### PR DESCRIPTION
This commit increases task starting timeout and makes it configurable.
Also, on `StartTask` retrying we'll check that previous attempt doesn't
really start a task.