### PR TITLE
fix: getTransactionReceipt To field unmarshalling

### DIFF
--- a/blockchain/client.go
+++ b/blockchain/client.go
@@ -66,7 +66,7 @@ func (r *Receipt) UnmarshalJSON(input []byte) error {
 	r.From = common.HexToAddress(dec.From)
 
 	if dec.To == "" {
-		return fmt.Errorf("unmarshaled to field is empty")
+		dec.To = "0x0"
 	}
 	r.To = common.HexToAddress(dec.To)
 

--- a/blockchain/client_test.go
+++ b/blockchain/client_test.go
@@ -47,3 +47,45 @@ func TestParseBlockNumberWith0x(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, int64(170), rec.BlockNumber)
 }
+
+func TestParseParseTo(t *testing.T) {
+	raw := []byte(`{
+"BlockNumber": "0xaa",
+"cumulativeGasUsed": "0x1",
+"gasUsed": "0x2",
+"To": "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+"logs": [],
+"transactionHash": "0xcccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+"contractAddress": "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+"logsBloom": "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+}`)
+
+	rec := &Receipt{
+		Receipt:     &types.Receipt{},
+		BlockNumber: 0,
+	}
+	err := rec.UnmarshalJSON(raw)
+	require.NoError(t, err)
+	assert.Equal(t, rec.To.String(), "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")
+}
+
+func TestParseParseToWithNull(t *testing.T) {
+	raw := []byte(`{
+"BlockNumber": "0xaa",
+"cumulativeGasUsed": "0x1",
+"gasUsed": "0x2",
+"To": null"
+"logs": [],
+"transactionHash": "0xcccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+"contractAddress": "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+"logsBloom": "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+}`)
+
+	rec := &Receipt{
+		Receipt:     &types.Receipt{},
+		BlockNumber: 0,
+	}
+	err := rec.UnmarshalJSON(raw)
+	require.NoError(t, err)
+	assert.Equal(t, rec.To.String(), "0x0000000000000000000000000000000000000000")
+}


### PR DESCRIPTION
Fix behaviour for parsing `To` field according to [web3 json rpc scpec](https://github.com/ethereum/wiki/wiki/JSON-RPC#eth_gettransactionreceipt)
> to: DATA, 20 Bytes - address of the receiver. null when it's a contract creation transaction.

This fix affect contract' creation transactions.