### PR TITLE
feat: Optimus should no longer remove active plans

### DIFF
--- a/optimus/engine.go
+++ b/optimus/engine.go
@@ -324,11 +324,10 @@ func (m *workerEngine) execute(ctx context.Context) error {
 	case swingTime:
 		m.log.Info("using replacement strategy")
 
-		for _, plan := range remove {
-			if victimPlan, ok := victimPlans[plan.GetID()]; ok {
-				if victimPlan.GetDealID().IsZero() {
-					victims = append(victims, plan)
-				}
+		// Remove all spot plans that have no deal associated with.
+		for _, plan := range victimPlans {
+			if plan.GetDealID().IsZero() {
+				victims = append(victims, plan)
 			}
 		}
 

--- a/proto/insonmnia.go
+++ b/proto/insonmnia.go
@@ -148,6 +148,14 @@ func (m *DataSizeRate) MarshalYAML() (interface{}, error) {
 	return string(text), err
 }
 
+func (m *Price) Add(other *Price) *Price {
+	x := m.GetPerSecond().Unwrap()
+	y := other.GetPerSecond().Unwrap()
+	x.Add(x, y)
+	m.PerSecond = NewBigInt(x)
+	return m
+}
+
 func (m *Price) MarshalYAML() (interface{}, error) {
 	v := big.NewFloat(0).SetPrec(256).SetInt(m.PerSecond.Unwrap())
 	div := big.NewFloat(params.Ether).SetPrec(256)


### PR DESCRIPTION
Currently after the optimization process is done, Optimus replaces some of ask-plans with the new ones, dropping currently running deals, which causes painful races in the entire SONM network - all running bots are greedily engaged on a new profitable order, but only one of them succeeds.
The new logic in the Worker should eliminate this race, we just support it in Optimus. Now it will cancel ask-plans only if there is no deal associated with it, delegating other plan management logic to the Worker.