### PR TITLE
feat: generalized log parser for Connor.

### DIFF
--- a/connor/antifraud/config.go
+++ b/connor/antifraud/config.go
@@ -8,21 +8,32 @@ import (
 )
 
 type ProcessorConfig struct {
-	Format          string        `yaml:"format" required:""`
+	Format          string        `yaml:"format" required:"true"`
 	TrackInterval   time.Duration `yaml:"track_interval" default:"10s"`
 	TaskWarmupDelay time.Duration `yaml:"warmup_delay" required:"true"`
 	DecayTime       float64       `yaml:"decay_time" required:"true"`
-	LogDir          string        `yaml:"log_dir"`
+}
+
+type LogProcessorConfig struct {
+	ProcessorConfig `yaml:",inline"`
+	Pattern         string  `yaml:"pattern" required:"true"`
+	Field           int     `yaml:"field"`
+	Multiplier      float64 `yaml:"multiplier" required:"true"`
+	LogDir          string  `yaml:"log_dir"`
+}
+
+type PoolProcessorConfig struct {
+	ProcessorConfig `yaml:",inline"`
 }
 
 type Config struct {
-	TaskQuality            float64          `yaml:"task_quality" required:"true"`
-	QualityCheckInterval   time.Duration    `yaml:"quality_check_interval" default:"15s"`
-	BlacklistCheckInterval time.Duration    `yaml:"blacklist_check_interval" default:"5m"`
-	ConnectionTimeout      time.Duration    `yaml:"connection_timeout" default:"60s"`
-	LogProcessorConfig     ProcessorConfig  `yaml:"log_processor"`
-	PoolProcessorConfig    ProcessorConfig  `yaml:"pool_processor"`
-	Whitelist              []common.Address `yaml:"whitelist"`
+	TaskQuality            float64             `yaml:"task_quality" required:"true"`
+	QualityCheckInterval   time.Duration       `yaml:"quality_check_interval" default:"15s"`
+	BlacklistCheckInterval time.Duration       `yaml:"blacklist_check_interval" default:"5m"`
+	ConnectionTimeout      time.Duration       `yaml:"connection_timeout" default:"60s"`
+	LogProcessorConfig     LogProcessorConfig  `yaml:"log_processor"`
+	PoolProcessorConfig    PoolProcessorConfig `yaml:"pool_processor"`
+	Whitelist              []common.Address    `yaml:"whitelist"`
 }
 
 func (c Config) Validate() error {

--- a/connor/antifraud/log_processor.go
+++ b/connor/antifraud/log_processor.go
@@ -183,6 +183,14 @@ func (m *logProcessor) logParser(ctx context.Context, reader io.Reader) {
 
 		if strings.Contains(line, m.cfg.Pattern) {
 			fields := strings.Fields(line)
+
+			if m.cfg.Field >= len(fields) {
+				m.log.Warn("fields count is less than required",
+					zap.String("line", line),
+					zap.Int("fields_count", len(fields)))
+				continue
+			}
+
 			raw := fields[m.cfg.Field]
 			hashrate, err := strconv.ParseFloat(raw, 64)
 			if err != nil {

--- a/connor/antifraud/log_processor_test.go
+++ b/connor/antifraud/log_processor_test.go
@@ -21,17 +21,33 @@ func mklog(n int) string {
 
 func TestClaymoreLogParser(t *testing.T) {
 	rd := strings.NewReader(`ETH - Total Speed: 100.000 Mh/s, Total Shares: 127, Rejected: 0, Time: 00:02`)
-	p := &commonLogProcessor{log: zap.NewNop(), hashrate: atomic.NewFloat64(0)}
+	p := &logProcessor{
+		log:      zap.NewNop(),
+		hashrate: atomic.NewFloat64(0),
+		cfg: &LogProcessorConfig{
+			Pattern:    "Total Speed:",
+			Field:      4,
+			Multiplier: 1000000,
+		},
+	}
 
-	claymoreLogParser(context.Background(), p, rd)
+	p.logParser(context.Background(), rd)
 	assert.Equal(t, float64(100e6), p.hashrate.Load(), "new value should be parsed and set")
 }
 
 func TestClaymoreLogParser_InvalidLine(t *testing.T) {
 	rd := strings.NewReader(`Oops! Claymore failed`)
-	p := &commonLogProcessor{log: zap.NewNop(), hashrate: atomic.NewFloat64(100500)}
+	p := &logProcessor{
+		log:      zap.NewNop(),
+		hashrate: atomic.NewFloat64(100500),
+		cfg: &LogProcessorConfig{
+			Pattern:    "Total Speed:",
+			Field:      4,
+			Multiplier: 1000000,
+		},
+	}
 
-	claymoreLogParser(context.Background(), p, rd)
+	p.logParser(context.Background(), rd)
 	assert.Equal(t, float64(100500), p.hashrate.Load(), "previous value should be kept")
 }
 
@@ -39,9 +55,9 @@ func TestClaymoreLogParser_ContextCancel(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 
 	rd := strings.NewReader(mklog(1000))
-	p := &commonLogProcessor{log: zap.NewNop(), hashrate: atomic.NewFloat64(1.2345)}
+	p := &logProcessor{log: zap.NewNop(), hashrate: atomic.NewFloat64(1.2345)}
 	cancel()
 
-	claymoreLogParser(ctx, p, rd)
-	assert.Equal(t, float64(1.2345), p.hashrate.Load(), "new value should be parsed and set")
+	p.logParser(ctx, rd)
+	assert.Equal(t, float64(1.2345), p.hashrate.Load(), "previous value should be kept")
 }

--- a/connor/antifraud/pool_processor.go
+++ b/connor/antifraud/pool_processor.go
@@ -19,7 +19,7 @@ import (
 )
 
 type dwarfPoolProcessor struct {
-	cfg      *ProcessorConfig
+	cfg      *PoolProcessorConfig
 	log      *zap.Logger
 	wallet   common.Address
 	taskID   string
@@ -32,7 +32,7 @@ type dwarfPoolProcessor struct {
 	hashrateQueue   *lane.Queue
 }
 
-func newDwarfPoolProcessor(cfg *ProcessorConfig, log *zap.Logger, deal *types.Deal, taskID string) *dwarfPoolProcessor {
+func newDwarfPoolProcessor(cfg *PoolProcessorConfig, log *zap.Logger, deal *types.Deal, taskID string) *dwarfPoolProcessor {
 	workerID := fmt.Sprintf("c%s", deal.GetId().Unwrap().String())
 	l := log.Named("dwarfpool").With(
 		zap.String("deal_id", deal.GetId().Unwrap().String()),

--- a/connor/antifraud/processor.go
+++ b/connor/antifraud/processor.go
@@ -9,8 +9,7 @@ import (
 )
 
 const (
-	LogFormatClaymore       = "claymore"
-	LogFormatXMRing         = "xmrig"
+	LogFormatCommon         = "common"
 	PoolFormatDwarf         = "dwarf"
 	ProcessorFormatDisabled = "disabled"
 )
@@ -57,15 +56,10 @@ func NewProcessorFactory(cfg *Config) ProcessorFactory {
 	}
 
 	switch cfg.LogProcessorConfig.Format {
-	case LogFormatClaymore:
+	case LogFormatCommon:
 		log = func(deal *types.Deal, taskID string, opts ...Option) Processor {
 			o := makeOpts(opts...)
-			return newClaymoreLogProcessor(&cfg.LogProcessorConfig, o.logger, o.cc, deal, taskID)
-		}
-	case LogFormatXMRing:
-		log = func(deal *types.Deal, taskID string, opts ...Option) Processor {
-			o := makeOpts(opts...)
-			return newXmrigLogProcessor(&cfg.LogProcessorConfig, o.logger, o.cc, deal, taskID)
+			return newLogProcessor(&cfg.LogProcessorConfig, o.logger, o.cc, deal, taskID)
 		}
 	case ProcessorFormatDisabled:
 		log = func(deal *types.Deal, taskID string, opts ...Option) Processor {

--- a/connor/config.go
+++ b/connor/config.go
@@ -84,8 +84,7 @@ func (c *Config) validate() error {
 		antifraud.ProcessorFormatDisabled: true,
 	}
 	availableLogs := map[string]bool{
-		antifraud.LogFormatClaymore:       true,
-		antifraud.LogFormatXMRing:         true,
+		antifraud.LogFormatCommon:         true,
 		antifraud.ProcessorFormatDisabled: true,
 	}
 

--- a/etc/connor.yaml
+++ b/etc/connor.yaml
@@ -101,11 +101,21 @@ antifraud:
   connection_timeout: 60s
 
   log_processor:
-    format: claymore
+    format: common
     track_interval: 30s
     warmup_delay: 5m
     # EWMA decay factor, seconds
     decay_time: 900
+    # string pattern to detect meaningful line in logs
+    # Required.
+    pattern: "Total Speed:"
+    # field in a meaningful log line that contain numeric value
+    # with hashrate, counts from zero.
+    # Required.
+    field: 4
+    # multiplier for parsed value, used when field contains
+    # value in KHash/s or MHash/s. Use `1` if multiplier is not applicable for the value.
+    multiplier: 1000000
 
   pool_processor:
     format: dwarf


### PR DESCRIPTION
This commit removes particular log parser with a single one with a subset of settings which can be applied to (almost) any logs with a number in their fields.
Log reader now has 3 options related to logline analyzing:
1. String pattern to detect line with logs. E.g: line that has 'Total speed' in it will be analyzed, if it doesn't - we'll skip this line.
2. Field number in line. Describes which position in a string is a numeric value that shows task quality (hash rate, actually).
3. The multiplier for parsed value. Used when a field contains the value in KHash/s or MHash/s. Use `1` if the multiplier is not applicable for the value.