### PR TITLE
fix: remove extra benchmark from Connor's config

### DIFF
--- a/connor/config.go
+++ b/connor/config.go
@@ -153,7 +153,6 @@ func (c *Config) getBaseBenchmarks() types.Benchmarks {
 			c.Market.Benchmarks["gpu-eth-hashrate"],
 			c.Market.Benchmarks["gpu-cash-hashrate"],
 			c.Market.Benchmarks["gpu-redshift"],
-			c.Market.Benchmarks["cpu-cryptonight"],
 		},
 	}
 }


### PR DESCRIPTION
Should be added in #1512.