### PR TITLE
fix: proper (un)marshaling for empty SSH keys

### DIFF
--- a/insonmnia/worker/ssh.go
+++ b/insonmnia/worker/ssh.go
@@ -38,16 +38,23 @@ type PublicKey struct {
 }
 
 func (m *PublicKey) UnmarshalText(data []byte) error {
-	pkey, _, _, _, err := ssh.ParseAuthorizedKey(data)
-	if err != nil {
-		return err
+	if len(data) > 0 {
+		pkey, _, _, _, err := ssh.ParseAuthorizedKey(data)
+		if err != nil {
+			return err
+		}
+		m.PublicKey = pkey
 	}
-	m.PublicKey = pkey
+
 	return nil
 }
 
 func (m PublicKey) MarshalText() ([]byte, error) {
-	return ssh.MarshalAuthorizedKey(m), nil
+	if m.PublicKey != nil {
+		return ssh.MarshalAuthorizedKey(m), nil
+	}
+
+	return []byte{}, nil
 }
 
 type SSH interface {
@@ -235,19 +242,6 @@ func (m *sshServer) Close() error {
 	m.log.Info("closing ssh server")
 
 	return m.server.Close()
-}
-
-func parsePublicKey(key string) (ssh.PublicKey, error) {
-	var publicKey ssh.PublicKey
-	if len(key) != 0 {
-		k, _, _, _, err := ssh.ParseAuthorizedKey([]byte(key))
-		if err != nil {
-			return nil, err
-		}
-		publicKey = k
-	}
-
-	return publicKey, nil
 }
 
 func capitalize(s string) string {

--- a/insonmnia/worker/ssh_test.go
+++ b/insonmnia/worker/ssh_test.go
@@ -1,6 +1,7 @@
 package worker
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/gliderlabs/ssh"
@@ -21,4 +22,15 @@ func TestSSHKeyParse(t *testing.T) {
 	parsed, _, _, _, err := ssh.ParseAuthorizedKey(b)
 	require.NoError(t, err)
 	assert.True(t, ssh.KeysEqual(pkey, parsed))
+}
+
+func TestMarshalEmpty(t *testing.T) {
+
+	var one PublicKey
+	data, err := json.Marshal(one)
+	require.NoError(t, err)
+
+	two := PublicKey{}
+	err = json.Unmarshal(data, &two)
+	require.NoError(t, err)
 }


### PR DESCRIPTION
This commit fixes couple bugs introduced in #1281.
1. Failed to start a task without providing ssh pubkey.
2. Marshalling an empty pubkey crashes worker.