### PR TITLE
fix: proper xdocker.Reference marshalling

### DIFF
--- a/util/xdocker/reference.go
+++ b/util/xdocker/reference.go
@@ -31,7 +31,7 @@ func (m *Reference) UnmarshalText(source []byte) error {
 	return m.Parse(string(source))
 }
 
-func (m *Reference) MarshalText() ([]byte, error) {
+func (m Reference) MarshalText() ([]byte, error) {
 	return []byte(m.String()), nil
 }
 

--- a/util/xdocker/reference_test.go
+++ b/util/xdocker/reference_test.go
@@ -1,0 +1,22 @@
+package xdocker
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestReferenceMarshalUnmarshal(t *testing.T) {
+	refStr := "httpd:latest"
+	ref, err := NewReference(refStr)
+	require.NoError(t, err)
+	data, err := json.Marshal(&ref)
+	require.NoError(t, err)
+	require.Equal(t, "\"docker.io/library/httpd:latest\"", string(data))
+
+	ref2 := &Reference{}
+	err = json.Unmarshal(data, ref2)
+	require.NoError(t, err)
+	require.Equal(t, "docker.io/library/httpd:latest", ref2.String())
+}


### PR DESCRIPTION
This commit fixes xdocker.Reference marshalling in the way it can be used via json and yaml encoders.