### PR TITLE
fix: proper worker startup, removing cocncurent container cleanup.

### DIFF
--- a/insonmnia/worker/container.go
+++ b/insonmnia/worker/container.go
@@ -34,6 +34,7 @@ func attachContainer(ctx context.Context, dockerClient *client.Client, ID string
 	log.S(ctx).Infof("attaching to container with ID: %s reference: %s", ID, d.Reference.String())
 
 	cont := containerDescriptor{
+		ID:          ID,
 		client:      dockerClient,
 		description: d,
 	}

--- a/insonmnia/worker/overseer.go
+++ b/insonmnia/worker/overseer.go
@@ -601,7 +601,7 @@ func (o *overseer) Stop(ctx context.Context, containerid string) error {
 }
 
 func (o *overseer) OnDealFinish(ctx context.Context, containerID string) error {
-	log.S(o.ctx).Debugf("ovs cleaning up %s on deal finish", containerID)
+	log.S(o.ctx).Debugf("overseer cleaning up %s on deal finish", containerID)
 	var isRunning bool
 	if info, err := o.client.ContainerInspect(ctx, containerID); err != nil {
 		return fmt.Errorf("failed to inspect container %s: %v", containerID, err)

--- a/insonmnia/worker/overseer.go
+++ b/insonmnia/worker/overseer.go
@@ -333,9 +333,6 @@ func (o *overseer) handleStreamingEvents(ctx context.Context, sinceUnix int64, f
 				o.mu.Unlock()
 
 				if !containerFound {
-					// NOTE: it could be orphaned container from our previous launch
-					log.G(ctx).Warn("unknown container with sonm tag will be removed", zap.String("id", id))
-					containerRemove(o.ctx, o.client, id)
 					continue
 				}
 				if statusFound {
@@ -604,6 +601,7 @@ func (o *overseer) Stop(ctx context.Context, containerid string) error {
 }
 
 func (o *overseer) OnDealFinish(ctx context.Context, containerID string) error {
+	log.S(o.ctx).Debugf("ovs cleaning up %s on deal finish", containerID)
 	var isRunning bool
 	if info, err := o.client.ContainerInspect(ctx, containerID); err != nil {
 		return fmt.Errorf("failed to inspect container %s: %v", containerID, err)
@@ -631,7 +629,7 @@ func (o *overseer) OnDealFinish(ctx context.Context, containerID string) error {
 		}
 	}
 	//This is needed in case container is uploaded into external registry
-	if descriptor.description.CommitOnStop {
+	if descriptor.description.PushOnStop {
 		if err := descriptor.upload(ctx); err != nil {
 			result = multierror.Append(result, err)
 		}

--- a/insonmnia/worker/server.go
+++ b/insonmnia/worker/server.go
@@ -395,6 +395,7 @@ func (m *Worker) setupHardware() error {
 }
 
 func (m *Worker) CancelDealTasks(dealID *sonm.BigInt) error {
+	log.S(m.ctx).Debugf("canceling deal's %s tasks", dealID)
 	var toDelete []*ContainerInfo
 
 	m.mu.Lock()


### PR DESCRIPTION
This PR fixes behaviour when containers are being concurently removed in
event watcher, resulting in error in OnDealFinish call
(e.g. inablility to push already removed container to registry).
If this situation took place on startup - worker would fail to start.