### PR TITLE
fix: check for deal existance before processing

### DIFF
--- a/connor/engine.go
+++ b/connor/engine.go
@@ -188,7 +188,6 @@ func (e *engine) RestoreOrder(ctx context.Context, order *types.Corder) {
 
 func (e *engine) RestoreDeal(ctx context.Context, deal *sonm.Deal) {
 	e.log.Debug("restoring deal", zap.String("id", deal.GetId().Unwrap().String()))
-	e.state.AddDeal(e.dealFactory.FromDeal(deal))
 	go e.processDeal(ctx, deal)
 }
 
@@ -316,8 +315,8 @@ func (e *engine) waitForDeal(ctx context.Context, order *types.Corder) {
 
 			e.CreateOrder(order)
 			if deal != nil {
-				if !e.state.HasDeal(e.dealFactory.FromDeal(deal)) {
-					e.processDeal(ctx, deal)
+				if ok := e.state.AddDeal(e.dealFactory.FromDeal(deal)); ok {
+					go e.processDeal(ctx, deal)
 				}
 			}
 
@@ -834,6 +833,7 @@ func (e *engine) restoreMarketState(ctx context.Context) error {
 		zap.Int("deals_restore", len(dealsToRestore)))
 
 	for _, deal := range dealsToRestore {
+		e.state.AddDeal(e.dealFactory.FromDeal(deal))
 		e.RestoreDeal(ctx, deal)
 	}
 
@@ -879,7 +879,7 @@ func (e *engine) adoptExternalDeals(ctx context.Context) {
 	}
 
 	for _, deal := range deals.GetDeal() {
-		if !e.state.HasDeal(e.dealFactory.FromDeal(deal)) {
+		if ok := e.state.AddDeal(e.dealFactory.FromDeal(deal)); ok {
 			adoptedDealsCounter.Inc()
 			e.RestoreDeal(ctx, deal)
 		}

--- a/connor/engine.go
+++ b/connor/engine.go
@@ -316,7 +316,9 @@ func (e *engine) waitForDeal(ctx context.Context, order *types.Corder) {
 
 			e.CreateOrder(order)
 			if deal != nil {
-				e.processDeal(ctx, deal)
+				if !e.state.HasDeal(e.dealFactory.FromDeal(deal)) {
+					e.processDeal(ctx, deal)
+				}
 			}
 
 			return

--- a/connor/state.go
+++ b/connor/state.go
@@ -109,18 +109,23 @@ func (s *state) DeleteQueuedOrder(ord *types.Corder) {
 		zap.Int("queued", len(s.queuedOrders)))
 }
 
-func (s *state) AddDeal(deal *types.Deal) {
+func (s *state) AddDeal(deal *types.Deal) bool {
 	id := deal.GetId().Unwrap().String()
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	s.deals[id] = &dealQuality{
-		Deal:   deal,
-		ByLogs: 1,
-		ByPool: 1,
+	if _, ok := s.deals[id]; !ok {
+		s.deals[id] = &dealQuality{
+			Deal:   deal,
+			ByLogs: 1,
+			ByPool: 1,
+		}
+		s.log.Debug("deal added", zap.String("deal_id", id), zap.Int("total", len(s.deals)))
+		return true
 	}
-	s.log.Debug("deal added", zap.String("deal_id", id), zap.Int("total", len(s.deals)))
+
+	return false
 }
 
 func (s *state) DeleteDeal(deal *types.Deal) {


### PR DESCRIPTION
We can get a race when `waitForDeal`'s timer ticks after the `waitForExternalUpdates`'s one.
Deal will be traited as externally opened and its processing will be started. Then waitForDeal will make a tick, detected new deal opened for known order and add the same deal to the processing. This commit adds check that deal is not in the state storage before starting the processing routine.