### PR TITLE
chore: worker's code cleanup

### DIFF
--- a/insonmnia/worker/overseer.go
+++ b/insonmnia/worker/overseer.go
@@ -154,9 +154,9 @@ type ContainerMetrics struct {
 }
 
 func (m *ContainerMetrics) Marshal() *pb.ResourceUsage {
-	network := make(map[string]*pb.NetworkUsage)
+	networkUsage := make(map[string]*pb.NetworkUsage)
 	for i, n := range m.net {
-		network[i] = &pb.NetworkUsage{
+		networkUsage[i] = &pb.NetworkUsage{
 			TxBytes:   n.TxBytes,
 			RxBytes:   n.RxBytes,
 			TxPackets: n.TxPackets,
@@ -173,7 +173,7 @@ func (m *ContainerMetrics) Marshal() *pb.ResourceUsage {
 		Memory: &pb.MemoryUsage{
 			MaxUsage: m.mem.MaxUsage,
 		},
-		Network: network,
+		Network: networkUsage,
 	}
 }
 
@@ -207,7 +207,7 @@ type Overseer interface {
 	// Stop terminates the container.
 	Stop(ctx context.Context, containerID string) error
 
-	// Makes all cleanup related to closed deal
+	// OnDealFinish makes all cleanup related to closed deal
 	OnDealFinish(ctx context.Context, containerID string) error
 
 	// Info returns runtime statistics collected from all running containers.
@@ -215,7 +215,7 @@ type Overseer interface {
 	// Depending on the implementation this can be cached.
 	Info(ctx context.Context) (map[string]ContainerMetrics, error)
 
-	// Fetch logs of the container
+	// Logs fetch logs of the container
 	Logs(ctx context.Context, id string, opts types.ContainerLogsOptions) (io.ReadCloser, error)
 
 	// Close terminates all associated asynchronous operations and prepares the Overseer for shutting down.

--- a/insonmnia/worker/server.go
+++ b/insonmnia/worker/server.go
@@ -27,25 +27,24 @@ import (
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/pborman/uuid"
 	"github.com/sonm-io/core/insonmnia/auth"
+	"github.com/sonm-io/core/insonmnia/benchmarks"
 	"github.com/sonm-io/core/insonmnia/cgroups"
+	"github.com/sonm-io/core/insonmnia/hardware"
 	"github.com/sonm-io/core/insonmnia/hardware/disk"
 	"github.com/sonm-io/core/insonmnia/npp"
 	"github.com/sonm-io/core/insonmnia/npp/relay"
+	"github.com/sonm-io/core/insonmnia/resource"
+	"github.com/sonm-io/core/insonmnia/structs"
 	"github.com/sonm-io/core/insonmnia/worker/gpu"
 	"github.com/sonm-io/core/insonmnia/worker/salesman"
+	"github.com/sonm-io/core/insonmnia/worker/volume"
+	pb "github.com/sonm-io/core/proto"
 	"github.com/sonm-io/core/util"
 	"github.com/sonm-io/core/util/debug"
 	"github.com/sonm-io/core/util/multierror"
 	"github.com/sonm-io/core/util/xgrpc"
-	"golang.org/x/sync/errgroup"
-	// todo: drop alias
-	bm "github.com/sonm-io/core/insonmnia/benchmarks"
-	"github.com/sonm-io/core/insonmnia/hardware"
-	"github.com/sonm-io/core/insonmnia/resource"
-	"github.com/sonm-io/core/insonmnia/structs"
-	"github.com/sonm-io/core/insonmnia/worker/volume"
-	pb "github.com/sonm-io/core/proto"
 	"go.uber.org/zap"
+	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
@@ -465,20 +464,21 @@ func (m *Worker) Status(ctx context.Context, _ *pb.Empty) (*pb.StatusReply, erro
 	return reply, nil
 }
 
-// FreeDevice provides information about unallocated resources
+// FreeDevices provides information about unallocated resources
 // that can be turned into ask-plans.
-// TODO: Looks like DevicesReply is not really suitable here
+// Deprecated: no longer usable
 func (m *Worker) FreeDevices(ctx context.Context, request *pb.Empty) (*pb.DevicesReply, error) {
 	resources, err := m.resources.GetFree()
 	if err != nil {
 		return nil, err
 	}
-	hardware, err := m.hardware.LimitTo(resources)
+
+	freeHardware, err := m.hardware.LimitTo(resources)
 	if err != nil {
 		return nil, err
 	}
 
-	return hardware.IntoProto(), nil
+	return freeHardware.IntoProto(), nil
 }
 
 func (m *Worker) setStatus(status *pb.TaskStatusReply, id string) {
@@ -586,7 +586,7 @@ func (m *Worker) PullTask(request *pb.PullTaskRequest, stream pb.Worker_PullTask
 
 func (m *Worker) taskAllowed(ctx context.Context, request *pb.StartTaskRequest) (bool, reference.Reference, error) {
 	spec := request.GetSpec()
-	reference, err := reference.ParseAnyReference(spec.GetContainer().GetImage())
+	ref, err := reference.ParseAnyReference(spec.GetContainer().GetImage())
 	if err != nil {
 		return false, nil, fmt.Errorf("failed to parse reference: %s", err)
 	}
@@ -600,10 +600,10 @@ func (m *Worker) taskAllowed(ctx context.Context, request *pb.StartTaskRequest) 
 		return false, nil, err
 	}
 	if level <= pb.IdentityLevel_REGISTERED {
-		return m.whitelist.Allowed(ctx, reference, spec.GetRegistry().Auth())
+		return m.whitelist.Allowed(ctx, ref, spec.GetRegistry().Auth())
 	}
 
-	return true, reference, nil
+	return true, ref, nil
 }
 
 func (m *Worker) StartTask(ctx context.Context, request *pb.StartTaskRequest) (*pb.StartTaskReply, error) {
@@ -664,9 +664,6 @@ func (m *Worker) StartTask(ctx context.Context, request *pb.StartTaskRequest) (*
 	if err := m.resources.ConsumeTask(ask.ID, taskID, spec.Resources); err != nil {
 		return nil, fmt.Errorf("could not start task: %s", err)
 	}
-
-	// This can be canceled by using "resourceHandle.commit()".
-	//defer resourceHandle.release()
 
 	mounts := make([]volume.Mount, 0)
 	for _, spec := range spec.Container.Mounts {
@@ -783,7 +780,7 @@ func (m *Worker) StartTask(ctx context.Context, request *pb.StartTaskRequest) (*
 	return &reply, nil
 }
 
-// Stop request forces to kill container
+// StopTask request forces to kill container
 func (m *Worker) StopTask(ctx context.Context, request *pb.ID) (*pb.Empty, error) {
 	m.mu.Lock()
 	containerInfo, ok := m.containers[request.Id]
@@ -942,7 +939,7 @@ func (m *Worker) setupResources() error {
 }
 
 func (m *Worker) setupSalesman() error {
-	salesman, err := salesman.NewSalesman(
+	s, err := salesman.NewSalesman(
 		salesman.WithLogger(log.S(m.ctx).With("source", "salesman")),
 		salesman.WithStorage(m.storage),
 		salesman.WithResources(m.resources),
@@ -956,7 +953,7 @@ func (m *Worker) setupSalesman() error {
 	if err != nil {
 		return err
 	}
-	m.salesman = salesman
+	m.salesman = s
 
 	ch := m.salesman.Run(m.ctx)
 	go m.listenDeals(ch)
@@ -972,6 +969,9 @@ func (m *Worker) setupRunningContainers() error {
 	defer dockerClient.Close()
 
 	containers, err := dockerClient.ContainerList(m.ctx, types.ContainerListOptions{})
+	if err != nil {
+		return err
+	}
 
 	for _, container := range containers {
 		var info runningContainerInfo
@@ -1050,7 +1050,7 @@ func (m *Worker) setupServer() error {
 }
 
 type BenchmarkHasher interface {
-	// Hash of the hardware, empty string means that we need to rebenchmark everytime
+	// HardwareHash returns hash of the hardware, empty string means that we need to rebenchmark everytime
 	HardwareHash() string
 }
 
@@ -1138,21 +1138,21 @@ func (m *Worker) dropCachedValue(benchID uint64) error {
 }
 
 func (m *Worker) getBenchValue(bench *pb.Benchmark, device interface{}) (uint64, error) {
-	if bench.GetID() == bm.CPUCores {
+	if bench.GetID() == benchmarks.CPUCores {
 		return uint64(m.hardware.CPU.Device.Cores), nil
 	}
-	if bench.GetID() == bm.RamSize {
+	if bench.GetID() == benchmarks.RamSize {
 		return m.hardware.RAM.Device.Total, nil
 	}
-	if bench.GetID() == bm.StorageSize {
+	if bench.GetID() == benchmarks.StorageSize {
 		return disk.FreeDiskSpace(m.ctx)
 	}
-	if bench.GetID() == bm.GPUCount {
+	if bench.GetID() == benchmarks.GPUCount {
 		//GPU count is always 1 for each GPU device.
 		return uint64(1), nil
 	}
 	gpuDevice, isGpu := device.(*pb.GPUDevice)
-	if bench.GetID() == bm.GPUMem {
+	if bench.GetID() == benchmarks.GPUMem {
 		if !isGpu {
 			return uint64(0), fmt.Errorf("invalid device for GPUMem benchmark")
 		}
@@ -1172,10 +1172,10 @@ func (m *Worker) getBenchValue(bench *pb.Benchmark, device interface{}) (uint64,
 		if err != nil {
 			return uint64(0), fmt.Errorf("could not create description for benchmark: %s", err)
 		}
-		d.Env[bm.CPUCountBenchParam] = fmt.Sprintf("%d", m.hardware.CPU.Device.Cores)
+		d.Env[benchmarks.CPUCountBenchParam] = fmt.Sprintf("%d", m.hardware.CPU.Device.Cores)
 
 		if isGpu {
-			d.Env[bm.GPUVendorParam] = gpuDevice.VendorType().String()
+			d.Env[benchmarks.GPUVendorParam] = gpuDevice.VendorType().String()
 			d.GPUDevices = []gpu.GPUID{gpu.GPUID(gpuDevice.GetID())}
 		}
 		res, err := m.execBenchmarkContainer(bench, d)
@@ -1198,9 +1198,10 @@ func (m *Worker) setBenchmark(bench *pb.Benchmark, device interface{}, benchMap 
 	if err != nil {
 		return err
 	}
-	copy := proto.Clone(bench).(*pb.Benchmark)
-	copy.Result = value
-	benchMap[bench.GetID()] = copy
+
+	clone := proto.Clone(bench).(*pb.Benchmark)
+	clone.Result = value
+	benchMap[bench.GetID()] = clone
 	return nil
 }
 
@@ -1220,8 +1221,8 @@ func (m *Worker) runBenchmark(bench *pb.Benchmark) error {
 	case pb.DeviceType_DEV_GPU:
 		//TODO: use context to prevent useless benchmarking in case of error
 		group := errgroup.Group{}
-		for _, gpu := range m.hardware.GPU {
-			g := gpu
+		for _, dev := range m.hardware.GPU {
+			g := dev
 			group.Go(func() error {
 				return m.setBenchmark(bench, g.Device, g.Benchmarks)
 			})
@@ -1237,7 +1238,7 @@ func (m *Worker) runBenchmark(bench *pb.Benchmark) error {
 
 // execBenchmarkContainerWithResults executes benchmark as docker image,
 // returns JSON output with measured values.
-func (m *Worker) execBenchmarkContainerWithResults(d Description) (map[string]*bm.ResultJSON, error) {
+func (m *Worker) execBenchmarkContainerWithResults(d Description) (map[string]*benchmarks.ResultJSON, error) {
 	logTime := time.Now().Add(-time.Minute)
 	err := m.ovs.Spool(m.ctx, d)
 	if err != nil {
@@ -1289,7 +1290,7 @@ func (m *Worker) execBenchmarkContainerWithResults(d Description) (map[string]*b
 	}
 }
 
-func (m *Worker) execBenchmarkContainer(ben *pb.Benchmark, des Description) (*bm.ResultJSON, error) {
+func (m *Worker) execBenchmarkContainer(ben *pb.Benchmark, des Description) (*benchmarks.ResultJSON, error) {
 	log.G(m.ctx).Debug("starting containered benchmark", zap.Any("benchmark", ben))
 	res, err := m.execBenchmarkContainerWithResults(des)
 	if err != nil {
@@ -1308,8 +1309,8 @@ func (m *Worker) execBenchmarkContainer(ben *pb.Benchmark, des Description) (*bm
 	return v, nil
 }
 
-func parseBenchmarkResult(data []byte) (map[string]*bm.ResultJSON, error) {
-	v := &bm.ContainerBenchmarkResultsJSON{}
+func parseBenchmarkResult(data []byte) (map[string]*benchmarks.ResultJSON, error) {
+	v := &benchmarks.ContainerBenchmarkResultsJSON{}
 	err := json.Unmarshal(data, &v)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse `%s` to json: %s", string(data), err)
@@ -1330,7 +1331,7 @@ func getDescriptionForBenchmark(b *pb.Benchmark) (Description, error) {
 	return Description{
 		Reference: reference.AsField(ref),
 		Container: pb.Container{Env: map[string]string{
-			bm.BenchIDEnvParamName: fmt.Sprintf("%d", b.GetID()),
+			benchmarks.BenchIDEnvParamName: fmt.Sprintf("%d", b.GetID()),
 		}},
 	}, nil
 }
@@ -1416,8 +1417,8 @@ func (m *Worker) RemoveBenchmark(ctx context.Context, id *pb.NumericID) (*pb.Emp
 
 func (m *Worker) PurgeBenchmarks(ctx context.Context, _ *pb.Empty) (*pb.Empty, error) {
 	multi := multierror.NewMultiError()
-	benchmarks := m.benchmarks.ByID()
-	for id := range benchmarks {
+	list := m.benchmarks.ByID()
+	for id := range list {
 		if err := m.dropCachedValue(uint64(id)); err != nil {
 			multi = multierror.Append(multi, err)
 		}
@@ -1479,9 +1480,6 @@ func (m *Worker) AskPlanByTaskID(taskID string) (*pb.AskPlan, error) {
 	}
 	return m.salesman.AskPlan(planID)
 }
-
-// todo: make the `worker.Init() error` method to kickstart all initial jobs for the Worker instance.
-// (state loading, benchmarking, market sync).
 
 // Close disposes all resources related to the Worker
 func (m *Worker) Close() {

--- a/proto/worker.pb.go
+++ b/proto/worker.pb.go
@@ -632,6 +632,7 @@ type WorkerManagementClient interface {
 	Devices(ctx context.Context, in *Empty, opts ...grpc.CallOption) (*DevicesReply, error)
 	// FreeDevices provides information about unallocated resources
 	// that can be turned into ask-plans.
+	// Deprecated: no longer usable.
 	FreeDevices(ctx context.Context, in *Empty, opts ...grpc.CallOption) (*DevicesReply, error)
 	// Tasks produces a list of all running tasks on the worker
 	Tasks(ctx context.Context, in *Empty, opts ...grpc.CallOption) (*TaskListReply, error)
@@ -792,6 +793,7 @@ type WorkerManagementServer interface {
 	Devices(context.Context, *Empty) (*DevicesReply, error)
 	// FreeDevices provides information about unallocated resources
 	// that can be turned into ask-plans.
+	// Deprecated: no longer usable.
 	FreeDevices(context.Context, *Empty) (*DevicesReply, error)
 	// Tasks produces a list of all running tasks on the worker
 	Tasks(context.Context, *Empty) (*TaskListReply, error)

--- a/proto/worker.proto
+++ b/proto/worker.proto
@@ -21,6 +21,7 @@ service WorkerManagement {
     rpc Devices (Empty) returns (DevicesReply) {}
     // FreeDevices provides information about unallocated resources
     // that can be turned into ask-plans.
+    // Deprecated: no longer usable.
     rpc FreeDevices (Empty) returns (DevicesReply) {}
     // Tasks produces a list of all running tasks on the worker
     rpc Tasks (Empty) returns (TaskListReply) {}


### PR DESCRIPTION
- Removed several stale TODOs, which was introduced
during previous large refactorings.
- Method's docstrings fixed to match the golang's standards.
- Import and variable names clashing avoided.