### PR TITLE
fix: properly detect IPv4 addresses

### DIFF
--- a/util/netutil/net.go
+++ b/util/netutil/net.go
@@ -200,5 +200,5 @@ func (s sortableIPs) Less(i, j int) bool {
 }
 
 func IsIPv4(ip net.IP) bool {
-	return len(ip) == net.IPv4len
+	return ip.To4() != nil
 }


### PR DESCRIPTION
For some unknown reasons, Go developers keep IPv4 addresses in a slice of size 16(!). It's so logical, yes.

Just take a look at this another example of clean go architecture:
```go
func IPv4(a, b, c, d byte) IP {
	p := make(IP, IPv6len)
	copy(p, v4InV6Prefix)
	p[12] = a
	p[13] = b
	p[14] = c
	p[15] = d
	return p
}
```