### PR TITLE
feat: remove extra orders in Connor

### DIFF
--- a/connor/engine.go
+++ b/connor/engine.go
@@ -741,6 +741,7 @@ func (e *engine) restoreMarketState(ctx context.Context) error {
 	e.log.Debug("restoring existing entities",
 		zap.Int("orders_restore", len(set.toRestore)),
 		zap.Int("orders_create", len(set.toCreate)),
+		zap.Int("orders_cancel", len(set.toCancel)),
 		zap.Int("deals_restore", len(existingDeals.GetDeal())))
 
 	for _, deal := range existingDeals.GetDeal() {
@@ -753,6 +754,10 @@ func (e *engine) restoreMarketState(ctx context.Context) error {
 
 	for _, ord := range set.toRestore {
 		e.RestoreOrder(ord)
+	}
+
+	for _, ord := range set.toCancel {
+		e.CancelOrder(ord)
 	}
 
 	return nil

--- a/connor/x_test.go
+++ b/connor/x_test.go
@@ -7,23 +7,65 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func makeTestCordersSet(f CorderFactoriy, from, to uint64) []*Corder {
+	set := make([]*Corder, 0)
+	for i := from; i <= to; i += 100 {
+		set = append(set, f.FromParams(big.NewInt(1), i, newBenchmarksWithGPUMem(0)))
+	}
+	return set
+}
+
 func TestDivideOrders(t *testing.T) {
 	f := NewCorderFactory("ETH", 0)
 
-	ex1 := f.FromParams(big.NewInt(1), 100, newBenchmarksWithGPUMem(0))
-	ex2 := f.FromParams(big.NewInt(2), 200, newBenchmarksWithGPUMem(0))
-	ex3 := f.FromParams(big.NewInt(3), 300, newBenchmarksWithGPUMem(0))
-
-	req0 := f.FromParams(big.NewInt(1), 50, newBenchmarksWithGPUMem(0))
-	req1 := f.FromParams(big.NewInt(1), 100, newBenchmarksWithGPUMem(0))
-	req2 := f.FromParams(big.NewInt(2), 200, newBenchmarksWithGPUMem(0))
-	req3 := f.FromParams(big.NewInt(3), 300, newBenchmarksWithGPUMem(0))
-	req4 := f.FromParams(big.NewInt(4), 400, newBenchmarksWithGPUMem(0))
-
-	existing := []*Corder{ex1, ex2, ex3}
-	required := []*Corder{req0, req1, req2, req3, req4}
+	existing := makeTestCordersSet(f, 200, 400)
+	required := makeTestCordersSet(f, 100, 500)
 
 	set := divideOrdersSets(existing, required)
 	assert.Len(t, set.toRestore, 3)
 	assert.Len(t, set.toCreate, 2)
+	assert.Len(t, set.toCancel, 0)
+}
+
+func TestDivideOrdersWithExtra(t *testing.T) {
+	f := NewCorderFactory("ETH", 0)
+
+	tests := []struct {
+		existing  [2]uint64
+		required  [2]uint64
+		toRestore int
+		toCreate  int
+		toCancel  int
+	}{
+		{
+			[2]uint64{200, 1000},
+			[2]uint64{500, 700},
+			3, 0, 6,
+		},
+		{
+			[2]uint64{500, 700},
+			[2]uint64{200, 1000},
+			3, 6, 0,
+		},
+		{
+			[2]uint64{200, 700},
+			[2]uint64{500, 1000},
+			3, 3, 3,
+		},
+		{
+			[2]uint64{500, 1000},
+			[2]uint64{100, 500},
+			1, 4, 5,
+		},
+	}
+
+	for _, tt := range tests {
+		existing := makeTestCordersSet(f, tt.existing[0], tt.existing[1])
+		required := makeTestCordersSet(f, tt.required[0], tt.required[1])
+
+		set := divideOrdersSets(existing, required)
+		assert.Len(t, set.toRestore, tt.toRestore)
+		assert.Len(t, set.toCreate, tt.toCreate)
+		assert.Len(t, set.toCancel, tt.toCancel)
+	}
 }


### PR DESCRIPTION
This commit brings code that looks at the desired and existing order sets
which present on the Market and decide what orders should be removed.
Extra orders can appear when configured hashrate range was changed (by decrease).