### PR TITLE
aux: change solium linter rules

### DIFF
--- a/blockchain/source/.soliumrc.json
+++ b/blockchain/source/.soliumrc.json
@@ -14,6 +14,12 @@
     ],
     "emit": [
       "off"
+    ],
+    "error-reason": [
+      "off"
+    ],
+    "security/no-block-members": [
+      "off"
     ]
   }
 }


### PR DESCRIPTION
Turn off some harmfull or useless rules:
* `error-reason` - required error messages for all `require` ops.
* `security/no-block-members` - don't use of timestamp.