### PR TITLE
chore: format incompatible code with go 1.11 tooling

### DIFF
--- a/blockchain/api.go
+++ b/blockchain/api.go
@@ -969,7 +969,7 @@ func NewProfileRegistry(address common.Address, opts *chainOpts) (ProfileRegistr
 	return &ProfileRegistry{
 		client:                  client,
 		profileRegistryContract: profileRegistryContract,
-		opts: opts,
+		opts:                    opts,
 	}, nil
 }
 

--- a/cmd/pandora/ammo_marketplace.go
+++ b/cmd/pandora/ammo_marketplace.go
@@ -130,14 +130,14 @@ func order() *sonm.Order {
 				uint64(rand.Int63n(20000)),      // cpu-sysbench-one
 				1 + uint64(rand.Int63n(16)),     // sys-cores
 				1e9 + uint64(rand.Int63n(1e10)), // size-ram
-				0, //uint64(rand.Int63n(1e12)),       // size-stor
-				uint64(rand.Int63n(1e3)), // download-net
-				uint64(rand.Int63n(1e3)), // upload-net
-				0, //1 + uint64(rand.Int63n(16)),     // count-gpu
-				0, //1e9 + uint64(rand.Int63n(1e11)), // mem-gpu
-				0, //uint64(rand.Int63n(1e9)),
-				0, //uint64(rand.Int63n(1e9)),
-				0, //uint64(rand.Int63n(1e9)),
+				0,                               //uint64(rand.Int63n(1e12)),       // size-stor
+				uint64(rand.Int63n(1e3)),        // download-net
+				uint64(rand.Int63n(1e3)),        // upload-net
+				0,                               //1 + uint64(rand.Int63n(16)),     // count-gpu
+				0,                               //1e9 + uint64(rand.Int63n(1e11)), // mem-gpu
+				0,                               //uint64(rand.Int63n(1e9)),
+				0,                               //uint64(rand.Int63n(1e9)),
+				0,                               //uint64(rand.Int63n(1e9)),
 			},
 		},
 	}

