### PR TITLE
fix: restore setting version in apps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ ifeq ($(WITH_NL),true)
     NL_TAGS := nl
 endif
 
-LDFLAGS = -X cmd.app.Version=$(FULL_VERSION)
+LDFLAGS = -X github.com/sonm-io/core/cmd.appVersion=$(FULL_VERSION)
 
 .PHONY: fmt vet test
 

--- a/cmd/cobra.go
+++ b/cmd/cobra.go
@@ -13,8 +13,10 @@ import (
 )
 
 var (
-	app = AppContext{
-		Name: path.Base(os.Args[0]),
+	appVersion string
+	app        = AppContext{
+		Name:    path.Base(os.Args[0]),
+		Version: appVersion,
 	}
 	showVersion bool
 )


### PR DESCRIPTION
Suddenly, go doesn't allow to set a nested variable through link arguments, only strings.