### PR TITLE
fix: deadlock in Rendezvous server

### DIFF
--- a/insonmnia/npp/rendezvous/server.go
+++ b/insonmnia/npp/rendezvous/server.go
@@ -251,7 +251,7 @@ func (m *Server) Publish(ctx context.Context, request *sonm.PublishRequest) (*so
 }
 
 func (m *Server) addServerWatch(id nppc.ResourceID, peer Peer) (<-chan Peer, deleter) {
-	c := make(chan Peer, 1)
+	c := make(chan Peer, 2)
 
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -275,7 +275,7 @@ func (m *Server) addServerWatch(id nppc.ResourceID, peer Peer) (<-chan Peer, del
 }
 
 func (m *Server) newClientWatch(id nppc.ResourceID, peer Peer) (<-chan Peer, deleter) {
-	c := make(chan Peer, 1)
+	c := make(chan Peer, 2)
 
 	m.mu.Lock()
 	defer m.mu.Unlock()


### PR DESCRIPTION
There is a situation where a client no longer awaits the resolution result, while there is actually alive server who is ready to establish the connection. In this case the communication channel becomes overflowed (because of its capacity of 1), which leads to a deadlock.
This PR fixes that by increasing the capacity to 2. Not the best solution, but for now at least it fixes deadlocking.