### PR TITLE
fix: limited access to the status server on startup

### DIFF
--- a/insonmnia/worker/acl.go
+++ b/insonmnia/worker/acl.go
@@ -166,11 +166,3 @@ func (a *anyOfAuth) Authorize(ctx context.Context, request interface{}) error {
 func newAnyOfAuth(a ...auth.Authorization) auth.Authorization {
 	return &anyOfAuth{authorizers: a}
 }
-
-func newStatusAuthorization(ctx context.Context) *auth.AuthRouter {
-	return auth.NewEventAuthorization(ctx,
-		auth.WithLog(log.G(ctx)),
-		auth.Allow(workerAPIPrefix+"Status").With(auth.NewNilAuthorization()),
-		auth.WithFallback(auth.NewDenyAuthorization()),
-	)
-}

--- a/insonmnia/worker/acl.go
+++ b/insonmnia/worker/acl.go
@@ -166,3 +166,11 @@ func (a *anyOfAuth) Authorize(ctx context.Context, request interface{}) error {
 func newAnyOfAuth(a ...auth.Authorization) auth.Authorization {
 	return &anyOfAuth{authorizers: a}
 }
+
+func newStatusAuthorization(ctx context.Context) *auth.AuthRouter {
+	return auth.NewEventAuthorization(ctx,
+		auth.WithLog(log.G(ctx)),
+		auth.Allow(workerAPIPrefix+"Status").With(auth.NewNilAuthorization()),
+		auth.WithFallback(auth.NewDenyAuthorization()),
+	)
+}

--- a/insonmnia/worker/server.go
+++ b/insonmnia/worker/server.go
@@ -1614,3 +1614,11 @@ func (m *Worker) Close() {
 		m.certRotator.Close()
 	}
 }
+
+func newStatusAuthorization(ctx context.Context) *auth.AuthRouter {
+	return auth.NewEventAuthorization(ctx,
+		auth.WithLog(log.G(ctx)),
+		auth.Allow(workerAPIPrefix+"Status").With(auth.NewNilAuthorization()),
+		auth.WithFallback(auth.NewDenyAuthorization()),
+	)
+}


### PR DESCRIPTION
This commit fixes a bug when the gRPC server running with WorkerManagement methods available, but the worker is not fully initialized. Thus calling methods like `debug-state` or` free-resources` lead to random  crashes of the worker. To prevent this we must limit access to this handles with ACL.