### PR TITLE
feat: added used bytes for the disk benchmark

### DIFF
--- a/insonmnia/worker/metrics/metrics.go
+++ b/insonmnia/worker/metrics/metrics.go
@@ -1,0 +1,1 @@
+package metrics

--- a/insonmnia/worker/metrics/metrics.go
+++ b/insonmnia/worker/metrics/metrics.go
@@ -1,1 +1,0 @@
-package metrics

--- a/insonmnia/worker/server.go
+++ b/insonmnia/worker/server.go
@@ -1281,7 +1281,11 @@ func (m *Worker) getBenchValue(bench *sonm.Benchmark, device interface{}) (uint6
 		return m.hardware.RAM.Device.Total, nil
 	}
 	if bench.GetID() == benchmarks.StorageSize {
-		return disk.FreeDiskSpace(m.ctx)
+		info, err := disk.FreeDiskSpace(m.ctx)
+		if err != nil {
+			return 0, err
+		}
+		return info.FreeBytes, nil
 	}
 	if bench.GetID() == benchmarks.GPUCount {
 		//GPU count is always 1 for each GPU device.


### PR DESCRIPTION
We must avoid two syscalls to gather disk space. Also will be useful for worker monitoring suite.