### PR TITLE
fix: default value for new benchmarks in Optimus

### DIFF
--- a/optimus/devices.go
+++ b/optimus/devices.go
@@ -364,6 +364,8 @@ func (m *DeviceManager) consume(benchmarks []uint64, consumer Consumer) (interfa
 			case consumer.SplittingAlgorithm():
 				if deviceBenchmark, ok := consumer.DeviceBenchmark(id); ok {
 					return deviceBenchmark.Result, true
+				} else {
+					return 0, true
 				}
 			}
 		}


### PR DESCRIPTION
When we add a new benchmark, Worker is required to be restarted to update those benchmarks. Hovewer when doing supplier price prediction, it is possible to forget setting some of the benchmarks, which results in completely ignoring values in Optimus. All of this results in invalid prediction. This commit fixes such behavior.