### PR TITLE
fix: Node hanging on failed startup

### DIFF
--- a/insonmnia/node/server.go
+++ b/insonmnia/node/server.go
@@ -223,6 +223,13 @@ func (m *Server) serveHTTP(ctx context.Context, listeners ...net.Listener) error
 
 	defer m.log.Infof("stopped REST server on %s", formatListeners(listeners))
 
+	go func() {
+		<-ctx.Done()
+		for _, listener := range listeners {
+			listener.Close()
+		}
+	}()
+
 	return m.serverREST.Serve(listeners...)
 }
 


### PR DESCRIPTION
This commit fixes race when Node starts with some failed condition, for example, when SSH port is occupied, and then hangs forever.