### PR TITLE
fix: proper identity level check in worker SSH

### DIFF
--- a/insonmnia/worker/server.go
+++ b/insonmnia/worker/server.go
@@ -82,13 +82,18 @@ func (m *overseerView) ContainerInfo(id string) (*ContainerInfo, bool) {
 	return m.worker.GetContainerInfo(id)
 }
 
-func (m *overseerView) IdentityLevel(id string) (pb.IdentityLevel, error) {
+func (m *overseerView) ConsumerIdentityLevel(ctx context.Context, id string) (pb.IdentityLevel, error) {
 	plan, err := m.worker.AskPlanByTaskID(id)
 	if err != nil {
 		return pb.IdentityLevel_UNKNOWN, err
 	}
 
-	return plan.Identity, nil
+	deal, err := m.worker.salesman.Deal(plan.GetDealID())
+	if err != nil {
+		return pb.IdentityLevel_UNKNOWN, err
+	}
+
+	return m.worker.eth.ProfileRegistry().GetProfileLevel(ctx, deal.GetConsumerID().Unwrap())
 }
 
 func (m *overseerView) ExecIdentity() pb.IdentityLevel {

--- a/insonmnia/worker/ssh.go
+++ b/insonmnia/worker/ssh.go
@@ -71,7 +71,9 @@ func (nilSSH) Close() error                  { return nil }
 // slightly more decomposed architecture.
 type OverseerView interface {
 	ContainerInfo(id string) (*ContainerInfo, bool)
-	IdentityLevel(id string) (sonm.IdentityLevel, error)
+	// ConsumerIdentityLevel returns the consumer identity level by the given
+	// task identifier.
+	ConsumerIdentityLevel(ctx context.Context, id string) (sonm.IdentityLevel, error)
 	ExecIdentity() sonm.IdentityLevel
 	Exec(ctx context.Context, id string, cmd []string, env []string, isTty bool, wCh <-chan sshd.Window) (types.HijackedResponse, error)
 }
@@ -133,7 +135,7 @@ func (m *connHandler) process(session sshd.Session) (sshStatus, error) {
 		cmd = []string{"login", "-f", "root"}
 	}
 
-	identity, err := m.overseer.IdentityLevel(session.User())
+	identity, err := m.overseer.ConsumerIdentityLevel(session.Context(), session.User())
 	if err != nil {
 		return sshStatusServerError, fmt.Errorf("failed to extract identity level for task `%s`: %v", session.User(), err)
 	}


### PR DESCRIPTION
This commit fixes invalid identity level verification while performing SSH access to a container using NPP API.
Previously an identity level of ask-plan was checked, while actuially it must be the consumer's level checked.

Closed #1421.