### PR TITLE
fix: no peer found error in Relay

### DIFF
--- a/insonmnia/npp/relay/monitor.go
+++ b/insonmnia/npp/relay/monitor.go
@@ -20,13 +20,13 @@ type monitor struct {
 	listener    net.Listener
 
 	cluster     *memberlist.Memberlist
-	meetingRoom *meetingRoom
+	meetingRoom *meetingHall
 
 	metrics *metrics
 	log     *zap.Logger
 }
 
-func newMonitor(cfg MonitorConfig, cluster *memberlist.Memberlist, meetingRoom *meetingRoom, metrics *metrics, log *zap.Logger) (*monitor, error) {
+func newMonitor(cfg MonitorConfig, cluster *memberlist.Memberlist, meetingRoom *meetingHall, metrics *metrics, log *zap.Logger) (*monitor, error) {
 	certificate, TLSConfig, err := util.NewHitlessCertRotator(context.Background(), cfg.PrivateKey)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Such error appeared when a server was under pressure. It worked the following way: a server announced itself and waited for a connection. When a client came it consumes that connection, causing `noPeerFound` errors for other clients that tried to resolve a server at the same time.
This commit fixes that behavior by putting clients into a short-waiting queue. In the future, we can improve this by checking whether a server was ever seen by Relay.