### PR TITLE
feat: Connor's log processor for xmrig

### DIFF
--- a/connor/antifraud/processor.go
+++ b/connor/antifraud/processor.go
@@ -10,6 +10,7 @@ import (
 
 const (
 	LogFormatClaymore       = "claymore"
+	LogFormatXMRing         = "xmrig"
 	PoolFormatDwarf         = "dwarf"
 	ProcessorFormatDisabled = "disabled"
 )
@@ -66,6 +67,14 @@ func NewProcessorFactory(cfg *Config) ProcessorFactory {
 				opt(o)
 			}
 			return newClaymoreLogProcessor(&cfg.LogProcessorConfig, o.logger, o.cc, deal, taskID)
+		}
+	case LogFormatXMRing:
+		log = func(deal *types.Deal, taskID string, opts ...Option) Processor {
+			o := &processorOpts{}
+			for _, opt := range opts {
+				opt(o)
+			}
+			return newXmrigLogProcessor(&cfg.LogProcessorConfig, o.logger, o.cc, deal, taskID)
 		}
 	case ProcessorFormatDisabled:
 		log = func(deal *types.Deal, taskID string, opts ...Option) Processor {

--- a/connor/config.go
+++ b/connor/config.go
@@ -84,6 +84,7 @@ func (c *Config) validate() error {
 	}
 	availableLogs := map[string]bool{
 		antifraud.LogFormatClaymore:       true,
+		antifraud.LogFormatXMRing:         true,
 		antifraud.ProcessorFormatDisabled: true,
 	}
 


### PR DESCRIPTION
This commit adds a new log processor type for Connor's anti-fraud module.
Brand new processor able to read logs from the xmrig miner, which is used to mine Monero (cryptonight) on CPUs.