### PR TITLE
feat: forward deals support in Optimus

### DIFF
--- a/etc/optimus.yaml
+++ b/etc/optimus.yaml
@@ -156,8 +156,13 @@ workers:
     # Optional.
     # Default value is 60s.
     epoch: 60s
-    # How the bot should filter orders. Possible values are: "spot_only".
-    order_policy: spot_only
+    # How the bot should filter orders.
+    # This values limits the maximum order duration the Optimus should take.
+    # Omitting this value results in that only spot orders will be taken in
+    # action.
+    # Optional.
+    # Default value is 24h.
+    order_duration_threshold: 24h
     # Orders that haven't been sold for this interval will be canceled.
     # Optional.
     # Default value is 5m.

--- a/optimus/engine.go
+++ b/optimus/engine.go
@@ -646,15 +646,11 @@ func (m *workerEngine) filtersErr(deviceManager *DeviceManager, devices *sonm.De
 			return fmt.Errorf("expected order type %s, actual: %s", sonm.OrderType_BID, order.OrderType)
 		},
 		func(order *sonm.Order) error {
-			switch m.cfg.OrderPolicy {
-			case PolicySpotOnly:
-				if order.GetDuration() == 0 {
-					return nil
-				}
-				return fmt.Errorf("expected order duration 0, actual: %d", order.GetDuration())
+			if order.GetDuration() <= uint64(m.cfg.OrderDuration) {
+				return nil
 			}
 
-			return fmt.Errorf("unknown order policy: %s", m.cfg.OrderPolicy.String())
+			return fmt.Errorf("expected order duration <= %d, actual %d", m.cfg.OrderDuration, order.GetDuration())
 		},
 		func(order *sonm.Order) error {
 			if m.blacklist.IsAllowed(order.GetAuthorID().Unwrap()) {

--- a/optimus/predictor.go
+++ b/optimus/predictor.go
@@ -25,11 +25,11 @@ func predictionEngineConfig(cfg marketplaceConfig) *workerConfig {
 	}
 
 	return &workerConfig{
-		PrivateKey:  cfg.PrivateKey,
-		Epoch:       60 * time.Second,
-		OrderPolicy: 0,
-		DryRun:      false,
-		Identity:    sonm.IdentityLevel_ANONYMOUS,
+		PrivateKey:    cfg.PrivateKey,
+		Epoch:         60 * time.Second,
+		OrderDuration: 24 * time.Hour,
+		DryRun:        false,
+		Identity:      sonm.IdentityLevel_ANONYMOUS,
 		PriceThreshold: priceThreshold{
 			PriceThreshold: priceThresholdValue,
 		},


### PR DESCRIPTION
Now Optimus is capable of optimizing orders that are targeting to forward deals in addition to its previous spot-only support. In the config one can specify the maximum deal duration that Optimus will take in action.