### PR TITLE
feat: return REST errors as JSON

### DIFF
--- a/insonmnia/node/worker.go
+++ b/insonmnia/node/worker.go
@@ -93,7 +93,7 @@ func (m *workerAPI) intercept(ctx context.Context, req interface{}, info *grpc.U
 	defer closer.Close()
 
 	t := reflect.ValueOf(cli)
-	method := t.MethodByName(xgrpc.MethodInfo(info.FullMethod).Method)
+	method := t.MethodByName(xgrpc.ParseMethodInfo(info.FullMethod).Method)
 	inValues := []reflect.Value{reflect.ValueOf(ctx), reflect.ValueOf(req)}
 	values := method.Call(inValues)
 
@@ -174,7 +174,7 @@ func (m *workerAPI) streamIntercept(srv interface{}, ss grpc.ServerStream, info 
 	defer closer.Close()
 
 	args := []interface{}{ctx}
-	methodName := xgrpc.MethodInfo(info.FullMethod).Method
+	methodName := xgrpc.ParseMethodInfo(info.FullMethod).Method
 
 	if !info.IsClientStream {
 		// first position is always context, second is request

--- a/util/rest/server.go
+++ b/util/rest/server.go
@@ -135,19 +135,20 @@ func (s *Server) ServeHTTP(rw http.ResponseWriter, request *http.Request) {
 
 	switch response := response.(type) {
 	case error:
-		if code/100 == 4 || code/100 == 5 {
-			s.log.Warn(response.Error())
+		data, err := json.Marshal(map[string]string{
+			"error": response.Error(),
+		})
+		if err != nil {
+			panic("unreachable")
 		}
 
-		rw.Write([]byte(fmt.Sprintf(`{"error": "%s"}`, response.Error())))
+		rw.Write(data)
 	case []byte:
 		rw.Write(response)
 	default:
 		rw.Write([]byte(fmt.Sprintf(`{"error": "internal server error: response type is %T"}`, response)))
 	}
 }
-
-// todo: log 4xx as warn, 5xx as errors, 2xx as info.
 
 func (s *Server) serveHTTP(request *http.Request) (int, interface{}) {
 	s.log.Debugf("serving URI: %s", request.RequestURI)

--- a/util/xgrpc/method.go
+++ b/util/xgrpc/method.go
@@ -4,22 +4,22 @@ import (
 	"strings"
 )
 
-type methodInfo struct {
+type MethodInfo struct {
 	Service string
 	Method  string
 }
 
-func (m *methodInfo) IntoTuple() (string, string) {
+func (m *MethodInfo) IntoTuple() (string, string) {
 	return m.Service, m.Method
 }
 
-func MethodInfo(fullMethod string) *methodInfo {
+func ParseMethodInfo(fullMethod string) *MethodInfo {
 	parts := strings.SplitN(fullMethod, "/", 3)
 	if len(parts) != 3 {
 		return nil
 	}
 
-	m := &methodInfo{
+	m := &MethodInfo{
 		Service: parts[1],
 		Method:  parts[2],
 	}

--- a/util/xgrpc/options.go
+++ b/util/xgrpc/options.go
@@ -271,7 +271,7 @@ func RequestLogInterceptor(truncatedMethods []string) ServerOption {
 
 func requestLogUnaryInterceptor(truncatedMethods map[string]bool) grpc.UnaryServerInterceptor {
 	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
-		executeRequestLogging(ctx, req, info.FullMethod, truncatedMethods[MethodInfo(info.FullMethod).Method])
+		executeRequestLogging(ctx, req, info.FullMethod, truncatedMethods[ParseMethodInfo(info.FullMethod).Method])
 		return handler(ctx, req)
 	}
 }
@@ -281,7 +281,7 @@ func requestLogStreamInterceptor(truncatedMethods map[string]bool) grpc.StreamSe
 		ss = &requestLoggingWrappedStream{
 			ServerStream: ss,
 			fullMethod:   info.FullMethod,
-			truncate:     truncatedMethods[MethodInfo(info.FullMethod).Method],
+			truncate:     truncatedMethods[ParseMethodInfo(info.FullMethod).Method],
 		}
 
 		return handler(srv, ss)


### PR DESCRIPTION
This commit slighty changes the REST server behavior by forcing to return errors as JSON for the sake of consistency.
Previously all errors were returned as a plain text. Now set set the application/json header and wrap the error into a JSON object.
Also the encoding/decoding logic was slightly changed - now if a Node is configured into secure mode it will return all responses as encoded byte array. This was done for symmetry, because one can have a client with encoder, and it expects the encoded response. Previously if a request failed in URI parsing stage a plain-text reply was returned. That was unexpected and completely helpless for people that try to work with secure Node in insecure manner. The error says something, but anyway you're unable to do anything with the Node unless you have a client-side encoder/decoder.