### PR TITLE
feat: SSH on Worker host

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -75,6 +75,7 @@ require (
 	github.com/jinzhu/configor v0.0.0-20171024081003-6ecfe629230f
 	github.com/json-iterator/go v0.0.0-20180424004623-2ddf6d758266
 	github.com/karalabe/hid v0.0.0-20180420081245-2b4488a37358
+	github.com/kr/pty v1.1.3 // indirect
 	github.com/lann/builder v0.0.0-20180216234317-1b87b36280d0
 	github.com/lann/ps v0.0.0-20150810152359-62de8c46ede0
 	github.com/lib/pq v0.0.0-20180327071824-d34b9ff171c2

--- a/go.mod
+++ b/go.mod
@@ -75,7 +75,7 @@ require (
 	github.com/jinzhu/configor v0.0.0-20171024081003-6ecfe629230f
 	github.com/json-iterator/go v0.0.0-20180424004623-2ddf6d758266
 	github.com/karalabe/hid v0.0.0-20180420081245-2b4488a37358
-	github.com/kr/pty v1.1.3 // indirect
+	github.com/kr/pty v1.1.3
 	github.com/lann/builder v0.0.0-20180216234317-1b87b36280d0
 	github.com/lann/ps v0.0.0-20150810152359-62de8c46ede0
 	github.com/lib/pq v0.0.0-20180327071824-d34b9ff171c2

--- a/go.sum
+++ b/go.sum
@@ -143,6 +143,8 @@ github.com/json-iterator/go v0.0.0-20180424004623-2ddf6d758266/go.mod h1:+SdeFBv
 github.com/karalabe/hid v0.0.0-20180420081245-2b4488a37358 h1:FVFwfCq+MMGoSohqKWiJwMy3FMZSM+vA0SrACbrFx1Y=
 github.com/karalabe/hid v0.0.0-20180420081245-2b4488a37358/go.mod h1:YvbcH+3Wo6XPs9nkgTY3u19KXLauXW+J5nB7hEHuX0A=
 github.com/konsorten/go-windows-terminal-sequences v0.0.0-20180402223658-b729f2633dfe/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
+github.com/kr/pty v1.1.3 h1:/Um6a/ZmD5tF7peoOJ5oN5KMQ0DrGVQSXLNwyckutPk=
+github.com/kr/pty v1.1.3/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/lann/builder v0.0.0-20180216234317-1b87b36280d0 h1:2KbkALbvz9OAr38ObGXxhv+RsCZqrM+9LnEnyP+7bqU=
 github.com/lann/builder v0.0.0-20180216234317-1b87b36280d0/go.mod h1:dXGbAdH5GtBTC4WfIxhKZfyBF/HBFgRZSWwZ9g/He9o=
 github.com/lann/ps v0.0.0-20150810152359-62de8c46ede0 h1:P6pPBnrTSX3DEVR4fDembhRWSsG5rVo6hYhAB/ADZrk=

--- a/insonmnia/node/mod.go
+++ b/insonmnia/node/mod.go
@@ -63,7 +63,7 @@ func New(ctx context.Context, cfg *Config, options ...Option) (*Node, error) {
 	}
 
 	if cfg.SSH != nil {
-		serverOptions = append(serverOptions, WithSSH(*cfg.SSH, transportCredentials, remoteOptions.eth.Market(), log.Sugar()))
+		serverOptions = append(serverOptions, WithSSH(*cfg.SSH, key, transportCredentials, remoteOptions.eth.Market(), log.Sugar()))
 	}
 
 	server, err := newServer(cfg.Node, services, serverOptions...)

--- a/insonmnia/node/options.go
+++ b/insonmnia/node/options.go
@@ -93,9 +93,9 @@ func WithGRPCServerMetrics() ServerOption {
 	}
 }
 
-func WithSSH(cfg ssh.ProxyServerConfig, credentials credentials.TransportCredentials, market blockchain.MarketAPI, log *zap.SugaredLogger) ServerOption {
+func WithSSH(cfg ssh.ProxyServerConfig, privateKey *ecdsa.PrivateKey, credentials credentials.TransportCredentials, market blockchain.MarketAPI, log *zap.SugaredLogger) ServerOption {
 	return func(o *serverOptions) error {
-		server, err := ssh.NewSSHProxyServer(cfg, credentials, market, log)
+		server, err := ssh.NewSSHProxyServer(cfg, privateKey, credentials, market, log)
 		if err != nil {
 			return err
 		}

--- a/insonmnia/ssh/crypto.go
+++ b/insonmnia/ssh/crypto.go
@@ -1,0 +1,64 @@
+package ssh
+
+import (
+	"bytes"
+	"crypto/ecdsa"
+	"encoding/base32"
+	"fmt"
+	"strings"
+
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+)
+
+type SSHIdentity struct {
+	Addr common.Address
+	Sign []byte
+}
+
+func (m *SSHIdentity) String() string {
+	return fmt.Sprintf("%s@%s", m.Addr.Hex(), base32.StdEncoding.EncodeToString(m.Sign))
+}
+
+func NewSSHIdentity(key *ecdsa.PrivateKey) (*SSHIdentity, error) {
+	addr := crypto.PubkeyToAddress(key.PublicKey)
+	hash := chainhash.DoubleHashB(addr.Bytes())
+	sign, err := crypto.Sign(hash, key)
+	if err != nil {
+		return nil, err
+	}
+
+	return &SSHIdentity{Addr: addr, Sign: sign}, nil
+}
+
+func ParseSSHIdentity(v string) (*SSHIdentity, error) {
+	parts := strings.SplitN(v, "@", 2)
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("invalid format")
+	}
+
+	sign, err := base32.StdEncoding.DecodeString(parts[1])
+	if err != nil {
+		return nil, err
+	}
+
+	return &SSHIdentity{
+		Addr: common.HexToAddress(parts[0]),
+		Sign: sign,
+	}, nil
+}
+
+func (m *SSHIdentity) Verify() error {
+	hash := chainhash.DoubleHashB(m.Addr.Bytes())
+	publicKey, err := crypto.SigToPub(hash, m.Sign)
+	if err != nil {
+		return fmt.Errorf("invalid signature")
+	}
+
+	if !bytes.Equal(crypto.PubkeyToAddress(*publicKey).Bytes(), m.Addr.Bytes()) {
+		return fmt.Errorf("invalid signature for provided ETH address")
+	}
+
+	return nil
+}

--- a/insonmnia/ssh/proxy.go
+++ b/insonmnia/ssh/proxy.go
@@ -122,6 +122,15 @@ func (m *SSHProxyServer) Serve(ctx context.Context) error {
 		Addr:        m.cfg.Addr,
 		Handler:     connHandler.onHandle,
 		HostSigners: convertHostSigners(hostSigners),
+		PublicKeyHandler: func(ctx sshd.Context, key sshd.PublicKey) bool {
+			for _, signer := range hostSigners {
+				if sshd.KeysEqual(signer.PublicKey(), key) {
+					return true
+				}
+			}
+
+			return false
+		},
 	}
 	defer server.Close()
 

--- a/insonmnia/worker/options.go
+++ b/insonmnia/worker/options.go
@@ -12,6 +12,7 @@ import (
 	"os"
 
 	"github.com/ethereum/go-ethereum/accounts/keystore"
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/noxiouz/zapctx/ctxlog"
 	"github.com/sonm-io/core/blockchain"
@@ -296,7 +297,16 @@ func (m *options) setupSSH(view OverseerView) error {
 			return err
 		}
 
-		ssh, err := NewSSHServer(*m.cfg.SSH, signer, m.creds, view, ctxlog.S(m.ctx))
+		authorizedKeys := []common.Address{
+			crypto.PubkeyToAddress(m.key.PublicKey),
+			m.cfg.Master,
+		}
+
+		if m.cfg.Admin != nil {
+			authorizedKeys = append(authorizedKeys, *m.cfg.Admin)
+		}
+
+		ssh, err := NewSSHServer(*m.cfg.SSH, signer, m.creds, authorizedKeys, view, ctxlog.S(m.ctx))
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Now it is possible to SSH to a Worker using Node proxy, which is especially useful for debugging. Internally it works the same way as we did SSH into containers, except the user identity, which is now can be a public ETH address of a Worker.

https://asciinema.org/a/XAY5ll7Mz4FsfdmlOkC9w4QuP