### PR TITLE
fix: add mount.cifs package to debian dependencies

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -11,7 +11,7 @@ Vcs-Browser: https://github.com/sonm-io/core
 
 Package: sonm-worker
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}, libopencl1, btrfs-progs | btrfs-tools
+Depends: ${shlibs:Depends}, ${misc:Depends}, libopencl1, btrfs-progs | btrfs-tools, cifs-utils
 Conflicts: sonm-hub
 Replaces: sonm-hub
 Description: Worker daemon for SONM network


### PR DESCRIPTION
Closes #1705.