### PR TITLE
refactor: deprecate TaskManagement service

### DIFF
--- a/cmd/cli/commands/client.go
+++ b/cmd/cli/commands/client.go
@@ -51,13 +51,13 @@ func newDealsClient(ctx context.Context) (sonm.DealManagementClient, error) {
 	return sonm.NewDealManagementClient(cc), nil
 }
 
-func newTaskClient(ctx context.Context) (sonm.TaskManagementClient, error) {
+func newTaskClient(ctx context.Context) (sonm.WorkerClient, error) {
 	cc, err := newClientConn(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	return sonm.NewTaskManagementClient(cc), nil
+	return sonm.NewWorkerClient(cc), nil
 }
 
 func newTokenManagementClient(ctx context.Context) (sonm.TokenManagementClient, error) {

--- a/cmd/cli/commands/common.go
+++ b/cmd/cli/commands/common.go
@@ -135,15 +135,15 @@ func newCommandError(message string, err error) *commandError {
 }
 
 // ShowError prints message and chained error in requested format
-func ShowError(cmd *cobra.Command, message string, err error) {
+func ShowError(printer Printer, message string, err error) {
 	if isSimpleFormat() {
 		if err != nil {
-			cmd.Printf("[ERR] %s: %s\r\n", message, err.Error())
+			printer.Printf("[ERR] %s: %s\r\n", message, err.Error())
 		} else {
-			cmd.Printf("[ERR] %s\r\n", message)
+			printer.Printf("[ERR] %s\r\n", message)
 		}
 	} else {
-		cmd.Println(newCommandError(message, err).ToJSONString())
+		printer.Println(newCommandError(message, err).ToJSONString())
 	}
 }
 

--- a/cmd/cli/commands/printers.go
+++ b/cmd/cli/commands/printers.go
@@ -142,7 +142,7 @@ func printNodeTaskStatus(printer Printer, reply *sonm.DealInfoReply) {
 		printer.Printf("Running:")
 		printTaskStatuses(idented, reply.GetRunning())
 		printer.Printf("Completed:")
-		printTaskStatuses(idented, reply.GetRunning())
+		printTaskStatuses(idented, reply.GetCompleted())
 	} else {
 		showJSON(printer, reply)
 	}

--- a/cmd/cli/commands/printers.go
+++ b/cmd/cli/commands/printers.go
@@ -51,7 +51,7 @@ func (p printerFlags) WarningSuppressed() bool {
 	return int(p)&suppressWarnings == 1
 }
 
-func printTaskStatus(cmd *cobra.Command, id string, taskStatus *sonm.TaskStatusReply) {
+func printTaskStatus(cmd Printer, id string, taskStatus *sonm.TaskStatusReply) {
 	if isSimpleFormat() {
 		cmd.Printf("ID: %s\r\n", id)
 		cmd.Printf("  Image:  %s\r\n", taskStatus.GetImageName())
@@ -117,17 +117,34 @@ func printNetworkSpec(cmd *cobra.Command, spec *sonm.NetworkSpec) {
 	}
 }
 
-func printNodeTaskStatus(cmd *cobra.Command, tasksMap map[string]*sonm.TaskStatusReply) {
+func printTaskStatuses(printer Printer, statuses map[string]*sonm.TaskStatusReply) {
 	if isSimpleFormat() {
-		if len(tasksMap) == 0 {
-			cmd.Printf("No active tasks\r\n")
-			return
-		}
-		for id, task := range tasksMap {
-			printTaskStatus(cmd, id, task)
+		if len(statuses) == 0 {
+			printer.Printf("No active tasks\r\n")
+		} else {
+			printer.Printf("\r\n")
+			for id, task := range statuses {
+				printTaskStatus(printer, id, task)
+			}
 		}
 	} else {
-		showJSON(cmd, tasksMap)
+		showJSON(printer, statuses)
+	}
+}
+
+func printNodeTaskStatus(printer Printer, reply *sonm.DealInfoReply) {
+	idented := &IndentPrinter{
+		Subprinter: printer,
+		IdentCount: 2,
+		Ident:      ' ',
+	}
+	if isSimpleFormat() {
+		printer.Printf("Running:")
+		printTaskStatuses(idented, reply.GetRunning())
+		printer.Printf("Completed:")
+		printTaskStatuses(idented, reply.GetRunning())
+	} else {
+		showJSON(printer, reply)
 	}
 }
 

--- a/cmd/cli/commands/tasks.go
+++ b/cmd/cli/commands/tasks.go
@@ -208,10 +208,12 @@ var taskStatusCmd = &cobra.Command{
 			return fmt.Errorf("cannot create client connection: %v", err)
 		}
 
-		ctx = newDealContext(ctx, args[0])
+		// Check if passed value is valid bigint
+		_, err = sonm.NewBigIntFromString(args[0])
 		if err != nil {
 			return err
 		}
+		ctx = newDealContext(ctx, args[0])
 
 		taskID := args[1]
 		req := &sonm.ID{
@@ -235,6 +237,12 @@ var taskJoinNetworkCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx, cancel := newTimeoutContext()
 		defer cancel()
+
+		// Check if passed dealID value is valid bigint
+		_, err := sonm.NewBigIntFromString(args[0])
+		if err != nil {
+			return err
+		}
 
 		node, err := newTaskClient(ctx)
 		if err != nil {

--- a/cmd/cli/commands/worker_tasks.go
+++ b/cmd/cli/commands/worker_tasks.go
@@ -16,7 +16,7 @@ var workerTasksCmd = &cobra.Command{
 			return fmt.Errorf("cannot get task list: %v", err)
 		}
 
-		printNodeTaskStatus(cmd, list.GetInfo())
+		printTaskStatuses(cmd, list.GetInfo())
 		return nil
 	},
 }

--- a/insonmnia/node/server.go
+++ b/insonmnia/node/server.go
@@ -51,6 +51,7 @@ type Services interface {
 	RegisterGRPC(server *grpc.Server) error
 	RegisterREST(server *rest.Server) error
 	Interceptor() grpc.UnaryServerInterceptor
+	StreamInterceptor() grpc.StreamServerInterceptor
 	Run(ctx context.Context) error
 }
 
@@ -126,6 +127,7 @@ func newServer(cfg nodeConfig, services Services, options ...ServerOption) (*Ser
 			xgrpc.RequestLogInterceptor(m.log.Desugar(), []string{"PushTask", "PullTask"}),
 			xgrpc.VerifyInterceptor(),
 			xgrpc.UnaryServerInterceptor(services.Interceptor()),
+			xgrpc.StreamServerInterceptor(services.StreamInterceptor()),
 		}, opts.optionsGRPC...)
 
 		m.serverGRPC = xgrpc.NewServer(m.log.Desugar(), options...)

--- a/insonmnia/node/services.go
+++ b/insonmnia/node/services.go
@@ -11,7 +11,7 @@ import (
 )
 
 type services struct {
-	worker         sonm.WorkerManagementServer
+	worker         *workerAPI
 	market         sonm.MarketServer
 	deals          sonm.DealManagementServer
 	tasks          sonm.TaskManagementServer
@@ -44,6 +44,7 @@ func (m *services) RegisterGRPC(server *grpc.Server) error {
 	}
 
 	sonm.RegisterWorkerManagementServer(server, m.worker)
+	sonm.RegisterWorkerServer(server, m.worker)
 	sonm.RegisterMarketServer(server, m.market)
 	sonm.RegisterDealManagementServer(server, m.deals)
 	sonm.RegisterTaskManagementServer(server, m.tasks)
@@ -65,6 +66,9 @@ func (m *services) RegisterREST(server *rest.Server) error {
 	}
 
 	if err := server.RegisterService((*sonm.WorkerManagementServer)(nil), m.worker); err != nil {
+		return err
+	}
+	if err := server.RegisterService((*sonm.WorkerServer)(nil), m.worker); err != nil {
 		return err
 	}
 	if err := server.RegisterService((*sonm.MarketServer)(nil), m.market); err != nil {
@@ -101,7 +105,11 @@ func (m *services) RegisterREST(server *rest.Server) error {
 }
 
 func (m *services) Interceptor() grpc.UnaryServerInterceptor {
-	return m.worker.(*workerAPI).intercept
+	return m.worker.intercept
+}
+
+func (m *services) StreamInterceptor() grpc.StreamServerInterceptor {
+	return m.worker.streamIntercept
 }
 
 func (m *services) Run(ctx context.Context) error {

--- a/insonmnia/node/tasks.go
+++ b/insonmnia/node/tasks.go
@@ -14,6 +14,7 @@ import (
 	"google.golang.org/grpc/status"
 )
 
+//Deprecated, use workerAPI via interceptor
 type tasksAPI struct {
 	remotes *remoteOptions
 	log     *zap.SugaredLogger

--- a/proto/node.proto
+++ b/proto/node.proto
@@ -16,6 +16,7 @@ package sonm;
 
 // TaskManagement describe a bunch of methods
 // to manage tasks running into the SONM network
+// Deprecated: use serviceWorker instead and pass dealID via context
 service TaskManagement {
     // List produces a list of all tasks running on different SONM nodes
     rpc List(TaskListRequest) returns (TaskListReply) {}

--- a/util/xgrpc/options.go
+++ b/util/xgrpc/options.go
@@ -73,6 +73,13 @@ func UnaryServerInterceptor(u grpc.UnaryServerInterceptor) ServerOption {
 	}
 }
 
+// UnaryServerInterceptor adds an unary interceptor to the chain.
+func StreamServerInterceptor(s grpc.StreamServerInterceptor) ServerOption {
+	return func(o *options) {
+		o.interceptors.s = append(o.interceptors.s, s)
+	}
+}
+
 type options struct {
 	options      []grpc.ServerOption
 	interceptors struct {


### PR DESCRIPTION
This PR deprecates Node TaskManagement service and replaces it with Worker service. 
All requests in node are proxied in interceptors as is, workere selection is based via dealID passed via deal context variable.