--- a/insonmnia/dwh/setup_test.go
+++ b/insonmnia/dwh/setup_test.go
@@ -299,7 +299,7 @@ func setupTestData(ctx context.Context, db *sql.DB, blockchain bch.API) (*sqlSto
 				common.HexToAddress(fmt.Sprintf("0x3%d", i)).Hex(), // Master
 				fmt.Sprintf("2020%d", i),
 				fmt.Sprintf("3030%d", i),
-				10010+i, // Duration
+				10010+i,                                            // Duration
 				pb.NewBigIntFromInt(20010+int64(i)).PaddedString(), // Price
 				30010+i, // StartTime
 				40010+i, // EndTime
@@ -493,7 +493,7 @@ func setupTestData(ctx context.Context, db *sql.DB, blockchain bch.API) (*sqlSto
 		uint64(pb.OrderStatus_ORDER_ACTIVE),
 		common.HexToAddress("0xCC").Hex(), // AuthorID
 		common.HexToAddress("0xA").Hex(),  // CounterpartyID
-		10, // Duration
+		10,                                // Duration
 		pb.NewBigIntFromInt(30010+int64(0)).PaddedString(), // Price
 		5, // Netflags
 		uint64(pb.IdentityLevel_ANONYMOUS),

--- a/optimus/devices_test.go
+++ b/optimus/devices_test.go
@@ -17,24 +17,24 @@ func TestGPUCombinationsEmpty(t *testing.T) {
 
 func TestGPUCombinations(t *testing.T) {
 	devices := []*sonm.GPU{
-		{&sonm.GPUDevice{ID: "0"}, map[uint64]*sonm.Benchmark{}},
-		{&sonm.GPUDevice{ID: "1"}, map[uint64]*sonm.Benchmark{}},
-		{&sonm.GPUDevice{ID: "2"}, map[uint64]*sonm.Benchmark{}},
+		{Device: &sonm.GPUDevice{ID: "0"}, Benchmarks: map[uint64]*sonm.Benchmark{}},
+		{Device: &sonm.GPUDevice{ID: "1"}, Benchmarks: map[uint64]*sonm.Benchmark{}},
+		{Device: &sonm.GPUDevice{ID: "2"}, Benchmarks: map[uint64]*sonm.Benchmark{}},
 	}
 	actual := combinationsGPU(devices, 2)
 
 	expected := [][]*sonm.GPU{
 		{
-			{&sonm.GPUDevice{ID: "0"}, map[uint64]*sonm.Benchmark{}},
-			{&sonm.GPUDevice{ID: "1"}, map[uint64]*sonm.Benchmark{}},
+			{Device: &sonm.GPUDevice{ID: "0"}, Benchmarks: map[uint64]*sonm.Benchmark{}},
+			{Device: &sonm.GPUDevice{ID: "1"}, Benchmarks: map[uint64]*sonm.Benchmark{}},
 		},
 		{
-			{&sonm.GPUDevice{ID: "0"}, map[uint64]*sonm.Benchmark{}},
-			{&sonm.GPUDevice{ID: "2"}, map[uint64]*sonm.Benchmark{}},
+			{Device: &sonm.GPUDevice{ID: "0"}, Benchmarks: map[uint64]*sonm.Benchmark{}},
+			{Device: &sonm.GPUDevice{ID: "2"}, Benchmarks: map[uint64]*sonm.Benchmark{}},
 		},
 		{
-			{&sonm.GPUDevice{ID: "1"}, map[uint64]*sonm.Benchmark{}},
-			{&sonm.GPUDevice{ID: "2"}, map[uint64]*sonm.Benchmark{}},
+			{Device: &sonm.GPUDevice{ID: "1"}, Benchmarks: map[uint64]*sonm.Benchmark{}},
+			{Device: &sonm.GPUDevice{ID: "2"}, Benchmarks: map[uint64]*sonm.Benchmark{}},
 		},
 	}
 	assert.Equal(t, 3, len(actual))
@@ -233,10 +233,10 @@ func TestConsumeGPU(t *testing.T) {
 	devices := newEmptyDevicesReply()
 	devices.GPUs = []*sonm.GPU{
 		{
-			&sonm.GPUDevice{
+			Device: &sonm.GPUDevice{
 				Hash: "0",
 			},
-			map[uint64]*sonm.Benchmark{
+			Benchmarks: map[uint64]*sonm.Benchmark{
 				9:  {ID: 9, Result: 1200},
 				10: {ID: 10, Result: 1860000},
 				11: {ID: 11, Result: 3000},
@@ -265,20 +265,20 @@ func TestConsumeOneOfTwoGPU(t *testing.T) {
 	devices := newEmptyDevicesReply()
 	devices.GPUs = []*sonm.GPU{
 		{
-			&sonm.GPUDevice{
+			Device: &sonm.GPUDevice{
 				Hash: "0",
 			},
-			map[uint64]*sonm.Benchmark{
+			Benchmarks: map[uint64]*sonm.Benchmark{
 				9:  {ID: 9, Result: 1200, SplittingAlgorithm: sonm.SplittingAlgorithm_PROPORTIONAL},
 				10: {ID: 10, Result: 1860000, SplittingAlgorithm: sonm.SplittingAlgorithm_PROPORTIONAL},
 				11: {ID: 11, Result: 3000, SplittingAlgorithm: sonm.SplittingAlgorithm_PROPORTIONAL},
 			},
 		},
 		{
-			&sonm.GPUDevice{
+			Device: &sonm.GPUDevice{
 				Hash: "1",
 			},
-			map[uint64]*sonm.Benchmark{
+			Benchmarks: map[uint64]*sonm.Benchmark{
 				9:  {ID: 9, Result: 1100, SplittingAlgorithm: sonm.SplittingAlgorithm_PROPORTIONAL},
 				10: {ID: 10, Result: 110000, SplittingAlgorithm: sonm.SplittingAlgorithm_PROPORTIONAL},
 				11: {ID: 11, Result: 3000, SplittingAlgorithm: sonm.SplittingAlgorithm_PROPORTIONAL},
@@ -307,20 +307,20 @@ func TestConsumeTwoOfTwoGPU(t *testing.T) {
 	devices := newEmptyDevicesReply()
 	devices.GPUs = []*sonm.GPU{
 		{
-			&sonm.GPUDevice{
+			Device: &sonm.GPUDevice{
 				Hash: "0",
 			},
-			map[uint64]*sonm.Benchmark{
+			Benchmarks: map[uint64]*sonm.Benchmark{
 				9:  {ID: 9, Result: 1200, SplittingAlgorithm: sonm.SplittingAlgorithm_PROPORTIONAL},
 				10: {ID: 10, Result: 1860000, SplittingAlgorithm: sonm.SplittingAlgorithm_PROPORTIONAL},
 				11: {ID: 11, Result: 3000, SplittingAlgorithm: sonm.SplittingAlgorithm_PROPORTIONAL},
 			},
 		},
 		{
-			&sonm.GPUDevice{
+			Device: &sonm.GPUDevice{
 				Hash: "1",
 			},
-			map[uint64]*sonm.Benchmark{
+			Benchmarks: map[uint64]*sonm.Benchmark{
 				9:  {ID: 9, Result: 1100, SplittingAlgorithm: sonm.SplittingAlgorithm_PROPORTIONAL},
 				10: {ID: 10, Result: 110000, SplittingAlgorithm: sonm.SplittingAlgorithm_PROPORTIONAL},
 				11: {ID: 11, Result: 3000, SplittingAlgorithm: sonm.SplittingAlgorithm_PROPORTIONAL},
@@ -349,40 +349,40 @@ func TestConsumeTwoOfFourGPU(t *testing.T) {
 	devices := newEmptyDevicesReply()
 	devices.GPUs = []*sonm.GPU{
 		{
-			&sonm.GPUDevice{
+			Device: &sonm.GPUDevice{
 				Hash: "0",
 			},
-			map[uint64]*sonm.Benchmark{
+			Benchmarks: map[uint64]*sonm.Benchmark{
 				9:  {ID: 9, Result: 1000, SplittingAlgorithm: sonm.SplittingAlgorithm_PROPORTIONAL},
 				10: {ID: 10, Result: 100000, SplittingAlgorithm: sonm.SplittingAlgorithm_PROPORTIONAL},
 				11: {ID: 11, Result: 3000, SplittingAlgorithm: sonm.SplittingAlgorithm_PROPORTIONAL},
 			},
 		},
 		{
-			&sonm.GPUDevice{
+			Device: &sonm.GPUDevice{
 				Hash: "1",
 			},
-			map[uint64]*sonm.Benchmark{
+			Benchmarks: map[uint64]*sonm.Benchmark{
 				9:  {ID: 9, Result: 1200, SplittingAlgorithm: sonm.SplittingAlgorithm_PROPORTIONAL},
 				10: {ID: 10, Result: 120000, SplittingAlgorithm: sonm.SplittingAlgorithm_PROPORTIONAL},
 				11: {ID: 11, Result: 3000, SplittingAlgorithm: sonm.SplittingAlgorithm_PROPORTIONAL},
 			},
 		},
 		{
-			&sonm.GPUDevice{
+			Device: &sonm.GPUDevice{
 				Hash: "2",
 			},
-			map[uint64]*sonm.Benchmark{
+			Benchmarks: map[uint64]*sonm.Benchmark{
 				9:  {ID: 9, Result: 1400, SplittingAlgorithm: sonm.SplittingAlgorithm_PROPORTIONAL},
 				10: {ID: 10, Result: 140000, SplittingAlgorithm: sonm.SplittingAlgorithm_PROPORTIONAL},
 				11: {ID: 11, Result: 3000, SplittingAlgorithm: sonm.SplittingAlgorithm_PROPORTIONAL},
 			},
 		},
 		{
-			&sonm.GPUDevice{
+			Device: &sonm.GPUDevice{
 				Hash: "3",
 			},
-			map[uint64]*sonm.Benchmark{
+			Benchmarks: map[uint64]*sonm.Benchmark{
 				9:  {ID: 9, Result: 1600, SplittingAlgorithm: sonm.SplittingAlgorithm_PROPORTIONAL},
 				10: {ID: 10, Result: 160000, SplittingAlgorithm: sonm.SplittingAlgorithm_PROPORTIONAL},
 				11: {ID: 11, Result: 3000, SplittingAlgorithm: sonm.SplittingAlgorithm_PROPORTIONAL},
@@ -671,10 +671,10 @@ func TestConsumeGPUWithMoreMemoryFails(t *testing.T) {
 	devices := newEmptyDevicesReply()
 	devices.GPUs = []*sonm.GPU{
 		{
-			&sonm.GPUDevice{
+			Device: &sonm.GPUDevice{
 				Hash: "0",
 			},
-			map[uint64]*sonm.Benchmark{
+			Benchmarks: map[uint64]*sonm.Benchmark{
 				8:  {ID: 8, Result: 2.5e9, SplittingAlgorithm: sonm.SplittingAlgorithm_MIN},
 				9:  {ID: 9, Result: 1000, SplittingAlgorithm: sonm.SplittingAlgorithm_PROPORTIONAL},
 				10: {ID: 10, Result: 0, SplittingAlgorithm: sonm.SplittingAlgorithm_PROPORTIONAL},
@@ -682,10 +682,10 @@ func TestConsumeGPUWithMoreMemoryFails(t *testing.T) {
 			},
 		},
 		{
-			&sonm.GPUDevice{
+			Device: &sonm.GPUDevice{
 				Hash: "1",
 			},
-			map[uint64]*sonm.Benchmark{
+			Benchmarks: map[uint64]*sonm.Benchmark{
 				8:  {ID: 8, Result: 3e9, SplittingAlgorithm: sonm.SplittingAlgorithm_MIN},
 				9:  {ID: 9, Result: 1200, SplittingAlgorithm: sonm.SplittingAlgorithm_PROPORTIONAL},
 				10: {ID: 10, Result: 0, SplittingAlgorithm: sonm.SplittingAlgorithm_PROPORTIONAL},
@@ -711,10 +711,10 @@ func TestConsumeGPUWithZeroCountRequiredStillConsumes(t *testing.T) {
 	devices := newEmptyDevicesReply()
 	devices.GPUs = []*sonm.GPU{
 		{
-			&sonm.GPUDevice{
+			Device: &sonm.GPUDevice{
 				Hash: "0",
 			},
-			map[uint64]*sonm.Benchmark{
+			Benchmarks: map[uint64]*sonm.Benchmark{
 				8:  {ID: 8, Result: 2.5e9, SplittingAlgorithm: sonm.SplittingAlgorithm_MIN},
 				9:  {ID: 9, Result: 1000, SplittingAlgorithm: sonm.SplittingAlgorithm_PROPORTIONAL},
 				10: {ID: 10, Result: 0, SplittingAlgorithm: sonm.SplittingAlgorithm_PROPORTIONAL},
@@ -722,10 +722,10 @@ func TestConsumeGPUWithZeroCountRequiredStillConsumes(t *testing.T) {
 			},
 		},
 		{
-			&sonm.GPUDevice{
+			Device: &sonm.GPUDevice{
 				Hash: "1",
 			},
-			map[uint64]*sonm.Benchmark{
+			Benchmarks: map[uint64]*sonm.Benchmark{
 				8:  {ID: 8, Result: 3e9, SplittingAlgorithm: sonm.SplittingAlgorithm_MIN},
 				9:  {ID: 9, Result: 1200, SplittingAlgorithm: sonm.SplittingAlgorithm_PROPORTIONAL},
 				10: {ID: 10, Result: 0, SplittingAlgorithm: sonm.SplittingAlgorithm_PROPORTIONAL},


### PR DESCRIPTION
formatting code with go 1.11 fmt  & vet tools.
incompatibility is very annoying