### PR TITLE
fix: proper log processor for Connor

### DIFF
--- a/connor/antifraud/log_processor.go
+++ b/connor/antifraud/log_processor.go
@@ -17,6 +17,7 @@ import (
 	"github.com/sonm-io/core/connor/types"
 	"github.com/sonm-io/core/proto"
 	"github.com/sonm-io/core/util"
+	"go.uber.org/atomic"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
 )
@@ -32,7 +33,7 @@ type commonLogProcessor struct {
 	hashrateEWMA metrics.EWMA
 	startTime    time.Time
 
-	hashrate    float64
+	hashrate    *atomic.Float64
 	logParser   logParseFunc
 	historyFile *os.File
 }
@@ -50,7 +51,7 @@ func newLogProcessor(cfg *ProcessorConfig, log *zap.Logger, conn *grpc.ClientCon
 		taskClient:   sonm.NewTaskManagementClient(conn),
 		hashrateEWMA: metrics.NewEWMA(1 - math.Exp(-5.0/cfg.DecayTime)),
 		startTime:    time.Now(),
-		hashrate:     float64(deal.Benchmarks.GPUEthHashrate()),
+		hashrate:     atomic.NewFloat64(float64(deal.BenchmarkValue())),
 	}
 }
 
@@ -66,6 +67,9 @@ func (m *commonLogProcessor) TaskID() string {
 }
 
 func (m *commonLogProcessor) Run(ctx context.Context) error {
+	m.hashrateEWMA.Update(int64(m.hashrate.Load() * 5.))
+	m.hashrateEWMA.Tick()
+
 	go m.fetchLogs(ctx)
 	m.log.Info("starting task's warm-up")
 	timer := time.NewTimer(m.cfg.TaskWarmupDelay)
@@ -79,8 +83,8 @@ func (m *commonLogProcessor) Run(ctx context.Context) error {
 	m.log.Info("task is warmed-up")
 
 	// This should not be configured, as ticker in ewma is bound to 5 seconds
-	ewmaTick := time.NewTicker(5 * time.Second)
-	ewmaUpdate := time.NewTicker(1 * time.Second)
+	ewmaTick := util.NewImmediateTicker(5 * time.Second)
+	ewmaUpdate := util.NewImmediateTicker(1 * time.Second)
 
 	defer ewmaTick.Stop()
 	defer ewmaUpdate.Stop()
@@ -90,7 +94,7 @@ func (m *commonLogProcessor) Run(ctx context.Context) error {
 		case <-ctx.Done():
 			return ctx.Err()
 		case <-ewmaUpdate.C:
-			m.hashrateEWMA.Update(int64(m.hashrate))
+			m.hashrateEWMA.Update(int64(m.hashrate.Load()))
 		case <-ewmaTick.C:
 			m.hashrateEWMA.Tick()
 		}
@@ -116,7 +120,8 @@ func (m *commonLogProcessor) maybeOpenHistoryFile() error {
 
 func (m *commonLogProcessor) maybeSaveLogLine(line string) {
 	if m.historyFile != nil {
-		if _, err := m.historyFile.WriteString(line + "\n"); err != nil {
+		withTimestamp := fmt.Sprintf("%s: %s\n", time.Now().Format(time.RFC3339), line)
+		if _, err := m.historyFile.WriteString(withTimestamp); err != nil {
 			m.log.Warn("cannot write task log", zap.String("file", m.historyFile.Name()), zap.Error(err))
 		}
 	}
@@ -124,9 +129,10 @@ func (m *commonLogProcessor) maybeSaveLogLine(line string) {
 
 func (m *commonLogProcessor) fetchLogs(ctx context.Context) error {
 	request := &sonm.TaskLogsRequest{
-		Type:   sonm.TaskLogsRequest_STDOUT,
+		Type:   sonm.TaskLogsRequest_BOTH,
 		Id:     m.taskID,
 		Follow: true,
+		Tail:   "1",
 		DealID: m.deal.Id,
 	}
 
@@ -138,6 +144,7 @@ func (m *commonLogProcessor) fetchLogs(ctx context.Context) error {
 
 	retryTicker := util.NewImmediateTicker(m.cfg.TrackInterval)
 	defer retryTicker.Stop()
+	failureCount := 0
 
 	for {
 		select {
@@ -146,22 +153,24 @@ func (m *commonLogProcessor) fetchLogs(ctx context.Context) error {
 		case <-retryTicker.C:
 		}
 
-		m.log.Debug("requesting logs")
+		m.log.Debug("requesting logs", zap.Int("count", failureCount))
 		cli, err := m.taskClient.Logs(ctx, request)
 		if err != nil {
-			m.hashrate = 0.
-			m.log.Warn("failed to fetch logs from the task")
+			m.hashrate.Store(0.)
+			m.log.Warn("failed to fetch logs from the task", zap.Error(err), zap.Int("count", failureCount))
 			continue
 		}
 
+		m.log.Debug("log reader client created", zap.Int("count", failureCount))
 		logReader := sonm.NewLogReader(cli)
 		reader, writer := io.Pipe()
 
 		go m.logParser(ctx, m, reader)
 
 		_, err = stdcopy.StdCopy(writer, writer, logReader)
-		m.log.Warn("stop reading logs for task", zap.Error(err))
+		m.log.Warn("stop reading logs for task", zap.Error(err), zap.Int("count", failureCount))
 		writer.Close()
+		failureCount++
 	}
 }
 
@@ -197,7 +206,7 @@ func claymoreLogParser(ctx context.Context, m *commonLogProcessor, reader io.Rea
 				return
 			}
 
-			m.hashrate = hashrate * 1e6
+			m.hashrate.Store(hashrate * 1e6)
 		}
 	}
 
@@ -234,7 +243,7 @@ func xmrigLogParser(ctx context.Context, m *commonLogProcessor, reader io.Reader
 				return
 			}
 
-			m.hashrate = hashrate
+			m.hashrate.Store(hashrate)
 		}
 	}
 }

--- a/connor/antifraud/log_processor_test.go
+++ b/connor/antifraud/log_processor_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"go.uber.org/atomic"
 	"go.uber.org/zap"
 )
 
@@ -20,27 +21,27 @@ func mklog(n int) string {
 
 func TestClaymoreLogParser(t *testing.T) {
 	rd := strings.NewReader(`ETH - Total Speed: 100.000 Mh/s, Total Shares: 127, Rejected: 0, Time: 00:02`)
-	p := &commonLogProcessor{log: zap.NewNop()}
+	p := &commonLogProcessor{log: zap.NewNop(), hashrate: atomic.NewFloat64(0)}
 
 	claymoreLogParser(context.Background(), p, rd)
-	assert.Equal(t, float64(100e6), p.hashrate, "new value should be parsed and set")
+	assert.Equal(t, float64(100e6), p.hashrate.Load(), "new value should be parsed and set")
 }
 
 func TestClaymoreLogParser_InvalidLine(t *testing.T) {
 	rd := strings.NewReader(`Oops! Claymore failed`)
-	p := &commonLogProcessor{log: zap.NewNop(), hashrate: 100500}
+	p := &commonLogProcessor{log: zap.NewNop(), hashrate: atomic.NewFloat64(100500)}
 
 	claymoreLogParser(context.Background(), p, rd)
-	assert.Equal(t, float64(100500), p.hashrate, "previous value should be kept")
+	assert.Equal(t, float64(100500), p.hashrate.Load(), "previous value should be kept")
 }
 
 func TestClaymoreLogParser_ContextCancel(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 
 	rd := strings.NewReader(mklog(1000))
-	p := &commonLogProcessor{log: zap.NewNop(), hashrate: 1.2345}
+	p := &commonLogProcessor{log: zap.NewNop(), hashrate: atomic.NewFloat64(1.2345)}
 	cancel()
 
 	claymoreLogParser(ctx, p, rd)
-	assert.Equal(t, float64(1.2345), p.hashrate, "new value should be parsed and set")
+	assert.Equal(t, float64(1.2345), p.hashrate.Load(), "new value should be parsed and set")
 }


### PR DESCRIPTION
This commit fixes several issues with log processor:
- Wrap calculated hashrate value with atomic to make it thread-safe.
- Perform initializing tick for EWMA.
- Add timestamps for stored logs.
- Read logs with tail. It prevents us from reloading full task log when Connor restarts or when connection was lost and Connot should start read logs again.