### PR TITLE
feat: activate nice market API on Worker matcher

### DIFF
--- a/insonmnia/worker/options.go
+++ b/insonmnia/worker/options.go
@@ -163,7 +163,7 @@ func (m *options) exportKey() error {
 
 func (m *options) setupBlockchainAPI() error {
 	if m.eth == nil {
-		eth, err := blockchain.NewAPI(m.ctx, blockchain.WithConfig(m.cfg.Blockchain))
+		eth, err := blockchain.NewAPI(m.ctx, blockchain.WithConfig(m.cfg.Blockchain), blockchain.WithNiceMarket())
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
This allows to see why a Worker's matcher failed to open a deal, instead
of just "transaction failed".