### PR TITLE
fix: show allocated resources in TaskStatus

### DIFF
--- a/insonmnia/resource/pool.go
+++ b/insonmnia/resource/pool.go
@@ -163,6 +163,17 @@ func (m *Scheduler) ReleaseTask(taskID string) error {
 	return nil
 }
 
+func (m *Scheduler) ResourceByTask(id string) (*sonm.AskPlanResources, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	res, ok := m.pool.used[id]
+	if !ok {
+		return nil, fmt.Errorf("failed to get resources")
+	}
+
+	return res, nil
+}
+
 func (m *Scheduler) OnDealFinish(taskID string) error {
 	_, ok := m.taskToAskPlan[taskID]
 

--- a/insonmnia/worker/overseer.go
+++ b/insonmnia/worker/overseer.go
@@ -115,7 +115,7 @@ type ContainerInfo struct {
 	Cgroup       string
 	CgroupParent string
 	NetworkIDs   []string
-	DealID       string
+	DealID       *pb.BigInt
 	TaskId       string
 	Tag          *pb.TaskTag
 	AskID        string

--- a/insonmnia/worker/overseer_test.go
+++ b/insonmnia/worker/overseer_test.go
@@ -280,6 +280,7 @@ func TestMarshalContainerInfo(t *testing.T) {
 
 	c := ContainerInfo{
 		PublicKey: pkey,
+		DealID:    sonm.NewBigIntFromInt(1234),
 	}
 
 	data, err := json.Marshal(c)
@@ -290,4 +291,5 @@ func TestMarshalContainerInfo(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.True(t, ssh.KeysEqual(c.PublicKey, n.PublicKey))
+	assert.Equal(t, n.DealID, sonm.NewBigIntFromInt(1234))
 }


### PR DESCRIPTION
This commit fills the `AllocatedResources` field from the deal's ask-plan.
Actual resources info gives an ability to show what part of deal's resources are acquired by task, at least what GPUs is used.
