### PR TITLE
feat: disabled anti-fraud modules in Connor

### DIFF
--- a/connor/config.go
+++ b/connor/config.go
@@ -95,10 +95,12 @@ func (c *Config) validate() error {
 		"NULL":    true, // null token is for testing purposes
 	}
 	availablePools := map[string]bool{
-		antifraud.PoolFormatDwarf: true,
+		antifraud.PoolFormatDwarf:         true,
+		antifraud.ProcessorFormatDisabled: true,
 	}
 	availableLogs := map[string]bool{
-		antifraud.LogFormatClaymore: true,
+		antifraud.LogFormatClaymore:       true,
+		antifraud.ProcessorFormatDisabled: true,
 	}
 
 	if _, ok := availableTokens[c.Mining.Token]; !ok {


### PR DESCRIPTION
This commit adds null log and pool processors for Connor's anti-fraud module.
It can be used for testing purposes or if the user wants to run custom (non-mining) tasks
with external quality tracking.