### PR TITLE
refact: restrict image push with KYC level

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -177,6 +177,7 @@ build_mockgen:
 
 mock: build_mockgen
 	mockgen -package worker -destination insonmnia/worker/overseer_mock.go -source insonmnia/worker/overseer.go
+	mockgen -package worker -destination insonmnia/worker/acl_mock.go -source insonmnia/worker/acl.go
 	mockgen -package benchmarks -destination insonmnia/benchmarks/benchmarks_mock.go -source insonmnia/benchmarks/benchmarks.go
 	mockgen -package benchmarks -destination insonmnia/benchmarks/mapping_mock.go -source insonmnia/benchmarks/mapping.go
 	mockgen -package blockchain -destination blockchain/api_mock.go  -source blockchain/api.go

--- a/etc/worker.yaml
+++ b/etc/worker.yaml
@@ -62,6 +62,7 @@ benchmarks:
 whitelist:
   # URL to downloads list of allowed containers.
   url: "https://raw.githubusercontent.com/sonm-io/allowed-list/master/general_whitelist.json"
+  # Deprecated: use PrivilegedIdentityLevel instead
   enabled: true
   # allow users of this level or higher to skip whitelist
   privileged_identity_level: identified

--- a/etc/worker.yaml
+++ b/etc/worker.yaml
@@ -63,6 +63,8 @@ whitelist:
   # URL to downloads list of allowed containers.
   url: "https://raw.githubusercontent.com/sonm-io/allowed-list/master/general_whitelist.json"
   enabled: true
+  # allow users of this level or higher to skip whitelist
+  privileged_identity_level: identified
 
 matcher:
   poll_delay: 10s

