### PR TITLE
feat: counterparty address for Connor's orders

### DIFF
--- a/connor/config.go
+++ b/connor/config.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/docker/distribution/reference"
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/jinzhu/configor"
 	"github.com/sonm-io/core/accounts"
 	"github.com/sonm-io/core/connor/antifraud"
@@ -29,6 +30,7 @@ type marketConfig struct {
 	From         uint64             `yaml:"from" required:"true"`
 	To           uint64             `yaml:"to" required:"true"`
 	Step         uint64             `yaml:"step" required:"true"`
+	Counterparty common.Address     `yaml:"counterparty"`
 	PriceControl priceControlConfig `yaml:"price_control"`
 	Benchmarks   map[string]uint64  `yaml:"benchmarks" required:"true"`
 
@@ -152,7 +154,7 @@ func (c *Config) getBaseBenchmarks() Benchmarks {
 func (c *Config) backends() *backends {
 	return &backends{
 		processorFactory: antifraud.NewProcessorFactory(&c.AntiFraud),
-		corderFactory:    NewCorderFactory(c.Container.Tag, c.Market.benchmarkID),
+		corderFactory:    NewCorderFactory(c.Container.Tag, c.Market.benchmarkID, c.Market.Counterparty),
 		dealFactory:      NewDealFactory(c.Market.benchmarkID),
 		priceProvider:    c.PriceSource.Init(c.Market.PriceControl.Marginality),
 	}

--- a/connor/types.go
+++ b/connor/types.go
@@ -1,9 +1,11 @@
 package connor
 
 import (
+	"fmt"
 	"math/big"
 	"time"
 
+	"github.com/cnf/structhash"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/sonm-io/core/connor/antifraud"
 	"github.com/sonm-io/core/connor/price"
@@ -21,16 +23,18 @@ type CorderFactory interface {
 	FromSlice(orders []*sonm.Order) []*Corder
 }
 
-func NewCorderFactory(tag string, benchmarkIndex int) CorderFactory {
+func NewCorderFactory(tag string, benchmarkIndex int, counterparty common.Address) CorderFactory {
 	return &anyCorderFactory{
 		orderTag:       tag,
 		benchmarkIndex: benchmarkIndex,
+		counterparty:   counterparty,
 	}
 }
 
 type anyCorderFactory struct {
 	benchmarkIndex int
 	orderTag       string
+	counterparty   common.Address
 }
 
 func (a *anyCorderFactory) FromOrder(order *sonm.Order) *Corder {
@@ -41,12 +45,13 @@ func (a *anyCorderFactory) FromParams(price *big.Int, hashrate uint64, bench Ben
 	bench.Values[a.benchmarkIndex] = hashrate
 
 	ord := &sonm.Order{
-		OrderType:     sonm.OrderType_BID,
-		Price:         sonm.NewBigInt(price),
-		Netflags:      &sonm.NetFlags{Flags: sonm.NetworkOutbound},
-		IdentityLevel: sonm.IdentityLevel_ANONYMOUS,
-		Tag:           []byte(a.orderTag),
-		Benchmarks:    bench.unwrap(),
+		OrderType:      sonm.OrderType_BID,
+		Price:          sonm.NewBigInt(price),
+		Netflags:       &sonm.NetFlags{Flags: sonm.NetworkOutbound},
+		IdentityLevel:  sonm.IdentityLevel_ANONYMOUS,
+		Tag:            []byte(a.orderTag),
+		Benchmarks:     bench.unwrap(),
+		CounterpartyID: sonm.NewEthAddress(a.counterparty),
 	}
 
 	return &Corder{Order: ord, benchmarkIndex: a.benchmarkIndex}
@@ -72,10 +77,11 @@ func (co *Corder) GetHashrate() uint64 {
 
 func (co *Corder) AsBID() *sonm.BidOrder {
 	return &sonm.BidOrder{
-		Price:     &sonm.Price{PerSecond: co.Order.GetPrice()},
-		Blacklist: sonm.NewEthAddress(common.StringToAddress(co.Order.GetBlacklist())),
-		Identity:  co.Order.IdentityLevel,
-		Tag:       string(co.Tag),
+		Price:        &sonm.Price{PerSecond: co.Order.GetPrice()},
+		Blacklist:    sonm.NewEthAddress(common.StringToAddress(co.Order.GetBlacklist())),
+		Identity:     co.Order.IdentityLevel,
+		Tag:          string(co.Tag),
+		Counterparty: co.CounterpartyID,
 		Resources: &sonm.BidResources{
 			Network: &sonm.BidNetwork{
 				Overlay:  co.Order.GetNetflags().GetOverlay(),
@@ -109,6 +115,20 @@ func (co *Corder) isReplaceable(newPrice *big.Int, delta float64) bool {
 	newFloatPrice := big.NewFloat(0).SetInt(newPrice)
 
 	return isOrderReplaceable(currentPrice, newFloatPrice, delta)
+}
+
+func (co *Corder) hash() string {
+	s := struct {
+		Benchmarks   []uint64
+		Counterparty common.Address
+		Netflags     uint64
+	}{
+		Benchmarks:   co.Benchmarks.Values,
+		Counterparty: co.GetCounterpartyID().Unwrap(),
+		Netflags:     co.GetNetflags().GetFlags(),
+	}
+
+	return fmt.Sprintf("%x", structhash.Sha1(s, 1))
 }
 
 type Benchmarks sonm.Benchmarks
@@ -197,7 +217,12 @@ func divideOrdersSets(existingCorders, targetCorders []*Corder) *ordersSets {
 
 	for _, ord := range targetCorders {
 		if ex, ok := existingByBenchmark[ord.GetHashrate()]; ok {
-			set.toRestore = append(set.toRestore, ex)
+			if ex.hash() == ord.hash() {
+				set.toRestore = append(set.toRestore, ex)
+			} else {
+				set.toCancel = append(set.toCancel, ex)
+				set.toCreate = append(set.toCreate, ord)
+			}
 		} else {
 			set.toCreate = append(set.toCreate, ord)
 		}

--- a/connor/types_test.go
+++ b/connor/types_test.go
@@ -5,6 +5,7 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/sonm-io/core/proto"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -23,21 +24,25 @@ func newBenchmarksWithGPUMem(mem uint64) Benchmarks {
 }
 
 func TestNewCorderFactory(t *testing.T) {
-
-	c1 := NewCorderFactory("ETH", ethBenchmarkIndex).FromParams(big.NewInt(100), 1000, newZeroBenchmarks())
+	c1 := NewCorderFactory("ETH", ethBenchmarkIndex, common.Address{}).FromParams(big.NewInt(100), 1000, newZeroBenchmarks())
 
 	assert.Equal(t, c1.GetHashrate(), uint64(1000))
 	assert.Equal(t, c1.Order.GetBenchmarks().GPUEthHashrate(), uint64(1000))
 
-	c2 := NewCorderFactory("NULL", nullBenchmarkIndex).FromParams(big.NewInt(200), 2000, newZeroBenchmarks())
+	c2 := NewCorderFactory("NULL", nullBenchmarkIndex, common.Address{}).FromParams(big.NewInt(200), 2000, newZeroBenchmarks())
 	assert.Equal(t, c2.GetHashrate(), uint64(2000))
 	assert.Equal(t, c2.Order.GetBenchmarks().GPURedshift(), uint64(2000))
+
+	counterParty := common.HexToAddress("0xeE0b6a7D7EC0a03e59319E6eAeBE1D25C32fADF7")
+	c3 := NewCorderFactory("NULL", nullBenchmarkIndex, counterParty).FromParams(big.NewInt(200), 2000, newZeroBenchmarks())
+	assert.Equal(t, c3.CounterpartyID.Unwrap(), counterParty)
+	assert.Equal(t, c3.AsBID().Counterparty.Unwrap(), counterParty)
 }
 
 func TestCorder_AsBID(t *testing.T) {
-	eth := NewCorderFactory("ETH", ethBenchmarkIndex).FromParams(big.NewInt(100), 1000, newBenchmarksWithGPUMem(3000e6))
-	zec := NewCorderFactory("ZEC", zecBenchmarkIndex).FromParams(big.NewInt(100), 130, newBenchmarksWithGPUMem(900e6))
-	null := NewCorderFactory("NULL", nullBenchmarkIndex).FromParams(big.NewInt(100), 550, newBenchmarksWithGPUMem(1e6))
+	eth := NewCorderFactory("ETH", ethBenchmarkIndex, common.Address{}).FromParams(big.NewInt(100), 1000, newBenchmarksWithGPUMem(3000e6))
+	zec := NewCorderFactory("ZEC", zecBenchmarkIndex, common.Address{}).FromParams(big.NewInt(100), 130, newBenchmarksWithGPUMem(900e6))
+	null := NewCorderFactory("NULL", nullBenchmarkIndex, common.Address{}).FromParams(big.NewInt(100), 550, newBenchmarksWithGPUMem(1e6))
 
 	hashrate, ok := eth.AsBID().GetResources().GetBenchmarks()["gpu-eth-hashrate"]
 	gpuMem, ok := eth.AsBID().GetResources().GetBenchmarks()["gpu-mem"]

--- a/connor/x_test.go
+++ b/connor/x_test.go
@@ -4,6 +4,8 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/sonm-io/core/proto"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -16,7 +18,7 @@ func makeTestCordersSet(f CorderFactory, from, to uint64) []*Corder {
 }
 
 func TestDivideOrders(t *testing.T) {
-	f := NewCorderFactory("ETH", 0)
+	f := NewCorderFactory("ETH", 0, common.Address{})
 
 	existing := makeTestCordersSet(f, 200, 400)
 	required := makeTestCordersSet(f, 100, 500)
@@ -27,8 +29,57 @@ func TestDivideOrders(t *testing.T) {
 	assert.Len(t, set.toCancel, 0)
 }
 
+func TestDivideOrderHashed(t *testing.T) {
+	f := NewCorderFactory("ETH", 0, common.Address{})
+
+	existing := makeTestCordersSet(f, 200, 400)
+	existing = append(existing, f.FromParams(big.NewInt(1), uint64(300), newBenchmarksWithGPUMem(100)))
+
+	required := make([]*Corder, 0)
+	for i := 100; i <= 500; i += 100 {
+		required = append(required, f.FromParams(big.NewInt(1), uint64(i), newBenchmarksWithGPUMem(100)))
+	}
+
+	set := divideOrdersSets(existing, required)
+	assert.Len(t, set.toRestore, 1)
+	assert.Len(t, set.toCreate, 4)
+	assert.Len(t, set.toCancel, 2)
+}
+
+func TestDivideOrderHashedCounterparty(t *testing.T) {
+	f := NewCorderFactory("ETH", 0, common.Address{})
+
+	// without counterparty
+	existing := makeTestCordersSet(f, 100, 500)
+	required := makeTestCordersSet(f, 100, 500)
+	for _, r := range required {
+		r.CounterpartyID = sonm.NewEthAddress(common.HexToAddress("0xB8f5c92aDDB5e3D8e137e13868caA427EaFf1140"))
+	}
+
+	set := divideOrdersSets(existing, required)
+	// should fully replace whole set on Market because counterparty was added.
+	assert.Len(t, set.toRestore, 0)
+	assert.Len(t, set.toCreate, 5)
+	assert.Len(t, set.toCancel, 5)
+}
+
+func TestDivideOrderHashedNetFlags(t *testing.T) {
+	f := NewCorderFactory("ETH", 0, common.Address{})
+	existing := makeTestCordersSet(f, 100, 500)
+	required := makeTestCordersSet(f, 100, 500)
+	for _, r := range required {
+		r.Netflags = &sonm.NetFlags{Flags: sonm.NetworkOutbound | sonm.NetworkIncoming}
+	}
+
+	set := divideOrdersSets(existing, required)
+	// should fully replace whole set on Market because netflags was changed.
+	assert.Len(t, set.toRestore, 0)
+	assert.Len(t, set.toCreate, 5)
+	assert.Len(t, set.toCancel, 5)
+}
+
 func TestDivideOrdersWithExtra(t *testing.T) {
-	f := NewCorderFactory("ETH", 0)
+	f := NewCorderFactory("ETH", 0, common.Address{})
 
 	tests := []struct {
 		existing  [2]uint64

--- a/etc/connor.yaml
+++ b/etc/connor.yaml
@@ -9,6 +9,10 @@ market:
   to: 300000000
   step: 500000
 
+  # set counterparty address if you want to place orders
+  # only for specified supplier.
+  # counterparty: 0xD0E743fFDBaEdAa3cf4E3232f3C1aB18ee9ca4aB
+
   price_control:
     # what part of the real market price will be used to
     # create orders on the market


### PR DESCRIPTION
This commit adds an ability to set counterparty address and place orders only for the required supplier. Also, migration code was added.
If a user wants to change non-main benchmark or set counterparty or change netflags,
Connor should be able to detect, that new requirements is changed.
It reached with partial order hashing when we decide to restore existing order or not.