### PR TITLE
fix: proper formula for XMR price calculation

### DIFF
--- a/connor/price/cmc_wtm_test.go
+++ b/connor/price/cmc_wtm_test.go
@@ -11,52 +11,49 @@ import (
 
 func TestCalculateEthPrice(t *testing.T) {
 	tests := []struct {
-		price      *big.Float
-		reward     *big.Float
-		difficulty *big.Float
+		price      *big.Int
+		reward     float64
+		difficulty float64
 		expected   *big.Int
 	}{
 		{
-			price:      big.NewFloat(0).Mul(big.NewFloat(params.Ether), big.NewFloat(465)),
-			reward:     big.NewFloat(2.91),
-			difficulty: big.NewFloat(3.28042614076814e+15),
+			price:      big.NewInt(0).Mul(big.NewInt(params.Ether), big.NewInt(465)),
+			reward:     2.91,
+			difficulty: 3.28042614076814e+15,
 			expected:   big.NewInt(412492),
 		},
 		{
-			price:      big.NewFloat(0).Mul(big.NewFloat(params.Ether), big.NewFloat(100)),
-			reward:     big.NewFloat(2.91),
-			difficulty: big.NewFloat(3.28042614076814e+15),
+			price:      big.NewInt(0).Mul(big.NewInt(params.Ether), big.NewInt(100)),
+			reward:     2.91,
+			difficulty: 3.28042614076814e+15,
 			expected:   big.NewInt(88707),
 		},
 		{
 			// what if the net difficulty will be highly increased and a token price will be dramatically low?
-			price:      big.NewFloat(0).Mul(big.NewFloat(params.Ether), big.NewFloat(3)),
-			reward:     big.NewFloat(2.91),
-			difficulty: big.NewFloat(3.5e17),
+			price:      big.NewInt(0).Mul(big.NewInt(params.Ether), big.NewInt(3)),
+			reward:     2.91,
+			difficulty: 3.5e17,
 			expected:   big.NewInt(24),
 		},
 		{
 			// what if the net difficulty will be slightly increased,
 			// the reward will be also increased, but the token price
 			// will be a lot higher than now?
-			price:      big.NewFloat(0).Mul(big.NewFloat(params.Ether), big.NewFloat(50000)),
-			reward:     big.NewFloat(3),
-			difficulty: big.NewFloat(3.88042614076814e+15),
+			price:      big.NewInt(0).Mul(big.NewInt(params.Ether), big.NewInt(50000)),
+			reward:     3,
+			difficulty: 3.88042614076814e+15,
 			expected:   big.NewInt(38655548),
 		},
 	}
 
 	for _, tt := range tests {
-		res := calculateEthPrice(tt.price, tt.reward, tt.difficulty, 1)
+		coin := &coinParams{Difficulty: tt.difficulty, BlockReward: tt.reward}
+		res := calculateEthPrice(tt.price, coin, 1)
 		assert.True(t, tt.expected.Cmp(res) == 0, fmt.Sprintf("%v == %v", tt.expected.String(), res.String()))
 	}
 }
 
 func TestPriceCalculationWithMargin(t *testing.T) {
-	price := big.NewFloat(0).Mul(big.NewFloat(params.Ether), big.NewFloat(500))
-	reward := big.NewFloat(3)
-	difficulty := big.NewFloat(3e15)
-
 	tests := []struct {
 		margin   float64
 		expected *big.Int
@@ -87,35 +84,38 @@ func TestPriceCalculationWithMargin(t *testing.T) {
 		},
 	}
 
+	price := big.NewInt(0).Mul(big.NewInt(params.Ether), big.NewInt(500))
 	for _, tt := range tests {
-		res := calculateEthPrice(price, reward, difficulty, tt.margin)
+		coin := &coinParams{Difficulty: 3e15, BlockReward: 3}
+		res := calculateEthPrice(price, coin, tt.margin)
 		assert.True(t, tt.expected.Cmp(res) == 0, fmt.Sprintf("%v == %v", tt.expected.String(), res.String()))
 	}
 }
 
 func TestCalculateXmrPrice(t *testing.T) {
 	tests := []struct {
-		price      *big.Float
-		reward     *big.Float
-		difficulty *big.Float
-		expected   *big.Int
+		price    *big.Int
+		reward   float64
+		netHash  float64
+		expected *big.Int
 	}{
 		{
-			price:      big.NewFloat(0).Mul(big.NewFloat(params.Ether), big.NewFloat(100)),
-			reward:     big.NewFloat(3),
-			difficulty: big.NewFloat(5e+10),
-			expected:   big.NewInt(6000000000),
+			price:    big.NewInt(0).Mul(big.NewInt(params.Ether), big.NewInt(100)),
+			reward:   4,
+			netHash:  563816182,
+			expected: big.NewInt(5912092344),
 		},
 		{
-			price:      big.NewFloat(0).Mul(big.NewFloat(params.Ether), big.NewFloat(0.001)),
-			reward:     big.NewFloat(50),
-			difficulty: big.NewFloat(5e+15),
-			expected:   big.NewInt(10),
+			price:    big.NewInt(params.Finney),
+			reward:   4,
+			netHash:  563816182,
+			expected: big.NewInt(59120),
 		},
 	}
 
 	for _, tt := range tests {
-		res := calculateXmrPrice(tt.price, tt.reward, tt.difficulty, 1)
+		coin := &coinParams{BlockReward: tt.reward, Nethash: int(tt.netHash)}
+		res := calculateXmrPrice(tt.price, coin, 1)
 		assert.True(t, tt.expected.Cmp(res) == 0, fmt.Sprintf("%v == %v", tt.expected.String(), res.String()))
 	}
 }

--- a/connor/price/utils.go
+++ b/connor/price/utils.go
@@ -22,7 +22,7 @@ const (
 	moneroEtmID   = 101
 )
 
-type wtmCoin struct {
+type coinParams struct {
 	ID          int     `json:"id"`
 	Difficulty  float64 `json:"difficulty"`
 	BlockReward float64 `json:"block_reward"`
@@ -32,10 +32,10 @@ type wtmCoin struct {
 }
 
 type wtmResponse struct {
-	Coins map[string]*wtmCoin `json:"coins"`
+	Coins map[string]*coinParams `json:"coins"`
 }
 
-func getTokenParamsFromWTM(id int) (*wtmCoin, error) {
+func getTokenParamsFromWTM(id int) (*coinParams, error) {
 	data, err := FetchURLWithRetry(whatToMineURL)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This commit fixes calculation algo for XMR.  Also, signature of the PriceProvider's `calculateFunc` has been changed because we want to use all available token params, not only reward and net difficulty.