### PR TITLE
feat: verbose filtering in Optimus

### DIFF
--- a/optimus/config.go
+++ b/optimus/config.go
@@ -94,6 +94,15 @@ func (m *workerConfig) Validate() error {
 
 type OrderPolicy int
 
+func (m *OrderPolicy) String() string {
+	switch *m {
+	case 0:
+		return "spot_only"
+	default:
+		return "unknown"
+	}
+}
+
 func (m *OrderPolicy) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	var cfg string
 	if err := unmarshal(&cfg); err != nil {


### PR DESCRIPTION
This commit forces Optimus to write why it has excluded orders from the candidates' list. Note, that this will dramatically increase logging output in exchange for more clean understanding why your favorite order was excluded.