### PR TITLE
fix: keep container info after task stop

### DIFF
--- a/insonmnia/worker/server.go
+++ b/insonmnia/worker/server.go
@@ -801,11 +801,6 @@ func (m *Worker) StopTask(ctx context.Context, request *pb.ID) (*pb.Empty, error
 	}
 
 	m.setStatus(&pb.TaskStatusReply{Status: pb.TaskStatusReply_FINISHED}, request.Id)
-	_, err := m.storage.Remove(containerInfo.TaskId)
-
-	if err != nil {
-		log.G(ctx).Warn("failed to delete cached container info", zap.Error(err))
-	}
 
 	return &pb.Empty{}, nil
 }
@@ -977,7 +972,7 @@ func (m *Worker) setupRunningContainers() error {
 	// Overseer mantains it's own instance of docker.Client
 	defer dockerClient.Close()
 
-	containers, err := dockerClient.ContainerList(m.ctx, types.ContainerListOptions{})
+	containers, err := dockerClient.ContainerList(m.ctx, types.ContainerListOptions{All: true})
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
`TaskStop` should not make worker forget about the task (i.e., worker should know about stopped tasks after restart if deal is still active).