### PR TITLE
fix: reduce bid price predictor deviation

### DIFF
--- a/optimus/market.go
+++ b/optimus/market.go
@@ -4,29 +4,45 @@ import (
 	"context"
 
 	"github.com/sonm-io/core/proto"
+	"golang.org/x/sync/errgroup"
 )
 
 const (
-	ordersPullLimit       = 1000
+	pullLimit             = 1000
+	pullConcurrency       = 256
 	ordersPreallocateSize = 1 << 13
 )
 
 type MarketOrder = sonm.DWHOrder
 
+type OrderRequestFactory func() *sonm.OrdersRequest
+
+func DefaultOrderRequestFactory(cfg marketplaceConfig) OrderRequestFactory {
+	return func() *sonm.OrdersRequest {
+		return &sonm.OrdersRequest{
+			Type:   sonm.OrderType_BID,
+			Status: sonm.OrderStatus_ORDER_ACTIVE,
+			Price: &sonm.MaxMinBig{
+				Min: cfg.MinPrice.GetPerSecond(),
+			},
+		}
+	}
+}
+
 type marketScanner struct {
-	cfg marketplaceConfig
-	dwh sonm.DWHClient
+	dwh            sonm.DWHClient
+	requestFactory OrderRequestFactory
 }
 
 func newMarketScanner(cfg marketplaceConfig, dwh sonm.DWHClient) *marketScanner {
 	return &marketScanner{
-		cfg: cfg,
-		dwh: dwh,
+		dwh:            dwh,
+		requestFactory: DefaultOrderRequestFactory(cfg),
 	}
 }
 
 func (m *marketScanner) ActiveOrders(ctx context.Context) ([]*MarketOrder, error) {
-	cursor := newCursor(m.cfg, m.dwh)
+	cursor := newCursor(m.dwh, m.requestFactory)
 
 	orders := make([]*MarketOrder, 0, ordersPreallocateSize)
 	for {
@@ -45,32 +61,92 @@ func (m *marketScanner) ActiveOrders(ctx context.Context) ([]*MarketOrder, error
 	return orders, nil
 }
 
-type cursor struct {
-	cfg    marketplaceConfig
-	dwh    sonm.DWHClient
-	offset uint64
-	limit  uint64
+func (m *marketScanner) ExecutedOrders(ctx context.Context, orderType sonm.OrderType) ([]*MarketOrder, error) {
+	response, err := m.dwh.GetDeals(ctx, &sonm.DealsRequest{})
+	if err != nil {
+		return nil, err
+	}
+
+	orderIds := make([]*sonm.BigInt, 0, len(response.Deals))
+	for _, deal := range response.Deals {
+		if orderType == sonm.OrderType_BID || orderType == sonm.OrderType_ANY {
+			orderIds = append(orderIds, deal.GetDeal().GetBidID())
+		}
+		if orderType == sonm.OrderType_ASK || orderType == sonm.OrderType_ANY {
+			orderIds = append(orderIds, deal.GetDeal().GetAskID())
+		}
+
+		// Ignore deals that costs less than 1e-6 USD/h.
+		if deal.GetDeal().GetPrice().Cmp(sonm.NewBigIntFromInt(277777777)) <= 0 {
+			continue
+		}
+	}
+
+	ch := make(chan int, len(orderIds))
+	wg := errgroup.Group{}
+	orders := make([]*MarketOrder, len(orderIds))
+	for numWorker := 0; numWorker < pullConcurrency; numWorker++ {
+		wg.Go(func() error {
+			for id := range ch {
+				select {
+				case <-ctx.Done():
+					// Still exhaust the channel.
+					continue
+				default:
+				}
+
+				order, err := m.dwh.GetOrderDetails(ctx, orderIds[id])
+				if err != nil {
+					return err
+				}
+
+				orders[id] = order
+			}
+
+			return nil
+		})
+	}
+
+	for id := range orderIds {
+		ch <- id
+	}
+	close(ch)
+
+	if err := wg.Wait(); err != nil {
+		return nil, err
+	}
+
+	// Leave only orders without counterparty.
+	filteredOrders := make([]*MarketOrder, 0, len(orders))
+	for _, order := range orders {
+		if order.GetOrder().GetCounterpartyID().IsZero() {
+			filteredOrders = append(filteredOrders, order)
+		}
+	}
+
+	return filteredOrders, nil
 }
 
-func newCursor(cfg marketplaceConfig, dwh sonm.DWHClient) *cursor {
+type cursor struct {
+	dwh            sonm.DWHClient
+	offset         uint64
+	limit          uint64
+	requestFactory OrderRequestFactory
+}
+
+func newCursor(dwh sonm.DWHClient, requestFactory OrderRequestFactory) *cursor {
 	return &cursor{
-		cfg:    cfg,
-		dwh:    dwh,
-		offset: 0,
-		limit:  ordersPullLimit,
+		dwh:            dwh,
+		offset:         0,
+		limit:          pullLimit,
+		requestFactory: requestFactory,
 	}
 }
 
 func (m *cursor) Next(ctx context.Context) ([]*MarketOrder, error) {
-	request := &sonm.OrdersRequest{
-		Type:   sonm.OrderType_ANY,
-		Status: sonm.OrderStatus_ORDER_ACTIVE,
-		Price: &sonm.MaxMinBig{
-			Min: m.cfg.MinPrice.GetPerSecond(),
-		},
-		Offset: m.offset,
-		Limit:  m.limit,
-	}
+	request := m.requestFactory()
+	request.Offset = m.offset
+	request.Limit = m.limit
 
 	response, err := m.dwh.GetOrders(ctx, request)
 	if err != nil {

--- a/optimus/market_cache.go
+++ b/optimus/market_cache.go
@@ -13,32 +13,28 @@ import (
 
 type MarketScanner interface {
 	ActiveOrders(ctx context.Context) ([]*MarketOrder, error)
+	ExecutedOrders(ctx context.Context, orderType sonm.OrderType) ([]*MarketOrder, error)
 }
 
-// MarketCache is a communication bus between fetching market orders and its
-// consumers.
-// Required, because there are multiple workers can be targeted by Optimus.
-type MarketCache struct {
+type cache struct {
 	mu             sync.Mutex
-	market         MarketScanner
 	orders         []*MarketOrder
 	updatedAt      time.Time
 	updateInterval time.Duration
 }
 
-func newMarketCache(market MarketScanner, updateInterval time.Duration) *MarketCache {
-	return &MarketCache{
-		market:         market,
+func newCache(updateInterval time.Duration) *cache {
+	return &cache{
 		updateInterval: updateInterval,
 	}
 }
 
-func (m *MarketCache) ActiveOrders(ctx context.Context) ([]*MarketOrder, error) {
+func (m *cache) get(ctx context.Context, fn func(ctx context.Context) ([]*MarketOrder, error)) ([]*MarketOrder, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
 	if time.Since(m.updatedAt) >= m.updateInterval {
-		orders, err := m.market.ActiveOrders(ctx)
+		orders, err := fn(ctx)
 		if err != nil {
 			return nil, err
 		}
@@ -48,6 +44,36 @@ func (m *MarketCache) ActiveOrders(ctx context.Context) ([]*MarketOrder, error) 
 	}
 
 	return m.orders, nil
+}
+
+// MarketCache is a communication bus between fetching market orders and its
+// consumers.
+// Required, because there are multiple workers can be targeted by Optimus.
+type MarketCache struct {
+	market MarketScanner
+
+	activeOrdersCache   *cache
+	executedOrdersCache *cache
+}
+
+func newMarketCache(market MarketScanner, updateInterval time.Duration) *MarketCache {
+	return &MarketCache{
+		market:              market,
+		activeOrdersCache:   newCache(updateInterval),
+		executedOrdersCache: newCache(updateInterval),
+	}
+}
+
+func (m *MarketCache) ActiveOrders(ctx context.Context) ([]*MarketOrder, error) {
+	return m.activeOrdersCache.get(ctx, func(ctx context.Context) ([]*MarketOrder, error) {
+		return m.market.ActiveOrders(ctx)
+	})
+}
+
+func (m *MarketCache) ExecutedOrders(ctx context.Context, orderType sonm.OrderType) ([]*MarketOrder, error) {
+	return m.executedOrdersCache.get(ctx, func(ctx context.Context) ([]*MarketOrder, error) {
+		return m.market.ExecutedOrders(ctx, orderType)
+	})
 }
 
 type PredefinedMarketCache struct {
@@ -81,5 +107,9 @@ func NewPredefinedMarketCache(orders []*sonm.BigInt, market blockchain.MarketAPI
 }
 
 func (m *PredefinedMarketCache) ActiveOrders(ctx context.Context) ([]*MarketOrder, error) {
+	return m.Orders, nil
+}
+
+func (m *PredefinedMarketCache) ExecutedOrders(ctx context.Context, orderType sonm.OrderType) ([]*MarketOrder, error) {
 	return m.Orders, nil
 }

--- a/proto/marketplace.go
+++ b/proto/marketplace.go
@@ -78,6 +78,10 @@ func (m *Benchmarks) CPUCores() uint64 {
 	return m.Get(2)
 }
 
+func (m *Benchmarks) SetCPUCores(v uint64) {
+	m.Values[2] = v
+}
+
 func (m *Benchmarks) RAMSize() uint64 {
 	return m.Get(3)
 }
@@ -96,6 +100,10 @@ func (m *Benchmarks) NetTrafficOut() uint64 {
 
 func (m *Benchmarks) GPUCount() uint64 {
 	return m.Get(7)
+}
+
+func (m *Benchmarks) SetGPUCount(v uint64) {
+	m.Values[7] = v
 }
 
 func (m *Benchmarks) GPUMem() uint64 {


### PR DESCRIPTION
Bid price predictor is now trained on BID orders that were successfully converted into deals. This should reduce the deviation between the predicted price and the actual one.
Also, Optimus is now trained on BID orders, while previously all active orders were used.

Internals:
- Renamed "optimus/cache" to "optimus/market_cache" for better showing its aim.
- Added setters for some benchmarks.

Analyzing currently pushed orders on the marketplace shows the following statistics on deviation, which is calculated as `predicted_price / price`:

Before:
```bash
Mean     = 4.167913477297036; 
Variance = 90.5015091172015; 
StdDev   = 9.513228112328722; 
Median   = 1.2999912360382637
```

After:
```bash
Mean     = 1.1611107487160566; 
Variance = 0.3367232091146091; 
StdDev   = 0.5802785616534606; 
Median   = 0.9792052969262874
```
