### PR TITLE
feat: experimental QUIC protocol support

### DIFF
--- a/cmd/rv/main.go
+++ b/cmd/rv/main.go
@@ -31,13 +31,12 @@ func start(app cmd.AppContext) error {
 	}
 	defer certRotator.Close()
 
-	credentials := util.NewTLS(TLSConfig)
-
 	options := []rendezvous.Option{
+		rendezvous.WithCredentials(TLSConfig),
+		rendezvous.WithQUIC(),
 		rendezvous.WithLogger(log.G(ctx)),
-		rendezvous.WithCredentials(credentials),
 	}
-	server, err := rendezvous.NewServer(*cfg, options...)
+	server, err := rendezvous.NewServer(cfg, options...)
 	if err != nil {
 		return fmt.Errorf("failed to create Rendezvous server: %s", err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -15,12 +15,14 @@ require (
 	github.com/armon/go-metrics v0.0.0-20180221182744-783273d70314
 	github.com/asaskevich/govalidator v0.0.0-20180319081651-7d2e70ef918f
 	github.com/beorn7/perks v0.0.0-20160804104726-4c0e84591b9a
+	github.com/bifurcation/mint v0.0.0-20181105071958-a14404e9a861 // indirect
 	github.com/boltdb/bolt v1.3.1
 	github.com/btcsuite/btcd v0.0.0-20171023093315-c7588cbf7690
 	github.com/c2h5oh/datasize v0.0.0-20171227191756-4eba002a5eae
 	github.com/ccding/go-stun v0.0.0-20170323223013-04a4eed61c57
 	github.com/cdipaolo/goml v0.0.0-20161030204843-e2d8def04c9a
 	github.com/certifi/gocertifi v0.0.0-20180905225744-ee1a9a0726d2
+	github.com/cheekybits/genny v1.0.0 // indirect
 	github.com/cnf/structhash v0.0.0-20170702194520-7710f1f78fb9
 	github.com/containerd/cgroups v0.0.0-20170714210333-6d5c608c203d
 	github.com/coreos/go-systemd v0.0.0-20170609144627-24036eb3df68
@@ -81,6 +83,9 @@ require (
 	github.com/lib/pq v0.0.0-20180327071824-d34b9ff171c2
 	github.com/libp2p/go-reuseport v0.1.10
 	github.com/libp2p/go-sockaddr v0.0.0-20180128062301-09ae606455f8
+	github.com/lucas-clemente/aes12 v0.0.0-20171027163421-cd47fb39b79f // indirect
+	github.com/lucas-clemente/quic-go v0.10.0
+	github.com/lucas-clemente/quic-go-certificates v0.0.0-20160823095156-d2f86524cced // indirect
 	github.com/magiconair/properties v0.0.0-20180217134545-2c9e95027885
 	github.com/mattn/go-colorable v0.0.0-20180310133214-efa589957cd0
 	github.com/mattn/go-isatty v0.0.4

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,7 @@ github.com/Masterminds/squirrel v0.0.0-20180612165926-7d201d09bfa8/go.mod h1:xnK
 github.com/MaxHalford/gago v0.0.0-20180803141938-502b393f59df h1:bvQ23VGspQtwqPLkq0ElO6Y0oIMEvVtH6RoQG7gSIBI=
 github.com/MaxHalford/gago v0.0.0-20180803141938-502b393f59df/go.mod h1:AQUEEjyx2VRPxPFDNBANzFOANctuUGeLIIieu3UUjsQ=
 github.com/NVIDIA/nvidia-docker v0.0.0-20170722195403-d8e8727788aa/go.mod h1:Owm+QXUYchDJTSFtwr8Q0xN+XCus9ltrQwSeCqqRXpg=
+github.com/StackExchange/wmi v0.0.0-20170410192909-ea383cf3ba6e h1:IHXQQIpxASe3m0Jtcd3XongL+lxHNd5nUmvHxJARUmg=
 github.com/StackExchange/wmi v0.0.0-20170410192909-ea383cf3ba6e/go.mod h1:3eOhrUMpNV+6aFIbp5/iudMxNCF27Vw2OZgy4xEx0Fg=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239 h1:kFOfPq6dUM1hTo4JG6LR5AXSUEsOjtdm0kw0FtQtMJA=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=
@@ -21,6 +22,8 @@ github.com/asaskevich/govalidator v0.0.0-20180319081651-7d2e70ef918f h1:/8NcnxL6
 github.com/asaskevich/govalidator v0.0.0-20180319081651-7d2e70ef918f/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/beorn7/perks v0.0.0-20160804104726-4c0e84591b9a h1:BtpsbiV638WQZwhA98cEZw2BsbnQJrbd0BI7tsy0W1c=
 github.com/beorn7/perks v0.0.0-20160804104726-4c0e84591b9a/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
+github.com/bifurcation/mint v0.0.0-20181105071958-a14404e9a861 h1:x17NvoJaphEzay72TFej4OSSsgu3xRYBLkbIwdofS/4=
+github.com/bifurcation/mint v0.0.0-20181105071958-a14404e9a861/go.mod h1:zVt7zX3K/aDCk9Tj+VM7YymsX66ERvzCJzw8rFCX2JU=
 github.com/boltdb/bolt v1.3.1 h1:JQmyP4ZBrce+ZQu0dY660FMfatumYDLun9hBCUVIkF4=
 github.com/boltdb/bolt v1.3.1/go.mod h1:clJnj/oiGkjum5o1McbSZDSLxVThjynRyGBgiAx27Ps=
 github.com/btcsuite/btcd v0.0.0-20171023093315-c7588cbf7690 h1:YSTjdPEsX8T2D31S9U7c4xxo0sQGa6TZ65cpCd7yVqU=
@@ -32,6 +35,8 @@ github.com/cdipaolo/goml v0.0.0-20161030204843-e2d8def04c9a h1:+8ndgVCRTyBJKTxfd
 github.com/cdipaolo/goml v0.0.0-20161030204843-e2d8def04c9a/go.mod h1:sduMkaHcXDIWurl/Bd/z0rNEUHw5tr6LUA9IO8E9o0o=
 github.com/certifi/gocertifi v0.0.0-20180905225744-ee1a9a0726d2 h1:MmeatFT1pTPSVb4nkPmBFN/LRZ97vPjsFKsZrU3KKTs=
 github.com/certifi/gocertifi v0.0.0-20180905225744-ee1a9a0726d2/go.mod h1:GJKEexRPVJrBSOjoqN5VNOIKJ5Q3RViH6eu3puDRwx4=
+github.com/cheekybits/genny v1.0.0 h1:uGGa4nei+j20rOSeDeP5Of12XVm7TGUd4dJA9RDitfE=
+github.com/cheekybits/genny v1.0.0/go.mod h1:+tQajlRqAUrPI7DOSpB0XAqZYtQakVtB7wXkRAgjxjQ=
 github.com/cnf/structhash v0.0.0-20170702194520-7710f1f78fb9 h1:Z6eVYnPyw1IbfiL+z+13vZhe3cI1lhE5nhRQbSxQFME=
 github.com/cnf/structhash v0.0.0-20170702194520-7710f1f78fb9/go.mod h1:pCxVEbcm3AMg7ejXyorUXi6HQCzOIBf7zEDVPtw0/U4=
 github.com/containerd/cgroups v0.0.0-20170714210333-6d5c608c203d h1:M7/OEkUwIjjSck/krOAf+5ErhE90WAyb53NGfWoygwc=
@@ -130,6 +135,7 @@ github.com/howeyc/gopass v0.0.0-20170109162249-bf9dde6d0d2c h1:kQWxfPIHVLbgLzphq
 github.com/howeyc/gopass v0.0.0-20170109162249-bf9dde6d0d2c/go.mod h1:lADxMC39cJJqL93Duh1xhAs4I2Zs8mKS89XWXFGp9cs=
 github.com/huin/goupnp v0.0.0-20180415215157-1395d1447324 h1:PV190X5/DzQ/tbFFG5YpT5mH6q+cHlfgqI5JuRnH9oE=
 github.com/huin/goupnp v0.0.0-20180415215157-1395d1447324/go.mod h1:MZ2ZmwcBpvOoJ22IJsc7va19ZwoheaBk43rKg12SKag=
+github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/influxdata/influxdb v0.0.0-20180412224233-7ebfc9c544e0 h1:UACGhl+uO8HlQlk0VHPcf1XxgrpGiCyamQe088piHLA=
 github.com/influxdata/influxdb v0.0.0-20180412224233-7ebfc9c544e0/go.mod h1:qZna6X/4elxqT3yI9iZYdZrWWdeFOOprn86kgg4+IzY=
@@ -155,6 +161,12 @@ github.com/libp2p/go-reuseport v0.1.10 h1:luit4a4lmixdyb1MXs8YNHkVe4cZx0ETN630HL
 github.com/libp2p/go-reuseport v0.1.10/go.mod h1:UeLFiw50cCfyDHBpU0sXBR8ul1MO/m51mXpRO/SYjCE=
 github.com/libp2p/go-sockaddr v0.0.0-20180128062301-09ae606455f8 h1:zKo9Niz9yo6aGKQy4aoILJ1XiWlyJYAVLznJASTI83U=
 github.com/libp2p/go-sockaddr v0.0.0-20180128062301-09ae606455f8/go.mod h1:N/q858DTOi0BT81GpvIRIls1x7my5oLpbxYZnbRXVBM=
+github.com/lucas-clemente/aes12 v0.0.0-20171027163421-cd47fb39b79f h1:sSeNEkJrs+0F9TUau0CgWTTNEwF23HST3Eq0A+QIx+A=
+github.com/lucas-clemente/aes12 v0.0.0-20171027163421-cd47fb39b79f/go.mod h1:JpH9J1c9oX6otFSgdUHwUBUizmKlrMjxWnIAjff4m04=
+github.com/lucas-clemente/quic-go v0.10.0 h1:xEF+pSHYAOcu+U10Meunf+DTtc8vhQDRqlA0BJ6hufc=
+github.com/lucas-clemente/quic-go v0.10.0/go.mod h1:wuD+2XqEx8G9jtwx5ou2BEYBsE+whgQmlj0Vz/77PrY=
+github.com/lucas-clemente/quic-go-certificates v0.0.0-20160823095156-d2f86524cced h1:zqEC1GJZFbGZA0tRyNZqRjep92K5fujFtFsu5ZW7Aug=
+github.com/lucas-clemente/quic-go-certificates v0.0.0-20160823095156-d2f86524cced/go.mod h1:NCcRLrOTZbzhZvixZLlERbJtDtYsmMw8Jc4vS8Z0g58=
 github.com/magiconair/properties v0.0.0-20180217134545-2c9e95027885 h1:HWxJJvF+QceKcql4r9PC93NtMEgEBfBxlQrZPvbcQvs=
 github.com/magiconair/properties v0.0.0-20180217134545-2c9e95027885/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/mattn/go-colorable v0.0.0-20180310133214-efa589957cd0 h1:cDvUG90i1ssGJGqMNx2Ubbn+bx7VOzjdvQ45zpy0X4w=
@@ -304,6 +316,7 @@ gopkg.in/bluesuncorp/validator.v9 v9.15.0/go.mod h1:sz1RrKEIYJCpC5S6ruDsBWo5vYV6
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/go-playground/validator.v8 v8.18.2 h1:lFB4DoMU6B626w8ny76MV7VX6W2VHct2GVOI3xgiMrQ=
 gopkg.in/go-playground/validator.v8 v8.18.2/go.mod h1:RX2a/7Ha8BgOhfk7j780h4/u/RRjR0eouCJSH80/M2Y=
+gopkg.in/natefinch/npipe.v2 v2.0.0-20160621034901-c1b8fa8bdcce h1:+JknDZhAj8YMt7GC73Ei8pv4MzjDUNPHgQWJdtMAaDU=
 gopkg.in/natefinch/npipe.v2 v2.0.0-20160621034901-c1b8fa8bdcce/go.mod h1:5AcXVHNjg+BDxry382+8OKon8SEWiKktQR07RKPsv1c=
 gopkg.in/olebedev/go-duktape.v3 v3.0.0-20180302121509-abf0ba0be5d5 h1:VWXVtmkY4YFVuF1FokZ0PUsuvtx3Di6z/m47daSP5f0=
 gopkg.in/olebedev/go-duktape.v3 v3.0.0-20180302121509-abf0ba0be5d5/go.mod h1:uAJfkITjFhyEEuUfm7bsmCZRbW5WRq8s9EY8HZ6hCns=

--- a/insonmnia/node/remote.go
+++ b/insonmnia/node/remote.go
@@ -16,7 +16,6 @@ import (
 	"github.com/sonm-io/core/util"
 	"github.com/sonm-io/core/util/xgrpc"
 	"go.uber.org/zap"
-	"google.golang.org/grpc/credentials"
 )
 
 type workerClientCreator func(ctx context.Context, addr *auth.Addr) (*workerClient, io.Closer, error)
@@ -81,7 +80,7 @@ func (re *remoteOptions) isWorkerAvailable(ctx context.Context, addr common.Addr
 	return err == nil
 }
 
-func newRemoteOptions(ctx context.Context, cfg *Config, key *ecdsa.PrivateKey, credentials credentials.TransportCredentials, log *zap.SugaredLogger) (*remoteOptions, error) {
+func newRemoteOptions(ctx context.Context, cfg *Config, key *ecdsa.PrivateKey, credentials *xgrpc.TransportCredentials, log *zap.SugaredLogger) (*remoteOptions, error) {
 	nppDialerOptions := []npp.Option{
 		npp.WithRendezvous(cfg.NPP.Rendezvous, credentials),
 		npp.WithRelay(cfg.NPP.Relay, key),

--- a/insonmnia/npp/common.go
+++ b/insonmnia/npp/common.go
@@ -7,6 +7,7 @@ const (
 	sourceDirectConnection
 	sourceNPPConnection
 	sourceRelayedConnection
+	sourceNPPQUICConnection
 )
 
 func (m connSource) String() string {
@@ -17,6 +18,8 @@ func (m connSource) String() string {
 		return "NPP"
 	case sourceRelayedConnection:
 		return "relay"
+	case sourceNPPQUICConnection:
+		return "NPP/QUIC"
 	default:
 		return "unknown source"
 	}

--- a/insonmnia/npp/metrics.go
+++ b/insonmnia/npp/metrics.go
@@ -47,6 +47,10 @@ type dialMetrics struct {
 	// UsingNATHistogram describes the distribution of resolve and connect
 	// times for successful connection attempts using NPP NAT traversal.
 	UsingNATHistogram prometheus.Histogram
+	// UsingQNATHistogram describes the distribution of resolve and connect
+	// times for successful connection attempts using NPP NAT traversal over
+	// UDP for QUIC.
+	UsingQNATHistogram prometheus.Histogram
 	// UsingRelayHistogram describes the distribution of resolve and connect
 	// times for successful connection attempts using Relay server.
 	UsingRelayHistogram prometheus.Histogram
@@ -67,6 +71,7 @@ func newDialMetrics() *dialMetrics {
 		NumFailed:               prometheus.NewCounter(prometheus.CounterOpts{}),
 		UsingTCPDirectHistogram: prometheus.NewHistogram(prometheus.HistogramOpts{}),
 		UsingNATHistogram:       prometheus.NewHistogram(prometheus.HistogramOpts{}),
+		UsingQNATHistogram:      prometheus.NewHistogram(prometheus.HistogramOpts{}),
 		UsingRelayHistogram:     prometheus.NewHistogram(prometheus.HistogramOpts{}),
 		SummaryHistogram:        prometheus.NewHistogram(prometheus.HistogramOpts{}),
 		LastTimeActive:          prometheus.NewGauge(prometheus.GaugeOpts{}),

--- a/insonmnia/npp/puncher_quic.go
+++ b/insonmnia/npp/puncher_quic.go
@@ -1,0 +1,228 @@
+package npp
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"net"
+	"strings"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/lucas-clemente/quic-go"
+	"github.com/sonm-io/core/proto"
+	"github.com/sonm-io/core/util/xnet"
+	"go.uber.org/zap"
+	"gopkg.in/oleiade/lane.v1"
+)
+
+const (
+	transportProtocol = "quic"
+)
+
+type quicPuncher struct {
+	rendezvousClient *rendezvousClient
+	tlsConfig        *tls.Config
+
+	listenerChannel    chan connTuple
+	pendingConnections *lane.Queue
+	protocol           string
+
+	timeout time.Duration
+	log     *zap.SugaredLogger
+}
+
+func newQUICPuncher(rendezvousClient *rendezvousClient, tlsConfig *tls.Config, protocol string, log *zap.Logger) (*quicPuncher, error) {
+	// TODO: Le soutien.
+	if protocol == sonm.DefaultNPPProtocol {
+		protocol = "grpc"
+	}
+
+	m := &quicPuncher{
+		rendezvousClient: rendezvousClient,
+		tlsConfig:        tlsConfig,
+
+		listenerChannel:    make(chan connTuple, 1),
+		pendingConnections: lane.NewQueue(),
+		protocol:           strings.Join([]string{transportProtocol, protocol}, "+"),
+
+		timeout: 30 * time.Second,
+		log:     log.With(zap.String("type", "QUIC")).Sugar(),
+	}
+
+	go func() {
+		if err := m.listen(); err != nil {
+			m.log.Warn("QUIC listener is closed", zap.Error(err))
+		}
+	}()
+
+	return m, nil
+}
+
+func (m *quicPuncher) listen() error {
+	conn := m.rendezvousClient.UDPConn
+
+	m.log.Debugf("exposing QUIC listener on %s", conn.LocalAddr().String())
+	defer m.log.Debugf("finished QUIC listening on %s", conn.LocalAddr().String())
+
+	listener, err := quic.Listen(conn, m.tlsConfig, xnet.DefaultQUICConfig())
+	if err != nil {
+		return err
+	}
+
+	wrappedListener := xnet.QUICListener{Listener: listener}
+
+	for {
+		conn, err := wrappedListener.Accept()
+		m.listenerChannel <- newConnTuple(conn, err)
+		switch {
+		case err == nil:
+			//case strings.Contains(err.Error(), "use of closed network connection"):
+			//	return err
+		default:
+			m.log.Errorw("failed to listen QUIC NPP", zap.Error(err))
+			return err
+		}
+	}
+}
+
+func (m *quicPuncher) Accept() (net.Conn, error) {
+	return m.AcceptContext(context.Background())
+}
+
+func (m *quicPuncher) AcceptContext(ctx context.Context) (net.Conn, error) {
+	// Check for pending connections in the acceptor from the channel, if
+	// there is a connection - return immediately.
+	select {
+	case conn := <-m.listenerChannel:
+		if err := conn.Error(); err == nil {
+			m.log.Infof("received acceptor peer from %s", conn.RemoteAddr())
+		}
+
+		return conn.unwrap()
+	default:
+	}
+
+	if conn := m.pendingConnections.Dequeue(); conn != nil {
+		m.log.Debugf("dequeueing pending connection")
+		return conn.(net.Conn), nil
+	}
+
+	addrs, err := m.publish(ctx)
+	if err != nil {
+		m.log.Warnw("failed to publish itself on the rendezvous", zap.Error(err))
+		return nil, newRendezvousError(err)
+	}
+
+	m.log.Infof("received remote peer endpoints: %s", *addrs)
+
+	ctx, cancel := context.WithTimeout(ctx, m.timeout)
+	defer cancel()
+
+	conn, err := m.punch(ctx, addrs, &serverConnectionWatcher{Queue: m.pendingConnections, Log: m.log.Desugar()}, true)
+	if err != nil {
+		return nil, newRendezvousError(err)
+	}
+
+	return conn, nil
+}
+
+func (m *quicPuncher) publish(ctx context.Context) (*sonm.RendezvousReply, error) {
+	request := &sonm.PublishRequest{
+		Protocol: m.protocol,
+	}
+
+	return m.rendezvousClient.Publish(ctx, request)
+}
+
+func (m *quicPuncher) punch(ctx context.Context, addrs *sonm.RendezvousReply, watcher connectionWatcher, isServer bool) (net.Conn, error) {
+	if addrs.Empty() {
+		return nil, fmt.Errorf("no addresses resolved")
+	}
+
+	channel := make(chan connTuple, 1)
+	go m.doPunch(ctx, addrs, channel, watcher)
+
+	// todo: out of band conns.
+	for {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case conn := <-channel:
+			if !isServer {
+				return conn.unwrap()
+			}
+		case conn := <-m.listenerChannel:
+			if isServer {
+				return conn.unwrap()
+			}
+			// todo: what to do if not?
+		}
+	}
+}
+
+func (m *quicPuncher) doPunch(ctx context.Context, addrs *sonm.RendezvousReply, channel chan<- connTuple, watcher connectionWatcher) {
+	m.log.Debugf("punching %s", *addrs)
+
+	conn, err := m.punchAddr(ctx, addrs.PublicAddr)
+	if err != nil {
+		channel <- newConnTuple(nil, err)
+		return
+	}
+
+	m.log.Debugf("received NPP NAT connection candidate: %s", *addrs.PublicAddr)
+	channel <- newConnTuple(conn, nil)
+}
+
+func (m *quicPuncher) punchAddr(ctx context.Context, addr *sonm.Addr) (net.Conn, error) {
+	peerAddr, err := addr.IntoUDP()
+	if err != nil {
+		return nil, err
+	}
+
+	udpConn := m.rendezvousClient.UDPConn
+
+	cfg := xnet.DefaultQUICConfig()
+
+	session, err := quic.DialContext(ctx, udpConn, peerAddr, peerAddr.String(), m.tlsConfig, cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	return xnet.NewQUICConn(session)
+}
+
+func (m *quicPuncher) Dial(addr common.Address) (net.Conn, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), m.timeout)
+	defer cancel()
+
+	return m.DialContext(ctx, addr)
+}
+
+func (m *quicPuncher) DialContext(ctx context.Context, addr common.Address) (net.Conn, error) {
+	addrs, err := m.resolve(ctx, addr)
+	if err != nil {
+		m.log.Warnf("failed to resolve %s using rendezvous: %v", addr.String(), err)
+		return nil, err
+	}
+
+	return m.punch(ctx, addrs, clientConnectionWatcher{}, false)
+}
+
+func (m *quicPuncher) resolve(ctx context.Context, addr common.Address) (*sonm.RendezvousReply, error) {
+	request := &sonm.ConnectRequest{
+		Protocol:     m.protocol,
+		PrivateAddrs: []*sonm.Addr{},
+		ID:           addr.Bytes(),
+	}
+
+	return m.rendezvousClient.Resolve(ctx, request)
+}
+
+func (m *quicPuncher) RemoteAddr() net.Addr {
+	return m.rendezvousClient.RemoteAddr()
+}
+
+func (m *quicPuncher) Close() error {
+	return nil
+}

--- a/insonmnia/ssh/proxy.go
+++ b/insonmnia/ssh/proxy.go
@@ -11,17 +11,16 @@ import (
 	"strings"
 
 	"github.com/ethereum/go-ethereum/common"
+	sshd "github.com/gliderlabs/ssh"
 	"github.com/sonm-io/core/blockchain"
 	"github.com/sonm-io/core/insonmnia/auth"
 	"github.com/sonm-io/core/insonmnia/npp"
 	"github.com/sonm-io/core/proto"
+	"github.com/sonm-io/core/util/xgrpc"
 	"go.uber.org/zap"
 	"golang.org/x/crypto/ssh"
 	"golang.org/x/crypto/ssh/agent"
 	"golang.org/x/sync/errgroup"
-	"google.golang.org/grpc/credentials"
-
-	sshd "github.com/gliderlabs/ssh"
 )
 
 const (
@@ -65,7 +64,7 @@ func convertHostSigners(v []ssh.Signer) []sshd.Signer {
 // agent.
 //
 // Example of external usage: "ssh <DealID>.<TaskID>@<host> -p <port>".
-func NewSSHProxyServer(cfg ProxyServerConfig, privateKey *ecdsa.PrivateKey, credentials credentials.TransportCredentials, market blockchain.MarketAPI, log *zap.SugaredLogger) (*SSHProxyServer, error) {
+func NewSSHProxyServer(cfg ProxyServerConfig, privateKey *ecdsa.PrivateKey, credentials *xgrpc.TransportCredentials, market blockchain.MarketAPI, log *zap.SugaredLogger) (*SSHProxyServer, error) {
 	options := []npp.Option{
 		npp.WithProtocol(proto),
 		npp.WithRendezvous(cfg.NPP.Rendezvous, credentials),

--- a/insonmnia/worker/options.go
+++ b/insonmnia/worker/options.go
@@ -4,6 +4,8 @@ import (
 	"context"
 )
 
+type Option func(*options)
+
 type options struct {
 	ctx     context.Context
 	version string
@@ -15,8 +17,6 @@ func newOptions() *options {
 		version: "unspecified",
 	}
 }
-
-type Option func(*options)
 
 func WithContext(ctx context.Context) Option {
 	return func(o *options) {

--- a/insonmnia/worker/ssh.go
+++ b/insonmnia/worker/ssh.go
@@ -17,15 +17,14 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/pkg/stdcopy"
 	"github.com/ethereum/go-ethereum/common"
+	sshd "github.com/gliderlabs/ssh"
 	"github.com/kr/pty"
 	"github.com/sonm-io/core/insonmnia/npp"
 	xssh "github.com/sonm-io/core/insonmnia/ssh"
 	"github.com/sonm-io/core/proto"
+	"github.com/sonm-io/core/util/xgrpc"
 	"go.uber.org/zap"
 	"golang.org/x/crypto/ssh"
-	"google.golang.org/grpc/credentials"
-
-	sshd "github.com/gliderlabs/ssh"
 )
 
 const (
@@ -366,12 +365,12 @@ func (m *connHandler) processLogin(session sshd.Session) (sshStatus, error) {
 
 type sshServer struct {
 	cfg         SSHConfig
-	credentials credentials.TransportCredentials
+	credentials *xgrpc.TransportCredentials
 	server      *sshd.Server
 	log         *zap.SugaredLogger
 }
 
-func NewSSHServer(cfg SSHConfig, signer ssh.Signer, credentials credentials.TransportCredentials, sshAuthorization *SSHAuthorization, overseer OverseerView, log *zap.SugaredLogger) (*sshServer, error) {
+func NewSSHServer(cfg SSHConfig, signer ssh.Signer, credentials *xgrpc.TransportCredentials, sshAuthorization *SSHAuthorization, overseer OverseerView, log *zap.SugaredLogger) (*sshServer, error) {
 	for _, addr := range cfg.Blacklist {
 		sshAuthorization.Deny(addr)
 	}

--- a/proto/net.go
+++ b/proto/net.go
@@ -31,6 +31,10 @@ func (m *Addr) IntoTCP() (net.Addr, error) {
 	return m.Addr.IntoTCP()
 }
 
+func (m *Addr) IntoUDP() (*net.UDPAddr, error) {
+	return m.Addr.IntoUDP()
+}
+
 // IsPrivate returns true if this address can't be reached from the Internet directly.
 func (m *Addr) IsPrivate() bool {
 	return m.Addr.IsPrivate()
@@ -57,9 +61,9 @@ func (m *SocketAddr) IsPrivate() bool {
 }
 
 func (m *SocketAddr) IntoTCP() (net.Addr, error) {
-	return m.intoNet("tcp")
+	return net.ResolveTCPAddr("tcp", fmt.Sprintf("%s:%d", m.Addr, m.Port))
 }
 
-func (m *SocketAddr) intoNet(protocol string) (net.Addr, error) {
-	return net.ResolveTCPAddr(protocol, fmt.Sprintf("%s:%d", m.Addr, m.Port))
+func (m *SocketAddr) IntoUDP() (*net.UDPAddr, error) {
+	return net.ResolveUDPAddr("udp", fmt.Sprintf("%s:%d", m.Addr, m.Port))
 }

--- a/proto/net.proto
+++ b/proto/net.proto
@@ -3,6 +3,8 @@ syntax = "proto3";
 package sonm;
 
 message Addr {
+    // Protocol describes the underlying transport protocol, for example "tcp"
+    // or "udp".
     string protocol = 1;
     SocketAddr addr = 2;
 }

--- a/proto/rendezvous.go
+++ b/proto/rendezvous.go
@@ -5,7 +5,7 @@ import (
 )
 
 const (
-	DefaultNPPProtocol = "tcp"
+	DefaultNPPProtocol = "tcp" // Equals to "tcp+grpc".
 )
 
 func (m *PublishRequest) Validate() error {

--- a/proto/rendezvous.proto
+++ b/proto/rendezvous.proto
@@ -23,19 +23,19 @@ service Rendezvous {
     rpc Info(Empty) returns (RendezvousState) {}
 }
 
-// ConnectRequest describres a connection request to a remote target, possibly
+// ConnectRequest describes a connection request to a remote target, possibly
 // located under the NAT.
 message ConnectRequest {
     // ID describes an unique ID of a target. Mainly it's an ETH address.
     bytes ID = 1;
-    // Protocol describes network protocol the peer wants to resolve.
+    // Protocol describes the application protocol the peer wants to resolve.
     string protocol = 2;
     // PrivateAddrs describes source private addresses.
     repeated Addr privateAddrs = 3;
 }
 
 message PublishRequest {
-    // Protocol describes network protocol the peer wants to publish.
+    // Protocol describes the application protocol the peer wants to publish.
     string protocol = 1;
     // PrivateAddrs describes source private addresses.
     repeated Addr privateAddrs = 2;

--- a/util/grpcsecure.go
+++ b/util/grpcsecure.go
@@ -66,8 +66,8 @@ func verifyCertificate(authInfo credentials.AuthInfo) (credentials.AuthInfo, err
 	}
 }
 
-// NewTLS wraps TLS TransportCredentials from grpc to add custom logic
-func NewTLS(c *tls.Config) credentials.TransportCredentials {
-	tc := credentials.NewTLS(c)
-	return tlsVerifier{TransportCredentials: tc}
+// NewTLS wraps TLS TransportCredentials from gRPC to add custom verification
+// logic.
+func NewTLS(cfg *tls.Config) credentials.TransportCredentials {
+	return tlsVerifier{TransportCredentials: credentials.NewTLS(cfg)}
 }

--- a/util/grpcutil_test.go
+++ b/util/grpcutil_test.go
@@ -1,19 +1,10 @@
 package util
 
 import (
-	"context"
 	"crypto/tls"
 	"crypto/x509"
-	"net"
 	"testing"
 	"time"
-
-	"github.com/sonm-io/core/util/xgrpc"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
-
-	"github.com/stretchr/testify/require"
 
 	ethcrypto "github.com/ethereum/go-ethereum/crypto"
 )
@@ -39,57 +30,4 @@ func TestTLSGenCerts(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-}
-
-func TestSecureGRPCConnect(t *testing.T) {
-	require := require.New(t)
-	ctx := context.Background()
-	serPriv, err := ethcrypto.GenerateKey()
-	require.NoError(err)
-	rot, serTLS, err := NewHitlessCertRotator(ctx, serPriv)
-	require.NoError(err)
-	defer rot.Close()
-	serCreds := NewTLS(serTLS)
-	server := xgrpc.NewServer(nil, xgrpc.Credentials(serCreds))
-	lis, err := net.Listen("tcp", "localhost:0")
-	require.NoError(err)
-	defer lis.Close()
-	go func() {
-		server.Serve(lis)
-	}()
-
-	t.Run("ClientWithTLS", func(t *testing.T) {
-		clientPriv, err := ethcrypto.GenerateKey()
-		require.NoError(err)
-		rot, clientTLS, err := NewHitlessCertRotator(ctx, clientPriv)
-		require.NoError(err)
-		defer rot.Close()
-		var clientCreds = NewTLS(clientTLS)
-		conn, err := xgrpc.NewClient(ctx, lis.Addr().String(), clientCreds, grpc.WithTimeout(time.Second), grpc.WithBlock())
-		require.NoError(err)
-		defer conn.Close()
-
-		err = grpc.Invoke(ctx, "/DummyService/dummyMethod", nil, nil, conn)
-		require.NotNil(err)
-		st, ok := status.FromError(err)
-		require.True(ok)
-		require.True(st.Code() == codes.Unimplemented)
-	})
-
-	t.Run("ClientWithoutTLS", func(t *testing.T) {
-		conn, err := xgrpc.NewClient(ctx, lis.Addr().String(), nil, grpc.WithBlock(), grpc.WithTimeout(time.Second))
-		if err != nil {
-			// On Linux we can have an error here due to failed TLS Handshake
-			// It's expected behavior
-			return
-		}
-		// If we got here, error must occur after the first call
-		require.NotNil(conn)
-		defer conn.Close()
-		err = grpc.Invoke(ctx, "/DummyService/dummyMethod", nil, nil, conn)
-		require.NotNil(err)
-		st, ok := status.FromError(err)
-		require.True(ok)
-		require.True(st.Code() == codes.Unavailable)
-	})
 }

--- a/util/xgrpc/client.go
+++ b/util/xgrpc/client.go
@@ -2,11 +2,14 @@ package xgrpc
 
 import (
 	"context"
+	"crypto/tls"
 
 	"github.com/grpc-ecosystem/go-grpc-middleware/tracing/opentracing"
+	"github.com/lucas-clemente/quic-go"
 	"github.com/opentracing/basictracer-go"
 	"github.com/opentracing/opentracing-go"
 	"github.com/sonm-io/core/insonmnia/auth"
+	"github.com/sonm-io/core/util/xnet"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 )
@@ -61,4 +64,35 @@ func newClient(ctx context.Context, addr string, credentials credentials.Transpo
 		return nil, err
 	}
 	return cc, err
+}
+
+func NewQUICClient(ctx context.Context, addr string, tlsConfig *tls.Config, credentials credentials.TransportCredentials, opts ...grpc.DialOption) (*grpc.ClientConn, error) {
+	authEndpoint, err := auth.NewAddr(addr)
+	if err != nil {
+		return nil, err
+	}
+
+	netAddr, err := authEndpoint.Addr()
+	if err != nil {
+		return nil, err
+	}
+
+	session, err := quic.DialAddr(netAddr, tlsConfig, xnet.DefaultQUICConfig())
+	if err != nil {
+		return nil, err
+	}
+
+	conn, err := xnet.NewQUICConn(session)
+	if err != nil {
+		return nil, err
+	}
+
+	opts = append(opts, WithConn(conn))
+
+	ethAddr, err := authEndpoint.ETH()
+	if err != nil {
+		return newClient(ctx, addr, credentials, opts...)
+	}
+
+	return newClient(ctx, netAddr, auth.NewWalletAuthenticator(credentials, ethAddr), opts...)
 }

--- a/util/xgrpc/client_test.go
+++ b/util/xgrpc/client_test.go
@@ -1,0 +1,68 @@
+package xgrpc
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/sonm-io/core/util"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func TestSecureGRPCConnect(t *testing.T) {
+	require := require.New(t)
+	ctx := context.Background()
+	serPriv, err := crypto.GenerateKey()
+	require.NoError(err)
+	rot, serTLS, err := util.NewHitlessCertRotator(ctx, serPriv)
+	require.NoError(err)
+	defer rot.Close()
+	serCreds := util.NewTLS(serTLS)
+	server := NewServer(nil, Credentials(serCreds))
+	lis, err := net.Listen("tcp", "localhost:0")
+	require.NoError(err)
+	defer lis.Close()
+	go func() {
+		server.Serve(lis)
+	}()
+
+	t.Run("ClientWithTLS", func(t *testing.T) {
+		clientPriv, err := crypto.GenerateKey()
+		require.NoError(err)
+		rot, clientTLS, err := util.NewHitlessCertRotator(ctx, clientPriv)
+		require.NoError(err)
+		defer rot.Close()
+		var clientCreds = util.NewTLS(clientTLS)
+		conn, err := NewClient(ctx, lis.Addr().String(), clientCreds, grpc.WithTimeout(time.Second), grpc.WithBlock())
+		require.NoError(err)
+		defer conn.Close()
+
+		err = grpc.Invoke(ctx, "/DummyService/dummyMethod", nil, nil, conn)
+		require.NotNil(err)
+		st, ok := status.FromError(err)
+		require.True(ok)
+		require.True(st.Code() == codes.Unimplemented)
+	})
+
+	t.Run("ClientWithoutTLS", func(t *testing.T) {
+		conn, err := NewClient(ctx, lis.Addr().String(), nil, grpc.WithBlock(), grpc.WithTimeout(time.Second))
+		if err != nil {
+			// On Linux we can have an error here due to failed TLS Handshake
+			// It's expected behavior
+			return
+		}
+		// If we got here, error must occur after the first call
+		require.NotNil(conn)
+		defer conn.Close()
+		err = grpc.Invoke(ctx, "/DummyService/dummyMethod", nil, nil, conn)
+		require.NotNil(err)
+		st, ok := status.FromError(err)
+		require.True(ok)
+		require.True(st.Code() == codes.Unavailable)
+	})
+}

--- a/util/xgrpc/credentials.go
+++ b/util/xgrpc/credentials.go
@@ -1,0 +1,22 @@
+package xgrpc
+
+import (
+	"crypto/tls"
+
+	. "github.com/sonm-io/core/util"
+	"google.golang.org/grpc/credentials"
+)
+
+// TransportCredentials wraps the standard transport credentials, adding an
+// ability to obtain the TLS config used.
+type TransportCredentials struct {
+	credentials.TransportCredentials
+	TLSConfig *tls.Config
+}
+
+func NewTransportCredentials(cfg *tls.Config) *TransportCredentials {
+	return &TransportCredentials{
+		TransportCredentials: NewTLS(cfg),
+		TLSConfig:            cfg,
+	}
+}

--- a/util/xnet/listener.go
+++ b/util/xnet/listener.go
@@ -38,3 +38,33 @@ func ListenLoopback(network string, port uint16) ([]net.Listener, error) {
 
 	return listeners, nil
 }
+
+func ListenPacketLoopback(network string, port uint16) ([]net.PacketConn, error) {
+	if network != "udp" && network != "udp4" && network != "udp6" {
+		return nil, fmt.Errorf("unexpected network type: %s", network)
+	}
+
+	ips, err := LookupLoopbackIP()
+	if err != nil {
+		return nil, err
+	}
+
+	onFail := func(listeners []net.PacketConn) {
+		for _, listener := range listeners {
+			listener.Close()
+		}
+	}
+
+	var listeners []net.PacketConn
+	for _, ip := range ips {
+		listener, err := net.ListenPacket(network, net.JoinHostPort(ip.String(), strconv.Itoa(int(port))))
+		if err != nil {
+			onFail(listeners)
+			return nil, err
+		}
+
+		listeners = append(listeners, listener)
+	}
+
+	return listeners, nil
+}

--- a/util/xnet/quic.go
+++ b/util/xnet/quic.go
@@ -1,0 +1,83 @@
+package xnet
+
+import (
+	"crypto/tls"
+	"net"
+
+	"github.com/lucas-clemente/quic-go"
+)
+
+func DefaultQUICConfig() *quic.Config {
+	return &quic.Config{
+		Versions: []quic.VersionNumber{
+			quic.VersionGQUIC39,
+			quic.VersionGQUIC43,
+			quic.VersionMilestone0_10_0,
+		},
+		KeepAlive: true,
+	}
+}
+
+type QUICConn struct {
+	quic.Stream
+	session quic.Session
+}
+
+func NewQUICConn(session quic.Session) (*QUICConn, error) {
+	stream, err := session.OpenStream()
+	if err != nil {
+		return nil, err
+	}
+
+	m := &QUICConn{
+		Stream:  stream,
+		session: session,
+	}
+
+	return m, nil
+}
+
+func (m *QUICConn) LocalAddr() net.Addr {
+	return m.session.LocalAddr()
+}
+
+func (m *QUICConn) RemoteAddr() net.Addr {
+	return m.session.RemoteAddr()
+}
+
+func ListenQUIC(network, address string, tlsConfig *tls.Config, config *quic.Config) (*QUICListener, error) {
+	conn, err := net.ListenPacket(network, address)
+	if err != nil {
+		return nil, err
+	}
+
+	listener, err := quic.Listen(conn, tlsConfig, config)
+	if err != nil {
+		return nil, err
+	}
+
+	return &QUICListener{Listener: listener}, nil
+}
+
+type QUICListener struct {
+	quic.Listener
+}
+
+func (m *QUICListener) Accept() (net.Conn, error) {
+	session, err := m.Listener.Accept()
+	if err != nil {
+		return nil, err
+	}
+
+	stream, err := session.AcceptStream()
+	if err != nil {
+		return nil, err
+	}
+
+	conn := &QUICConn{
+		Stream:  stream,
+		session: session,
+	}
+
+	return conn, nil
+}


### PR DESCRIPTION
Tread lightly. What is it now? Speak, fool. At last. No one orders me around!

Introducing QUIC protocol support in most of the components. QUIC is
an experimental transport layer network protocol, which we use as an
alternative to TCP to achieve reliable communication between our
components.
The main reason to include this is to increase connection establishing
stability between any 2 peers, which are located under private networks.
QUIC is designed at top of UDP, which is more predictable and
investigated for NAT penetration, unlike we do for TCP in a hacky way.
Since QUIC allows to multiplex many connections into a single socket
there is no need to penetrate NAT for the same client-server pair
multiple times. After the first successful attempt, the punched hole will
be reused.

The Rendezvous server has been updated to support UDP hole punching using
QUIC protocol. It additionally exposes its gRPC server on the same UDP
port as for TCP, since it is possible to reuse ports in case of different
network protocols used. The wire-level left the same - gRPC.

Affected components: Worker, Node, Rendezvous. Both Node and Worker now
expose its gRPC services on both TCP and UDP sockets, the port number is
the same.

At last, Windows users now can utilize our NAT punching feature, since
multiplexed UDP communication does not require SO_REUSEPORT flag. So
relaying now isn't the only single option for Windows.

Note, that this feature is currently in an experimental stage. You can
try it by specifying "SONM_ENABLE_QUIC=true" environment while starting
Node server.