--- a/insonmnia/worker/acl_test.go
+++ b/insonmnia/worker/acl_test.go
@@ -147,7 +147,7 @@ func TestKycAuthorization(t *testing.T) {
 	identifiedMock := NewMockkycFetcher(ctrl)
 	identifiedMock.EXPECT().GetProfileLevel(gomock.Any(), addr).AnyTimes().Return(sonm.IdentityLevel_IDENTIFIED, nil)
 
-	// Excatly same level
+	// Exactly the same level
 	kyc := newKYCAuthorization(context.Background(), sonm.IdentityLevel_IDENTIFIED, identifiedMock)
 	peerCtx := peer.NewContext(testCtx(), &peer.Peer{
 		AuthInfo: auth.EthAuthInfo{TLS: credentials.TLSInfo{}, Wallet: addr},

--- a/insonmnia/worker/config.go
+++ b/insonmnia/worker/config.go
@@ -23,7 +23,9 @@ type ResourcesConfig struct {
 }
 
 type WhitelistConfig struct {
-	Url                     string             `yaml:"url"`
+	Url string `yaml:"url"`
+	// Deprecated: use PrivilegedIdentityLevel instead
+	Enabled                 *bool              `yaml:"enabled" default:"true" required:"true"`
 	PrivilegedAddresses     []string           `yaml:"privileged_addresses"`
 	RefreshPeriod           uint               `yaml:"refresh_period" default:"60"`
 	PrivilegedIdentityLevel sonm.IdentityLevel `yaml:"privileged_identity_level" default:"identified"`
@@ -63,6 +65,10 @@ func NewConfig(path string) (*Config, error) {
 
 	if err != nil {
 		return nil, err
+	}
+	// TODO: drop in next major version
+	if *cfg.Whitelist.Enabled == false {
+		cfg.Whitelist.PrivilegedIdentityLevel = sonm.IdentityLevel_ANONYMOUS
 	}
 
 	return cfg, nil

--- a/insonmnia/worker/config.go
+++ b/insonmnia/worker/config.go
@@ -24,7 +24,7 @@ type ResourcesConfig struct {
 
 type WhitelistConfig struct {
 	Url string `yaml:"url"`
-	// Deprecated: use PrivilegedIdentityLevel instead
+	// Deprecated: use PrivilegedIdentityLevel instead. Breaking issue #1470.
 	Enabled                 *bool              `yaml:"enabled" default:"true" required:"true"`
 	PrivilegedAddresses     []string           `yaml:"privileged_addresses"`
 	RefreshPeriod           uint               `yaml:"refresh_period" default:"60"`
@@ -66,8 +66,8 @@ func NewConfig(path string) (*Config, error) {
 	if err != nil {
 		return nil, err
 	}
-	// TODO: drop in next major version
-	if *cfg.Whitelist.Enabled == false {
+	// TODO: drop in next major version. Breaking issue #1470.
+	if !*cfg.Whitelist.Enabled {
 		cfg.Whitelist.PrivilegedIdentityLevel = sonm.IdentityLevel_ANONYMOUS
 	}
 

--- a/insonmnia/worker/config.go
+++ b/insonmnia/worker/config.go
@@ -13,6 +13,7 @@ import (
 	"github.com/sonm-io/core/insonmnia/state"
 	"github.com/sonm-io/core/insonmnia/worker/plugin"
 	"github.com/sonm-io/core/insonmnia/worker/salesman"
+	"github.com/sonm-io/core/proto"
 	"github.com/sonm-io/core/util/debug"
 )
 
@@ -22,10 +23,10 @@ type ResourcesConfig struct {
 }
 
 type WhitelistConfig struct {
-	Url                 string   `yaml:"url"`
-	Enabled             *bool    `yaml:"enabled" default:"true" required:"true"`
-	PrivilegedAddresses []string `yaml:"privileged_addresses"`
-	RefreshPeriod       uint     `yaml:"refresh_period" default:"60"`
+	Url                     string             `yaml:"url"`
+	PrivilegedAddresses     []string           `yaml:"privileged_addresses"`
+	RefreshPeriod           uint               `yaml:"refresh_period" default:"60"`
+	PrivilegedIdentityLevel sonm.IdentityLevel `yaml:"privileged_identity_level" default:"identified"`
 }
 
 type DevConfig struct {
@@ -35,7 +36,7 @@ type DevConfig struct {
 type Config struct {
 	Endpoint          string              `yaml:"endpoint" required:"true"`
 	Logging           logging.Config      `yaml:"logging"`
-	Resources         *ResourcesConfig    `yaml:"resources" required:"false" `
+	Resources         *ResourcesConfig    `yaml:"resources" required:"false"`
 	Blockchain        *blockchain.Config  `yaml:"blockchain"`
 	NPP               npp.Config          `yaml:"npp"`
 	SSH               *SSHConfig          `yaml:"ssh" required:"false" `

--- a/insonmnia/worker/server.go
+++ b/insonmnia/worker/server.go
@@ -610,7 +610,7 @@ func (m *Worker) taskAllowed(ctx context.Context, request *pb.StartTaskRequest) 
 	if err != nil {
 		return false, nil, err
 	}
-	if level <= m.cfg.Whitelist.PrivilegedIdentityLevel {
+	if level < m.cfg.Whitelist.PrivilegedIdentityLevel {
 		return m.whitelist.Allowed(ctx, ref, spec.GetRegistry().Auth())
 	}
 

--- a/insonmnia/worker/server.go
+++ b/insonmnia/worker/server.go
@@ -323,7 +323,10 @@ func (m *Worker) setupAuthorization() error {
 			return structs.DealID(request.(*pb.StartTaskRequest).GetDealID().Unwrap().String()), nil
 		}))),
 		auth.Allow(taskAPIPrefix+"TaskLogs").With(newDealAuthorization(m.ctx, m, newFromTaskDealExtractor(m))),
-		auth.Allow(taskAPIPrefix+"PushTask").With(newDealAuthorization(m.ctx, m, newContextDealExtractor())),
+		auth.Allow(taskAPIPrefix+"PushTask").With(newAllOfAuth(
+			newDealAuthorization(m.ctx, m, newContextDealExtractor()),
+			newKYCAuthorization(m.ctx, m.cfg.Whitelist.PrivilegedIdentityLevel, m.eth.ProfileRegistry())),
+		),
 		auth.Allow(taskAPIPrefix+"PullTask").With(newDealAuthorization(m.ctx, m, newRequestDealExtractor(func(request interface{}) (structs.DealID, error) {
 			return structs.DealID(request.(*pb.PullTaskRequest).DealId), nil
 		}))),
@@ -607,7 +610,7 @@ func (m *Worker) taskAllowed(ctx context.Context, request *pb.StartTaskRequest) 
 	if err != nil {
 		return false, nil, err
 	}
-	if level <= pb.IdentityLevel_REGISTERED {
+	if level <= m.cfg.Whitelist.PrivilegedIdentityLevel {
 		return m.whitelist.Allowed(ctx, ref, spec.GetRegistry().Auth())
 	}
 

--- a/insonmnia/worker/whitelist.go
+++ b/insonmnia/worker/whitelist.go
@@ -24,10 +24,6 @@ type Whitelist interface {
 }
 
 func NewWhitelist(ctx context.Context, config *WhitelistConfig) Whitelist {
-	if config.Enabled != nil && !*config.Enabled {
-		return &disabledWhitelist{}
-	}
-
 	wl := whitelist{
 		superusers: make(map[string]struct{}),
 	}
@@ -165,11 +161,4 @@ func (w *whitelist) Allowed(ctx context.Context, ref reference.Reference, author
 	allowed, err := w.digestAllowed(ref.(reference.Named).Name(), (string)(inspection.Descriptor.Digest))
 
 	return allowed, ref, err
-}
-
-type disabledWhitelist struct {
-}
-
-func (w *disabledWhitelist) Allowed(ctx context.Context, ref reference.Reference, auth string) (bool, reference.Reference, error) {
-	return true, ref, nil
 }


### PR DESCRIPTION
This PR introduces acl which checks KYC level and allow only users of specific level to push custom inages on worker. Also it's made configurable and it is reused in whitelist configuration.
closes #1434 