### PR TITLE
feat: show deal type in deal list cmd

### DIFF
--- a/cmd/cli/commands/printers.go
+++ b/cmd/cli/commands/printers.go
@@ -397,6 +397,16 @@ func dealsExpensesPerHour(addr common.Address, deals []*sonm.DWHDeal) (*sonm.Big
 	return sonm.NewBigInt(inAsks), sonm.NewBigInt(inBids)
 }
 
+func dealType(deal *sonm.Deal, addr common.Address) string {
+	if deal.GetSupplierID().Unwrap() == addr || deal.GetMasterID().Unwrap() == addr {
+		return "SELL"
+	}
+	if deal.GetConsumerID().Unwrap() == addr {
+		return "BUY"
+	}
+	return ""
+}
+
 func printDealsList(cmd *cobra.Command, addr common.Address, deals []*sonm.DWHDeal) {
 	asks, bids := dealsExpensesPerHour(addr, deals)
 
@@ -407,7 +417,7 @@ func printDealsList(cmd *cobra.Command, addr common.Address, deals []*sonm.DWHDe
 		}
 
 		w := tablewriter.NewWriter(cmd.OutOrStdout())
-		w.SetHeader([]string{"ID", "price", "started at", "duration", "counterparty"})
+		w.SetHeader([]string{"ID", "type", "price", "started at", "duration", "counterparty"})
 		w.SetCaption(true, fmt.Sprintf("count: %d  ASKs: %s USD/h  BIDs: %s USD/h",
 			len(deals), asks.ToPriceString(), bids.ToPriceString()))
 		w.SetBorder(false)
@@ -424,6 +434,7 @@ func printDealsList(cmd *cobra.Command, addr common.Address, deals []*sonm.DWHDe
 
 			w.Append([]string{
 				deal.GetId().Unwrap().String(),
+				dealType(d.GetDeal(), addr),
 				deal.PricePerHour(),
 				deal.StartTime.Unix().Format(time.RFC3339),
 				duration,

--- a/cmd/cli/commands/printers.go
+++ b/cmd/cli/commands/printers.go
@@ -398,10 +398,14 @@ func dealsExpensesPerHour(addr common.Address, deals []*sonm.DWHDeal) (*sonm.Big
 }
 
 func dealType(deal *sonm.Deal, addr common.Address) string {
-	if deal.GetSupplierID().Unwrap() == addr || deal.GetMasterID().Unwrap() == addr {
+	isSell := deal.GetSupplierID().Unwrap() == addr || deal.GetMasterID().Unwrap() == addr
+	isBuy := deal.GetConsumerID().Unwrap() == addr
+
+	if isSell && isBuy {
+		return "BOTH"
+	} else if isSell {
 		return "SELL"
-	}
-	if deal.GetConsumerID().Unwrap() == addr {
+	} else if isBuy {
 		return "BUY"
 	}
 	return ""


### PR DESCRIPTION
This commit adds the `type` field into the `sonmcli deal list` command.
The type indicates that the current user is selling or buying resources in that deal.

Closes #1445