### PR TITLE
fix: memory leak in Node and everywhere

### DIFF
--- a/util/xgrpc/client.go
+++ b/util/xgrpc/client.go
@@ -15,7 +15,7 @@ func newTracer() opentracing.Tracer {
 	return basictracer.NewWithOptions(basictracer.Options{
 		ShouldSample:   func(traceID uint64) bool { return true },
 		MaxLogsPerSpan: 100,
-		Recorder:       basictracer.NewInMemoryRecorder(),
+		Recorder:       newNoOpRecorder(),
 	})
 }
 

--- a/util/xgrpc/options.go
+++ b/util/xgrpc/options.go
@@ -62,8 +62,16 @@ func TraceInterceptor(tracer opentracing.Tracer) ServerOption {
 	}
 }
 
+type noopRecorder struct{}
+
+func newNoOpRecorder() *noopRecorder {
+	return &noopRecorder{}
+}
+
+func (noopRecorder) RecordSpan(span basictracer.RawSpan) {}
+
 func DefaultTraceInterceptor() ServerOption {
-	return TraceInterceptor(basictracer.New(basictracer.NewInMemoryRecorder()))
+	return TraceInterceptor(basictracer.New(newNoOpRecorder()))
 }
 
 // UnaryServerInterceptor adds an unary interceptor to the chain.


### PR DESCRIPTION
Node and other servers under the medium/high load should no longer suffer from a memory leak.

Internals:
- For a long time, we used the in-memory recorder for tracing. However, it doesn't make sense, because internally it just saved all spans without reason and cleaning up. Now we use a no-op recorder because seems everything works fine without span recording.