### PR TITLE
refactor: simplify main definition

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ ifeq ($(WITH_NL),true)
     NL_TAGS := nl
 endif
 
-LDFLAGS = -X main.appVersion=$(FULL_VERSION)
+LDFLAGS = -X cmd.app.Version=$(FULL_VERSION)
 
 .PHONY: fmt vet test
 

--- a/cmd/cobra.go
+++ b/cmd/cobra.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"path"
 	"strings"
 
 	"github.com/mitchellh/go-homedir"
@@ -11,30 +12,50 @@ import (
 	"github.com/spf13/pflag"
 )
 
-// Runner func starts service wrapper by Cobra command.
-type Runner func() error
+var (
+	app = AppContext{
+		Name: path.Base(os.Args[0]),
+	}
+	showVersion bool
+)
 
-func NewCmd(name, appVersion string, cfg *string, version *bool, run Runner) *cobra.Command {
-	wrapped := func() error {
-		expandedCfg, err := homedir.Expand(*cfg)
-		if err != nil {
-			return fmt.Errorf("failed to parse config path: %v", err)
-		}
-		*cfg = expandedCfg
-		return run()
+// Runner func starts service wrapper by Cobra command.
+type Runner func(appContext AppContext) error
+
+// AppContext represents the application context.
+type AppContext struct {
+	// Name holds the current application name.
+	Name string
+	// ConfigPath holds the current application's config path, if any.
+	ConfigPath string
+	// Version holds string representation of a current application's version.
+	Version string
+}
+
+// RunWithHomeExpand runs the given runner, expanding the config path field
+// by taking in action HOME directory symbol (~) if it exists.
+func (m *AppContext) RunWithHomeExpand(runner Runner) error {
+	expandedCfg, err := homedir.Expand(app.ConfigPath)
+	if err != nil {
+		return fmt.Errorf("failed to parse config path: %v", err)
 	}
 
+	app.ConfigPath = expandedCfg
+	return runner(app)
+}
+
+func NewCmd(runner Runner) *cobra.Command {
 	c := &cobra.Command{
-		Use: appName(name),
+		Use: app.Name,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
-			if version != nil && *version {
-				fmt.Println(versionString(name, appVersion))
+			if showVersion {
+				fmt.Println(versionString(app.Name, app.Version))
 				os.Exit(0)
 			}
 			return checkRequiredFlags(cmd.PersistentFlags())
 		},
 		Run: func(cmd *cobra.Command, args []string) {
-			if err := wrapped(); err != nil {
+			if err := app.RunWithHomeExpand(runner); err != nil {
 				fmt.Println(capitalize(err.Error()))
 				os.Exit(1)
 			}
@@ -42,8 +63,8 @@ func NewCmd(name, appVersion string, cfg *string, version *bool, run Runner) *co
 	}
 
 	c.SetOutput(os.Stdout)
-	c.PersistentFlags().StringVar(cfg, "config", "", configFlagHelp(name))
-	c.PersistentFlags().BoolVar(version, "version", false, versionFlagHelp(name))
+	c.PersistentFlags().StringVar(&app.ConfigPath, "config", "", configFlagHelp())
+	c.PersistentFlags().BoolVar(&showVersion, "version", false, versionFlagHelp())
 
 	c.MarkPersistentFlagRequired("config")
 
@@ -58,16 +79,12 @@ func capitalize(s string) string {
 	return strings.ToUpper(s[:1]) + s[1:]
 }
 
-func appName(name string) string {
-	return "sonm" + name
+func configFlagHelp() string {
+	return "Path to the config file (required)"
 }
 
-func configFlagHelp(name string) string {
-	return fmt.Sprintf("Path to the %s config file (required)", name)
-}
-
-func versionFlagHelp(name string) string {
-	return fmt.Sprintf("Show %s version and exit", name)
+func versionFlagHelp() string {
+	return "Show version and exit"
 }
 
 func versionString(name, appVersion string) string {

--- a/cmd/connor/main.go
+++ b/cmd/connor/main.go
@@ -12,18 +12,12 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-var (
-	appVersion  string
-	configFlag  string
-	versionFlag bool
-)
-
 func main() {
-	cmd.NewCmd("connor", appVersion, &configFlag, &versionFlag, run).Execute()
+	cmd.NewCmd(run).Execute()
 }
 
-func run() error {
-	cfg, err := connor.NewConfig(configFlag)
+func run(app cmd.AppContext) error {
+	cfg, err := connor.NewConfig(app.ConfigPath)
 	if err != nil {
 		return fmt.Errorf("failed to load config file: %s", err)
 	}

--- a/cmd/dwh/main.go
+++ b/cmd/dwh/main.go
@@ -16,18 +16,12 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-var (
-	configFlag  string
-	versionFlag bool
-	appVersion  string
-)
-
 func main() {
-	cmd.NewCmd("dwh", appVersion, &configFlag, &versionFlag, run).Execute()
+	cmd.NewCmd(run).Execute()
 }
 
-func run() error {
-	cfg, err := dwh.NewDWHConfig(configFlag)
+func run(app cmd.AppContext) error {
+	cfg, err := dwh.NewDWHConfig(app.ConfigPath)
 	if err != nil {
 		return fmt.Errorf("failed to load config file: %s", err)
 	}

--- a/cmd/node/main.go
+++ b/cmd/node/main.go
@@ -12,18 +12,12 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-var (
-	appVersion  string
-	configFlag  string
-	versionFlag bool
-)
-
 func main() {
-	cmd.NewCmd("node", appVersion, &configFlag, &versionFlag, run).Execute()
+	cmd.NewCmd(run).Execute()
 }
 
-func run() error {
-	cfg, err := node.NewConfig(configFlag)
+func run(app cmd.AppContext) error {
+	cfg, err := node.NewConfig(app.ConfigPath)
 	if err != nil {
 		return fmt.Errorf("failed to load config file: %s", err)
 	}

--- a/cmd/optimus/main.go
+++ b/cmd/optimus/main.go
@@ -11,18 +11,12 @@ import (
 	"go.uber.org/zap/zapcore"
 )
 
-var (
-	configFlag  string
-	versionFlag bool
-	appVersion  string
-)
-
 func main() {
-	cmd.NewCmd("optimus", appVersion, &configFlag, &versionFlag, run).Execute()
+	cmd.NewCmd(run).Execute()
 }
 
-func run() error {
-	cfg, err := optimus.LoadConfig(configFlag)
+func run(app cmd.AppContext) error {
+	cfg, err := optimus.LoadConfig(app.ConfigPath)
 	if err != nil {
 		return fmt.Errorf("failed to parse config: %v", err)
 	}
@@ -51,7 +45,7 @@ func run() error {
 	}
 
 	ctx := ctxlog.WithLogger(context.Background(), log)
-	bot, err := optimus.NewOptimus(cfg, optimus.WithVersion(appVersion), optimus.WithLog(log.Sugar()))
+	bot, err := optimus.NewOptimus(cfg, optimus.WithVersion(app.Version), optimus.WithLog(log.Sugar()))
 	if err != nil {
 		return fmt.Errorf("failed to create Optimus: %v", err)
 	}

--- a/cmd/oracle/main.go
+++ b/cmd/oracle/main.go
@@ -10,18 +10,12 @@ import (
 	"github.com/sonm-io/core/insonmnia/oracle"
 )
 
-var (
-	configFlag  string
-	versionFlag bool
-	appVersion  string
-)
-
 func main() {
-	cmd.NewCmd("oracle", appVersion, &configFlag, &versionFlag, run).Execute()
+	cmd.NewCmd(run).Execute()
 }
 
-func run() error {
-	cfg, err := oracle.NewConfig(configFlag)
+func run(app cmd.AppContext) error {
+	cfg, err := oracle.NewConfig(app.ConfigPath)
 	if err != nil {
 		return fmt.Errorf("failed to load config file: %s", err)
 	}

--- a/cmd/relay/main.go
+++ b/cmd/relay/main.go
@@ -11,14 +11,8 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-var (
-	cfgPath     string
-	versionFlag bool
-	appVersion  string
-)
-
-func start() error {
-	cfg, err := relay.NewServerConfig(cfgPath)
+func start(app cmd.AppContext) error {
+	cfg, err := relay.NewServerConfig(app.ConfigPath)
 	if err != nil {
 		return fmt.Errorf("failed to load config file: %s", err)
 	}
@@ -61,5 +55,5 @@ func start() error {
 }
 
 func main() {
-	cmd.NewCmd("relay", appVersion, &cfgPath, &versionFlag, start).Execute()
+	cmd.NewCmd(start).Execute()
 }

--- a/cmd/rv/main.go
+++ b/cmd/rv/main.go
@@ -12,14 +12,8 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-var (
-	cfgPath     string
-	versionFlag bool
-	appVersion  string
-)
-
-func start() error {
-	cfg, err := rendezvous.NewServerConfig(cfgPath)
+func start(app cmd.AppContext) error {
+	cfg, err := rendezvous.NewServerConfig(app.ConfigPath)
 	if err != nil {
 		return fmt.Errorf("failed to load config file: %s", err)
 	}
@@ -64,5 +58,5 @@ func start() error {
 }
 
 func main() {
-	cmd.NewCmd("rendezvous", appVersion, &cfgPath, &versionFlag, start).Execute()
+	cmd.NewCmd(start).Execute()
 }

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -17,20 +17,14 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-var (
-	configFlag  string
-	versionFlag bool
-	appVersion  string
-)
-
 func main() {
-	cmd.NewCmd("worker", appVersion, &configFlag, &versionFlag, run).Execute()
+	cmd.NewCmd(run).Execute()
 }
 
-func run() error {
+func run(app cmd.AppContext) error {
 	ctx := context.Background()
 	waiter, ctx := errgroup.WithContext(ctx)
-	cfg, err := worker.NewConfig(configFlag)
+	cfg, err := worker.NewConfig(app.ConfigPath)
 	if err != nil {
 		return fmt.Errorf("failed to load config file: %s", err)
 	}
@@ -62,7 +56,7 @@ func run() error {
 	})
 
 	w, err := worker.NewWorker(worker.WithConfig(cfg), worker.WithContext(ctx), worker.WithStateStorage(storage),
-		worker.WithVersion(appVersion))
+		worker.WithVersion(app.Version))
 	if err != nil {
 		return fmt.Errorf("failed to create Worker instance: %s", err)
 	}


### PR DESCRIPTION
This commit brings a minor rethinking about how we define our main executables.
First, there is no need to define "magic" global variables, such as "appVersion" and other flags, that are used in our CMD internals - all is done automatically. The required parameters can be extracted from the new "AppContext" argument, that is passed to all runner functions.
Then, there is no need to specify the application name - now it is taken from the actual file name, and it means that it will contain sometimes required suffixes, such as "_linux_x86_64".