### PR TITLE
fix: decrease connection timeout in sonmmon

### DIFF
--- a/cmd/sonmmon/main.go
+++ b/cmd/sonmmon/main.go
@@ -155,7 +155,7 @@ func (w *WorkerStatus) waitFirst(ctx context.Context, log *zap.Logger, cc *grpc.
 }
 
 func (w *WorkerStatus) update(ctx context.Context, cc *grpc.ClientConn, addr string) error {
-	ctx, cancel := context.WithTimeout(ctx, 90*time.Second)
+	ctx, cancel := context.WithTimeout(ctx, 20*time.Second)
 	defer cancel()
 
 	client := sonm.NewWorkerManagementClient(cc)


### PR DESCRIPTION
Internals:
We're connecting to a worker we use the full address (eth@ip:port) and shouldn't go through rendezvous\relay, probably, we can use a shorter timeout to obtain the first status quickly. This change also should decrease time to show first sonmmon screen after reboot.