### PR TITLE
feat: ability to collect metrics from DRI devices

### DIFF
--- a/cmd/lsgpu/main.go
+++ b/cmd/lsgpu/main.go
@@ -20,7 +20,7 @@ func main() {
 	for _, card := range cards {
 		fmt.Printf("Card: %s\r\n", card.Path)
 		if m, err := card.Metrics(); err == nil {
-			fmt.Printf(" t = %v (fan = %v%%)\r\n", m.Temperature, m.Fan)
+			fmt.Printf(" t = %.1f (fan = %.1f%%)\r\n", m.Temperature, m.Fan)
 		} else {
 			fmt.Printf(" metrics is not available\r\n")
 		}

--- a/cmd/lsgpu/main.go
+++ b/cmd/lsgpu/main.go
@@ -19,6 +19,11 @@ func main() {
 
 	for _, card := range cards {
 		fmt.Printf("Card: %s\r\n", card.Path)
+		if m, err := card.Metrics(); err == nil {
+			fmt.Printf(" t = %v (fan = %v%%)\r\n", m.Temperature, m.Fan)
+		} else {
+			fmt.Printf(" metrics is not available\r\n")
+		}
 
 		fmt.Printf("   vid=%d did=%d\r\n", card.VendorID, card.DeviceID)
 		fmt.Printf("   maj=%d min=%d\r\n", card.Major, card.Minor)

--- a/insonmnia/worker/gpu/dri.go
+++ b/insonmnia/worker/gpu/dri.go
@@ -64,10 +64,7 @@ func NewDRICard(num int, name, path string) (DRICard, error) {
 		return DRICard{}, err
 	}
 
-	err = c.collectHwmonPath()
-	if err != nil {
-		return DRICard{}, err
-	}
+	c.collectHwmonPath()
 
 	return c, nil
 }

--- a/insonmnia/worker/gpu/dri.go
+++ b/insonmnia/worker/gpu/dri.go
@@ -159,7 +159,7 @@ func (card *DRICard) collectHwmonPath() error {
 	}
 
 	for _, fd := range dir {
-		if fd.IsDir() && strings.Contains(fd.Name(), "hwmon") {
+		if fd.IsDir() && strings.HasPrefix(fd.Name(), "hwmon") {
 			card.HwmonPath = fmt.Sprintf("%s/%s", p, fd.Name())
 			break
 		}

--- a/insonmnia/worker/gpu/dri.go
+++ b/insonmnia/worker/gpu/dri.go
@@ -148,14 +148,14 @@ func (card *DRICard) collectPCIBusID() error {
 	return errors.New("cannot find PCI slot name into the file")
 }
 
-func (card *DRICard) collectHwmonPath() error {
+func (card *DRICard) collectHwmonPath() {
 	p := fmt.Sprintf("/sys/dev/char/%d:%d/device/hwmon", card.Major, card.Minor)
 
 	dir, err := ioutil.ReadDir(p)
 	if err != nil {
 		// if we can't find such directory - just skip it,
 		// hwmon dir may be not present for on-board card.
-		return nil
+		return
 	}
 
 	for _, fd := range dir {
@@ -164,8 +164,6 @@ func (card *DRICard) collectHwmonPath() error {
 			break
 		}
 	}
-
-	return nil
 }
 
 func (card *DRICard) readFanSpeed() (float64, error) {


### PR DESCRIPTION
Now we're trying to find hwmon path on the device initialization.
If we can do this, the monitoring interface for this card became available.

The `Monitoring` method reads some data from the `/sys/dev` internals, all behavior has been ported from the [ROC-smi tool](https://github.com/RadeonOpenCompute/ROC-smi).