### PR TITLE
feat: generate SSH key instead of require

### DIFF
--- a/etc/worker.yaml
+++ b/etc/worker.yaml
@@ -101,9 +101,8 @@ metrics_listen_addr: "127.0.0.1:14001"
 # It works through NPP, i.e. can be used even if a worker is located behind NAT.
 ssh:
   # Endpoint where SSH server will be exposed.
-  endpoint: localhost:2222
-  # Private key path, that is used only for SSH DH.
-  private_key_path: /root/.ssh/id_rsa
+  # Optional.
+  endpoint: localhost:0
   # NPP settings.
   # It is extremely likely that it should be borrowed from the global NPP
   # settings.


### PR DESCRIPTION
This commit simplifies SSH server configuration on a Worker by deprecating "private_key_path" option in "ssh" section. Now SSH key is generated at Worker start up and cached in boltdb.