### PR TITLE
feat: detect duplicate orders in Optimus

### DIFF
--- a/optimus/engine.go
+++ b/optimus/engine.go
@@ -325,7 +325,7 @@ func (m *workerEngine) execute(ctx context.Context) error {
 	if swingTime {
 		m.log.Info("using replacement strategy")
 
-		create, remove, ignore := m.splitPlans(input.Plans, virtualKnapsack.Plans())
+		create, remove, ignore := splitPlans(input.Plans, virtualKnapsack.Plans())
 		m.log.Infow("ignoring already existing plans", zap.Any("plans", ignore))
 		m.log.Infow("removing plans", zap.Any("plans", remove))
 		m.log.Infow("creating plans", zap.Any("plans", create))
@@ -370,7 +370,7 @@ func (m *workerEngine) execute(ctx context.Context) error {
 	return nil
 }
 
-func (m *workerEngine) splitPlans(plans map[string]*sonm.AskPlan, candidates []*sonm.AskPlan) (create, remove, ignore []*sonm.AskPlan) {
+func splitPlans(plans map[string]*sonm.AskPlan, candidates []*sonm.AskPlan) (create, remove, ignore []*sonm.AskPlan) {
 	orders := map[string]struct{}{}
 	for _, plan := range plans {
 		orders[plan.GetOrderID().Unwrap().String()] = struct{}{}
@@ -396,15 +396,24 @@ func (m *workerEngine) splitPlans(plans map[string]*sonm.AskPlan, candidates []*
 	}
 
 	create, remove = removeDuplicates(create, remove)
+
 	return create, remove, ignore
 }
 
-func planEq(a, b *sonm.AskPlan) bool {
-	return a.GetResources().Eq(b.GetResources()) &&
-		a.GetPrice().GetPerSecond().Cmp(b.GetPrice().GetPerSecond()) == 0 &&
-		a.GetDuration().Unwrap() == b.GetDuration().Unwrap()
-}
-
+// Here we find orders in the creation list that are equal with orders in
+// the removal list. This is required to not to replace existing orders
+// with the same ones somehow appeared in the marketplace.
+//
+// The algorithm works as the follows:
+// Given: [c0, c1, c2, c3, c4] [r0, r1, r2, r3]
+// Where: c1==r3, c3==r2, c4==r2.
+// Then:
+//													[c0, c1, c2, c3, c4] [r0, r1, r2, r3]
+//			c0!=r0, c0!=r1, c0!=r2, c0!=r3 ->		[c0, c1, c2, c3, c4] [r0, r1, r2, r3]
+//		  	c1!=r0, c1!=r1, c1!=r2, c1==r3(!) ->	[c0, c2, c3, c4]     [r0, r1, r2]
+//			c2!=r0, c2!=r1, c2!=r2 ->				[c0, c2, c3, c4]     [r0, r1, r2]
+//			c3!=r0, c3!=r1, c3==r2(!) ->			[c0, c2, c4]         [r0, r1]
+//			c4!=r0, c4!=r1 ->						[c0, c2, c4]         [r0, r1]
 func removeDuplicates(create, remove []*sonm.AskPlan) ([]*sonm.AskPlan, []*sonm.AskPlan) {
 	filteredCreate := make([]*sonm.AskPlan, 0, len(create))
 	for _, planCreate := range create {
@@ -430,7 +439,7 @@ func removeDuplicates(create, remove []*sonm.AskPlan) ([]*sonm.AskPlan, []*sonm.
 	return create, remove
 }
 
-func removeDuplicates2(create, remove []*sonm.AskPlan) ([]*sonm.AskPlan, []*sonm.AskPlan) {
+func removeDuplicatesLinear(create, remove []*sonm.AskPlan) ([]*sonm.AskPlan, []*sonm.AskPlan) {
 	sort.Slice(create, func(i, j int) bool {
 		return create[i].Price.PerSecond.Cmp(create[j].Price.PerSecond) < 0
 	})
@@ -445,7 +454,7 @@ func removeDuplicates2(create, remove []*sonm.AskPlan) ([]*sonm.AskPlan, []*sonm
 		i, j int
 	}
 
-	eq := []Eq{}
+	var eq []Eq
 
 	for {
 		if i >= len(create) {
@@ -842,4 +851,10 @@ func (m *Knapsack) PPSf64() float64 {
 
 func (m *Knapsack) Plans() []*sonm.AskPlan {
 	return m.plans
+}
+
+func planEq(a, b *sonm.AskPlan) bool {
+	return a.GetResources().Eq(b.GetResources()) &&
+		a.GetPrice().GetPerSecond().Cmp(b.GetPrice().GetPerSecond()) == 0 &&
+		a.GetDuration().Unwrap() == b.GetDuration().Unwrap()
 }

--- a/optimus/engine_test.go
+++ b/optimus/engine_test.go
@@ -239,6 +239,6 @@ func BenchmarkRemoveDuplicatesKurilshchika(b *testing.B) {
 	create, remove := genBench()
 
 	for i := 0; i < b.N; i++ {
-		removeDuplicates2(create, remove)
+		removeDuplicatesLinear(create, remove)
 	}
 }

--- a/optimus/engine_test.go
+++ b/optimus/engine_test.go
@@ -1,0 +1,244 @@
+package optimus
+
+import (
+	"testing"
+
+	"github.com/sonm-io/core/proto"
+	"github.com/stretchr/testify/require"
+)
+
+func genPrice(price int64) *sonm.Price {
+	return &sonm.Price{
+		PerSecond: sonm.NewBigIntFromInt(price),
+	}
+}
+
+func genAsk(price int64) *sonm.AskPlan {
+	return &sonm.AskPlan{
+		Price: genPrice(price),
+	}
+}
+
+func TestRemoveDuplicates(t *testing.T) {
+	// simple case
+	create := []*sonm.AskPlan{
+		genAsk(1),
+		genAsk(2),
+		genAsk(3),
+	}
+	remove := []*sonm.AskPlan{
+		genAsk(2),
+	}
+
+	create, remove = removeDuplicates(create, remove)
+	require.Equal(t, 2, len(create))
+	require.Equal(t, 0, len(remove))
+	require.Equal(t, int64(1), create[0].Price.PerSecond.Unwrap().Int64())
+	require.Equal(t, int64(3), create[1].Price.PerSecond.Unwrap().Int64())
+
+	// 2
+	create = []*sonm.AskPlan{
+		genAsk(1),
+		genAsk(2),
+		genAsk(3),
+	}
+	remove = []*sonm.AskPlan{
+		genAsk(3),
+		genAsk(4),
+	}
+
+	create, remove = removeDuplicates(create, remove)
+	require.Equal(t, 2, len(create))
+	require.Equal(t, 1, len(remove))
+	require.Equal(t, int64(1), create[0].Price.PerSecond.Unwrap().Int64())
+	require.Equal(t, int64(2), create[1].Price.PerSecond.Unwrap().Int64())
+	require.Equal(t, int64(4), remove[0].Price.PerSecond.Unwrap().Int64())
+
+	// 3
+	create = []*sonm.AskPlan{
+		genAsk(1),
+		genAsk(1),
+		genAsk(2),
+	}
+	remove = []*sonm.AskPlan{
+		genAsk(1),
+		genAsk(4),
+		genAsk(4),
+	}
+
+	create, remove = removeDuplicates(create, remove)
+	require.Equal(t, 2, len(create))
+	require.Equal(t, 2, len(remove))
+	require.Equal(t, int64(1), create[0].Price.PerSecond.Unwrap().Int64())
+	require.Equal(t, int64(2), create[1].Price.PerSecond.Unwrap().Int64())
+	require.Equal(t, int64(4), remove[0].Price.PerSecond.Unwrap().Int64())
+	require.Equal(t, int64(4), remove[1].Price.PerSecond.Unwrap().Int64())
+
+	//4
+	create = []*sonm.AskPlan{
+		genAsk(1),
+		genAsk(1),
+		genAsk(1),
+	}
+	remove = []*sonm.AskPlan{
+		genAsk(1),
+		genAsk(1),
+		genAsk(1),
+	}
+
+	create, remove = removeDuplicates(create, remove)
+	require.Equal(t, 0, len(create))
+	require.Equal(t, 0, len(remove))
+
+	// 5
+
+	create = []*sonm.AskPlan{
+		genAsk(1),
+		genAsk(1),
+		genAsk(1),
+	}
+	remove = []*sonm.AskPlan{
+		genAsk(4),
+		genAsk(1),
+		genAsk(1),
+		genAsk(1),
+	}
+
+	create, remove = removeDuplicates(create, remove)
+	require.Equal(t, 0, len(create))
+	require.Equal(t, 1, len(remove))
+	require.Equal(t, int64(4), remove[0].Price.PerSecond.Unwrap().Int64())
+
+	//6
+
+	create = []*sonm.AskPlan{
+		genAsk(1),
+		genAsk(1),
+		genAsk(1),
+	}
+	remove = []*sonm.AskPlan{
+		genAsk(1),
+		genAsk(1),
+	}
+
+	create, remove = removeDuplicates(create, remove)
+	require.Equal(t, 1, len(create))
+	require.Equal(t, 0, len(remove))
+	require.Equal(t, int64(1), create[0].Price.PerSecond.Unwrap().Int64())
+
+	//7
+
+	create = []*sonm.AskPlan{
+		genAsk(1),
+		genAsk(1),
+		genAsk(1),
+		genAsk(2),
+		genAsk(2),
+	}
+	remove = []*sonm.AskPlan{
+		genAsk(2),
+		genAsk(1),
+		genAsk(1),
+	}
+
+	create, remove = removeDuplicates(create, remove)
+	require.Equal(t, 2, len(create))
+	require.Equal(t, 0, len(remove))
+	require.Equal(t, int64(1), create[0].Price.PerSecond.Unwrap().Int64())
+	require.Equal(t, int64(2), create[1].Price.PerSecond.Unwrap().Int64())
+
+	//8
+
+	create = []*sonm.AskPlan{
+		genAsk(2),
+		genAsk(3),
+		genAsk(5),
+		genAsk(4),
+		genAsk(1),
+		genAsk(4),
+	}
+	remove = []*sonm.AskPlan{
+		genAsk(4),
+		genAsk(2),
+		genAsk(2),
+		genAsk(3),
+		genAsk(3),
+	}
+
+	create, remove = removeDuplicates(create, remove)
+	require.Equal(t, 3, len(create))
+	require.Equal(t, 2, len(remove))
+	require.Equal(t, int64(1), create[0].Price.PerSecond.Unwrap().Int64())
+	require.Equal(t, int64(4), create[1].Price.PerSecond.Unwrap().Int64())
+	require.Equal(t, int64(5), create[2].Price.PerSecond.Unwrap().Int64())
+	require.Equal(t, int64(2), remove[0].Price.PerSecond.Unwrap().Int64())
+	require.Equal(t, int64(3), remove[1].Price.PerSecond.Unwrap().Int64())
+}
+
+func genBench() ([]*sonm.AskPlan, []*sonm.AskPlan) {
+	create := []*sonm.AskPlan{
+		genAsk(2),
+		genAsk(3),
+		genAsk(5),
+		genAsk(4),
+		genAsk(1),
+		genAsk(4),
+		genAsk(2),
+		genAsk(3),
+		genAsk(5),
+		genAsk(4),
+		genAsk(1),
+		genAsk(4),
+		genAsk(2),
+		genAsk(3),
+		genAsk(5),
+		genAsk(4),
+		genAsk(1),
+		genAsk(4),
+		genAsk(2),
+		genAsk(3),
+		genAsk(5),
+		genAsk(4),
+		genAsk(1),
+		genAsk(4),
+	}
+	remove := []*sonm.AskPlan{
+		genAsk(4),
+		genAsk(2),
+		genAsk(2),
+		genAsk(3),
+		genAsk(3),
+		genAsk(4),
+		genAsk(2),
+		genAsk(2),
+		genAsk(3),
+		genAsk(3),
+		genAsk(4),
+		genAsk(2),
+		genAsk(2),
+		genAsk(3),
+		genAsk(3),
+		genAsk(4),
+		genAsk(2),
+		genAsk(2),
+		genAsk(3),
+		genAsk(3),
+	}
+	return create, remove
+}
+
+func BenchmarkRemoveDuplicatesVeipera(b *testing.B) {
+	create, remove := genBench()
+
+	for i := 0; i < b.N; i++ {
+		removeDuplicates(create, remove)
+	}
+}
+
+func BenchmarkRemoveDuplicatesKurilshchika(b *testing.B) {
+	create, remove := genBench()
+
+	for i := 0; i < b.N; i++ {
+		removeDuplicates2(create, remove)
+	}
+}

--- a/proto/ask_plan.go
+++ b/proto/ask_plan.go
@@ -180,6 +180,13 @@ func (m *AskPlanResources) CPUQuota() int64 {
 	return int64(defaultCPUPeriod) * int64(m.GetCPU().GetCorePercents()) / 100
 }
 
+func (m *AskPlanResources) Eq(resources *AskPlanResources) bool {
+	errF := m.CheckContains(resources)
+	errR := resources.CheckContains(m)
+
+	return errF == nil && errR == nil
+}
+
 func (m *AskPlanResources) CheckContains(resources *AskPlanResources) error {
 	if m.GetCPU().GetCorePercents() < resources.GetCPU().GetCorePercents() {
 		return fmt.Errorf("not enough CPU, required %d core percents, available %d core percents",
@@ -353,10 +360,4 @@ func SumPrice(plans []*AskPlan) *Price {
 	}
 
 	return &Price{PerSecond: NewBigInt(sum)}
-}
-
-func (m *AskPlanResources) Eq(resources *AskPlanResources) bool {
-	errF := m.CheckContains(resources)
-	errR := resources.CheckContains(m)
-	return errF == nil && errR == nil
 }

--- a/proto/ask_plan.go
+++ b/proto/ask_plan.go
@@ -354,3 +354,9 @@ func SumPrice(plans []*AskPlan) *Price {
 
 	return &Price{PerSecond: NewBigInt(sum)}
 }
+
+func (m *AskPlanResources) Eq(resources *AskPlanResources) bool {
+	errF := m.CheckContains(resources)
+	errR := resources.CheckContains(m)
+	return errF == nil && errR == nil
+}


### PR DESCRIPTION
During learning the following situation may appear: there are a set of orders that are planned to replace existing ones, but some of them are technically equal, i.e. have the same resources, price, and duration. Current Optimus just replaces ask-plans, which results in deal cancellation, which is not good.
This commit teaches Optimus to detect duplicate orders when it's time to replace ask-plans with more profitable ones and not to touch them if any.