### PR TITLE
feat: adapt extra orders in Connor

### DIFF
--- a/connor/config.go
+++ b/connor/config.go
@@ -34,7 +34,7 @@ type marketConfig struct {
 	Counterparty common.Address     `yaml:"counterparty"`
 	PriceControl priceControlConfig `yaml:"price_control"`
 	Benchmarks   map[string]uint64  `yaml:"benchmarks" required:"true"`
-	NoCancel     bool               `yaml:"no_cancel"`
+	AdoptOrders  bool               `yaml:"adopt_orders"`
 
 	benchmarkID int
 }

--- a/connor/config.go
+++ b/connor/config.go
@@ -34,6 +34,7 @@ type marketConfig struct {
 	Counterparty common.Address     `yaml:"counterparty"`
 	PriceControl priceControlConfig `yaml:"price_control"`
 	Benchmarks   map[string]uint64  `yaml:"benchmarks" required:"true"`
+	NoCancel     bool               `yaml:"no_cancel"`
 
 	benchmarkID int
 }

--- a/connor/engine.go
+++ b/connor/engine.go
@@ -845,8 +845,16 @@ func (e *engine) restoreMarketState(ctx context.Context) error {
 		e.RestoreOrder(ctx, ord)
 	}
 
-	for _, ord := range set.Cancel {
-		e.CancelOrder(ord)
+	if e.cfg.Market.NoCancel {
+		e.log.Debug("no_cancel option is enabled, restoring excess orders")
+		for _, ord := range set.Cancel {
+			e.RestoreOrder(ctx, ord)
+		}
+	} else {
+		e.log.Debug("no_cancel option is disabled, cancelling excess orders")
+		for _, ord := range set.Cancel {
+			e.CancelOrder(ord)
+		}
 	}
 
 	return nil

--- a/connor/engine.go
+++ b/connor/engine.go
@@ -845,13 +845,13 @@ func (e *engine) restoreMarketState(ctx context.Context) error {
 		e.RestoreOrder(ctx, ord)
 	}
 
-	if e.cfg.Market.NoCancel {
-		e.log.Debug("no_cancel option is enabled, restoring excess orders")
+	if e.cfg.Market.AdoptOrders {
+		e.log.Debug("adopt_orders option is enabled, restoring excess orders")
 		for _, ord := range set.Cancel {
 			e.RestoreOrder(ctx, ord)
 		}
 	} else {
-		e.log.Debug("no_cancel option is disabled, cancelling excess orders")
+		e.log.Debug("adopt_orders option is disabled, cancelling excess orders")
 		for _, ord := range set.Cancel {
 			e.CancelOrder(ord)
 		}

--- a/etc/connor.yaml
+++ b/etc/connor.yaml
@@ -13,6 +13,11 @@ market:
   # only for specified supplier.
   # counterparty: 0xD0E743fFDBaEdAa3cf4E3232f3C1aB18ee9ca4aB
 
+  # set to true if Connor should adapt excess orders
+  # (which are not fits in the target set), otherwise, orders will be canceled.
+  # Default: false
+  # no_cancel: false
+
   price_control:
     # what part of the real market price will be used to
     # create orders on the market

--- a/etc/connor.yaml
+++ b/etc/connor.yaml
@@ -16,7 +16,7 @@ market:
   # set to true if Connor should adapt excess orders
   # (which are not fits in the target set), otherwise, orders will be canceled.
   # Default: false
-  # no_cancel: false
+  # adopt_orders: false
 
   price_control:
     # what part of the real market price will be used to


### PR DESCRIPTION
This commit adds config option that change `restoreMarketState` behavior.
If `no_cancel` parameter is enabled, Connor will adapt orders that not fits in target orders set.