### PR TITLE
fix: properly eject spot committed ask-plans

### DIFF
--- a/insonmnia/resource/plan_pool.go
+++ b/insonmnia/resource/plan_pool.go
@@ -120,11 +120,18 @@ func (m *pool) shrinkSpotPool(plan *sonm.AskPlan) ([]string, error) {
 func (m *pool) shrinkCommitedSpotPool(plan *sonm.AskPlan) ([]string, error) {
 	ejectedPlans := []string{}
 	available := deepcopy.Copy(m.all).(*sonm.AskPlanResources)
-	commitedSum, err := m.commitedFw.Sum()
+	commitedFwSum, err := m.commitedFw.Sum()
 	if err != nil {
 		return ejectedPlans, err
 	}
-	if err := available.Sub(commitedSum); err != nil {
+	commitedSpotSum, err := m.commitedSpot.Sum()
+	if err != nil {
+		return ejectedPlans, err
+	}
+	if err := available.Sub(commitedFwSum); err != nil {
+		return ejectedPlans, err
+	}
+	if err := available.Sub(commitedSpotSum); err != nil {
 		return ejectedPlans, err
 	}
 	return m.ejectAskPlans(plan.GetResources(), available, m.commitedSpot)


### PR DESCRIPTION
Subtraction of committed spot ask-plans was forgotten resulting in inappropriate available resources calculation. This sometimes led to a situation where the same resource was sold multiple times.
Now everything should work properly.
WARNING: we recommend everyone to update workers, otherwise, they may get blacklisted.