### PR TITLE
fix: proper initialize GPU resources before substraction

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -255,6 +255,7 @@ github.com/sshaman1101/nvidia-docker v0.0.0-20180123151056-303029acd1a0e29ef58d6
 github.com/sshaman1101/nvidia-docker v0.0.0-20180123151056-759a11342d8f h1:eCpVKr87+XbqYDd+ndm9BYApgeHpY7/QcLTUyLkgiwY=
 github.com/sshaman1101/nvidia-docker v0.0.0-20180123151056-759a11342d8f/go.mod h1:b7O6MiIOQVIu7sdyTrRe7bv4iRhQZPwrQ3Z3z0FmbIA=
 github.com/sshaman1101/nvidia-docker v0.0.0-20180123151056-ca608186965c8bd0da8d2c123b40086609bb1a32/go.mod h1:b7O6MiIOQVIu7sdyTrRe7bv4iRhQZPwrQ3Z3z0FmbIA=
+github.com/sshaman1101/nvidia-docker v0.0.1 h1:otBBAZUW02Ocmf2HsoZ3ZYFZxanWtb9hq9VC8psuGuo=
 github.com/sshaman1101/nvidia-docker v0.0.1/go.mod h1:b7O6MiIOQVIu7sdyTrRe7bv4iRhQZPwrQ3Z3z0FmbIA=
 github.com/stretchr/testify v0.0.0-20180319223459-c679ae2cc0cb/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=

--- a/proto/ask_plan.go
+++ b/proto/ask_plan.go
@@ -151,10 +151,10 @@ func subAtMost(lhs uint64, rhs uint64) uint64 {
 
 // This function substracts as much resources as it can
 func (m *AskPlanResources) SubAtMost(resources *AskPlanResources) error {
+	m.initNilWithZero()
 	if err := m.GPU.Sub(resources.GetGPU()); err != nil {
 		return err
 	}
-	m.initNilWithZero()
 	m.CPU.CorePercents = subAtMost(m.CPU.CorePercents, resources.GetCPU().GetCorePercents())
 	m.RAM.Size.Bytes = subAtMost(m.RAM.Size.Bytes, resources.GetRAM().GetSize().GetBytes())
 	m.Storage.Size.Bytes = subAtMost(m.Storage.Size.Bytes, resources.GetStorage().GetSize().GetBytes())


### PR DESCRIPTION
This fixes segfault when trying to substract resources from resources with nil GPU 