### PR TITLE
fix: properly initialize tinc network

### DIFF
--- a/insonmnia/worker/network/tinc_tuner.go
+++ b/insonmnia/worker/network/tinc_tuner.go
@@ -128,14 +128,10 @@ func (t *TincTuner) Tune(ctx context.Context, net *structs.NetworkSpec, hostConf
 	//t.netDriver.RegisterNetworkMapping(response.ID, net.ID())
 	if config.EndpointsConfig == nil {
 		config.EndpointsConfig = make(map[string]*network.EndpointSettings)
-		config.EndpointsConfig[response.ID] = &network.EndpointSettings{
-			//IPAMConfig: &network.EndpointIPAMConfig{
-			//	IPv4Address: net.NetworkAddr(),
-			//},
-			//IPAddress: net.NetworkAddr(),
-			//NetworkID: response.ID,
-			DriverOpts: opts,
-		}
+	}
+	config.EndpointsConfig[response.ID] = &network.EndpointSettings{
+		NetworkID:  response.ID,
+		DriverOpts: opts,
 	}
 
 	return &TincCleaner{


### PR DESCRIPTION
This PR fixes ability to add tinc network alongside shaped interface. As docker does not accept multiple networks during container creation we do connect them afterward.