### PR TITLE
fix: proper deal closing when price is changed

### DIFF
--- a/connor/engine.go
+++ b/connor/engine.go
@@ -519,6 +519,13 @@ func (e *engine) checkDealStatus(ctx context.Context, log *zap.Logger, dealID *s
 		deal := e.dealFactory.FromDeal(dealStatus.GetDeal())
 		if deal.isReplaceable(e.priceProvider.GetPrice(), e.cfg.Market.PriceControl.DealCancelThreshold) {
 			log := log.Named("price-deviation")
+			if len(e.orderCancelChan) > 0 {
+				log.Warn("shouldn't finish deal, orders replacing in progress",
+					zap.Int("cancel", len(e.orderCancelChan)),
+					zap.Int("create", len(e.ordersCreateChan)))
+				return true, nil
+			}
+
 			log.Info("too much price deviation detected: closing deal",
 				zap.Uint64("benchmark", deal.getBenchmarkValue()),
 				zap.String("actual_price", e.priceProvider.GetPrice().String()),


### PR DESCRIPTION
such problem occurs in the following conditions: Connor detects price deviation and starts replacing orders, also it starts to close non-profitalbe deals. When the deal is closed, a worker on another side can pick the order that we schedule for cancellation. This order is turned into a deal that immediately will be closed because of the low price. So this shitfall will perform until all of the orders isn't replaced. This commit fixes that behavior: now Connor checks that the cancel chan is empty before really closing an active deal.