### PR TITLE
aux: debug whitelist for Connor

### DIFF
--- a/connor/antifraud/antifraud.go
+++ b/connor/antifraud/antifraud.go
@@ -131,10 +131,17 @@ func (m *antiFraud) checkDeals(ctx context.Context) error {
 			log.Debug("task quality is less that required: detected by pool reports")
 		}
 
+		supplier := dealMeta.deal.GetSupplierID().Unwrap()
 		logQualityMetrics := []zapcore.Field{
+			zap.String("supplier_id", supplier.Hex()),
 			zap.Float64("by_logs", qualityByLogs),
 			zap.Float64("by_pool", qualityByPool),
 			zap.Float64("required", m.cfg.TaskQuality),
+		}
+
+		if m.isAddressWhitelisted(supplier) {
+			log.Warn("supplier is whitelisted, do not track failure", logQualityMetrics...)
+			shouldClose = false
 		}
 
 		if shouldClose {
@@ -278,6 +285,11 @@ func (m *antiFraud) whoToBlacklist(deal *sonm.Deal) sonm.BlacklistType {
 		return sonm.BlacklistType_BLACKLIST_NOBODY
 	}
 
+	if m.isAddressWhitelisted(meta.deal.GetSupplierID().Unwrap()) {
+		m.log.Debug("decide to NOT blacklist - supplier is in whitelist")
+		return sonm.BlacklistType_BLACKLIST_NOBODY
+	}
+
 	if meta.poolProcessor == nil || meta.logProcessor == nil {
 		m.log.Debug("decide to blacklist worker - no task")
 		m.blacklistWatchers[deal.GetSupplierID().Unwrap()].Failure()
@@ -293,4 +305,13 @@ func (m *antiFraud) whoToBlacklist(deal *sonm.Deal) sonm.BlacklistType {
 	}
 
 	return sonm.BlacklistType_BLACKLIST_NOBODY
+}
+
+func (m *antiFraud) isAddressWhitelisted(addr common.Address) bool {
+	for _, addr := range m.cfg.Whitelist {
+		if addr == addr {
+			return true
+		}
+	}
+	return false
 }

--- a/connor/antifraud/config.go
+++ b/connor/antifraud/config.go
@@ -1,6 +1,10 @@
 package antifraud
 
-import "time"
+import (
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+)
 
 type ProcessorConfig struct {
 	Format          string        `yaml:"format" required:""`
@@ -9,10 +13,11 @@ type ProcessorConfig struct {
 }
 
 type Config struct {
-	TaskQuality            float64         `yaml:"task_quality" required:"true"`
-	QualityCheckInterval   time.Duration   `yaml:"quality_check_interval" default:"15s"`
-	BlacklistCheckInterval time.Duration   `yaml:"blacklist_check_interval" default:"5m"`
-	ConnectionTimeout      time.Duration   `yaml:"connection_timeout" default:"60s"`
-	LogProcessorConfig     ProcessorConfig `yaml:"log_processor"`
-	PoolProcessorConfig    ProcessorConfig `yaml:"pool_processor"`
+	TaskQuality            float64          `yaml:"task_quality" required:"true"`
+	QualityCheckInterval   time.Duration    `yaml:"quality_check_interval" default:"15s"`
+	BlacklistCheckInterval time.Duration    `yaml:"blacklist_check_interval" default:"5m"`
+	ConnectionTimeout      time.Duration    `yaml:"connection_timeout" default:"60s"`
+	LogProcessorConfig     ProcessorConfig  `yaml:"log_processor"`
+	PoolProcessorConfig    ProcessorConfig  `yaml:"pool_processor"`
+	Whitelist              []common.Address `yaml:"whitelist"`
 }


### PR DESCRIPTION
USE ONLY FOR DEBUGGING PURPOSES AND NEVER USE IN PRODUCTION.

Connor debugging will be pretty easy if deals with test suppliers in the Testent will not be closed (because we should remove it from the blacklist, restart Connor, restart tasks, etc..
and it does the whole development process really sucks).