### PR TITLE
fix: replace TCP KA with HTTP2 pings to Rendezvous

### DIFF
--- a/insonmnia/npp/net.go
+++ b/insonmnia/npp/net.go
@@ -5,14 +5,14 @@ import (
 	"fmt"
 	"net"
 	"syscall"
-	"time"
 
 	"github.com/libp2p/go-reuseport"
 	"github.com/sonm-io/core/util/netutil"
 )
 
-const protocol = "tcp"
-const tcpKeepAliveInterval = 15 * time.Second
+const (
+	protocol = "tcp"
+)
 
 type Port uint16
 

--- a/insonmnia/npp/rendezvous/server.go
+++ b/insonmnia/npp/rendezvous/server.go
@@ -38,6 +38,7 @@ import (
 	"math/rand"
 	"net"
 	"sync"
+	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
@@ -52,6 +53,7 @@ import (
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/keepalive"
 	"google.golang.org/grpc/peer"
 	"google.golang.org/grpc/status"
 )
@@ -142,6 +144,14 @@ func NewServer(cfg *ServerConfig, options ...Option) (*Server, error) {
 		log: opts.Log,
 		server: xgrpc.NewServer(
 			opts.Log,
+			xgrpc.GRPCServerOptions(
+				grpc.KeepaliveParams(keepalive.ServerParameters{
+					Time: 30 * time.Second,
+				}),
+				grpc.KeepaliveEnforcementPolicy(keepalive.EnforcementPolicy{
+					MinTime: 30 * time.Second,
+				}),
+			),
 			xgrpc.Credentials(opts.Credentials),
 			xgrpc.DefaultTraceInterceptor(),
 			xgrpc.RequestLogInterceptor([]string{}),

--- a/insonmnia/npp/rv.go
+++ b/insonmnia/npp/rv.go
@@ -3,6 +3,7 @@ package npp
 import (
 	"context"
 	"net"
+	"time"
 
 	"github.com/libp2p/go-reuseport"
 	"github.com/lucas-clemente/quic-go"
@@ -10,7 +11,9 @@ import (
 	"github.com/sonm-io/core/insonmnia/npp/rendezvous"
 	"github.com/sonm-io/core/util/xgrpc"
 	"github.com/sonm-io/core/util/xnet"
+	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/keepalive"
 )
 
 // RendezvousClient is a tiny wrapper over the generated gRPC client allowing
@@ -26,26 +29,28 @@ type rendezvousClient struct {
 }
 
 func newRendezvousClient(ctx context.Context, addr auth.Addr, credentials credentials.TransportCredentials) (*rendezvousClient, error) {
-	// Setting TCP keepalive is required, because NAT's conntrack can purge out
-	// idle connections for its internal garbage collection reasons at the most
-	// inopportune moment.
-	dialer := reuseport.Dialer{
-		D: net.Dialer{
-			KeepAlive: tcpKeepAliveInterval,
-		},
-	}
-
 	netAddr, err := addr.Addr()
 	if err != nil {
 		return nil, err
 	}
 
+	dialer := reuseport.Dialer{}
 	conn, err := dialer.Dial(protocol, netAddr)
 	if err != nil {
 		return nil, err
 	}
 
-	client, err := rendezvous.NewRendezvousClient(ctx, addr.String(), credentials, xgrpc.WithConn(conn))
+	options := []grpc.DialOption{
+		xgrpc.WithConn(conn),
+		// Setting HTTP/2 keepalive is required, because NAT's conntrack can purge out
+		// idle connections for its internal garbage collection reasons at the most
+		// inopportune moment.
+		grpc.WithKeepaliveParams(keepalive.ClientParameters{
+			Time: 30 * time.Second,
+		}),
+	}
+
+	client, err := rendezvous.NewRendezvousClient(ctx, addr.String(), credentials, options...)
 	if err != nil {
 		return nil, err
 	}

--- a/util/xgrpc/options.go
+++ b/util/xgrpc/options.go
@@ -35,6 +35,12 @@ const (
 
 type ServerOption func(options *options)
 
+func GRPCServerOptions(opts ...grpc.ServerOption) ServerOption {
+	return func(o *options) {
+		o.options = append(o.options, opts...)
+	}
+}
+
 // Credentials activates credentials for server connections.
 func Credentials(creds credentials.TransportCredentials) ServerOption {
 	return func(o *options) {


### PR DESCRIPTION
Previously we tried to set up TCP keepalive option to ensure that even
if the NAT closes the connection we're still able to detect it properly.
However, the library we use to configure SO_REUSEPORT option just
ignores any keepalive specifications. So we set it, but nothing worked
properly. All this results in a situation when sometimes during either
network instability or NAT conntrack configurations the Rendezvous
server properly detected whether a Worker is disconnected, but the
Worker itself - was not, otherwise it would try to reconnect.
This change replaces TCP keepalives with HTTP/2 ping frames, which
are more portable and works in userland.