### PR TITLE
chore: print CPU model in worker devices cmd

### DIFF
--- a/cmd/cli/commands/printers.go
+++ b/cmd/cli/commands/printers.go
@@ -164,6 +164,7 @@ func printDeviceList(cmd *cobra.Command, dev *sonm.DevicesReply) {
 	if isSimpleFormat() {
 		cpu := dev.GetCPU().GetDevice()
 		cmd.Printf("CPU: %d cores at %d sockets\r\n", cpu.GetCores(), cpu.GetSockets())
+		cmd.Printf("  %s\r\n", cpu.GetModelName())
 		printBenchmarkGroup(cmd, dev.GetCPU().GetBenchmarks())
 
 		ram := datasize.NewByteSize(dev.GetRAM().GetDevice().GetAvailable()).HumanReadable()


### PR DESCRIPTION
Closes #1521

```
CPU: 2 cores at 1 sockets
  Intel(R) Core(TM) i5-5257U CPU @ 2.70GHz
  Benchmarks:
    cpu-cryptonight: 40
    cpu-sysbench-multi: 5406
    cpu-sysbench-single: 30677
    cpu-cores: 2
```