### PR TITLE
refactor: avoid duplication in CLI's flags

### DIFF
--- a/cmd/cli/commands/common.go
+++ b/cmd/cli/commands/common.go
@@ -29,6 +29,10 @@ const (
 	detailsFlag       = "detailed"
 	prependStreamFlag = "source"
 	defaultNodeAddr   = "localhost:15030"
+
+	// flag defaults
+	defaultListLimit   = 100
+	defaultConnTimeout = 60 * time.Second
 )
 
 var (
@@ -45,10 +49,11 @@ var (
 	// deprecated: should be replaced with outputModeJSON
 	outputModeFlag string
 	outputModeJSON bool
-	timeoutFlag    = 60 * time.Second
+	timeoutFlag    time.Duration
 	insecureFlag   bool
 	keystoreFlag   string
 	configFlag     string
+	listLimitFlag  uint64
 
 	// logging flag vars
 	logType       string
@@ -102,7 +107,7 @@ func init() {
 	})
 
 	rootCmd.PersistentFlags().StringVar(&nodeAddressFlag, "node", "", "node endpoint")
-	rootCmd.PersistentFlags().DurationVar(&timeoutFlag, "timeout", 60*time.Second, "Connection timeout")
+	rootCmd.PersistentFlags().DurationVar(&timeoutFlag, "timeout", defaultConnTimeout, "Connection timeout")
 	rootCmd.PersistentFlags().StringVar(&outputModeFlag, "out", "", "Output mode: simple or json (DEPRECATED)")
 	rootCmd.PersistentFlags().BoolVar(&outputModeJSON, "json", false, "Show command output in JSON format")
 	rootCmd.PersistentFlags().BoolVar(&insecureFlag, "insecure", false, "Disable TLS for connection")

--- a/cmd/cli/commands/deals.go
+++ b/cmd/cli/commands/deals.go
@@ -13,7 +13,6 @@ import (
 )
 
 var (
-	dealsSearchCount  uint64
 	blacklistTypeStr  string
 	crNewDurationFlag string
 	crNewPriceFlag    string
@@ -22,7 +21,7 @@ var (
 )
 
 func init() {
-	dealListCmd.PersistentFlags().Uint64Var(&dealsSearchCount, "limit", 10, "Deals count to show")
+	dealListCmd.PersistentFlags().Uint64Var(&listLimitFlag, "limit", defaultListLimit, "Deals count to show")
 	dealCloseCmd.PersistentFlags().StringVar(&blacklistTypeStr, "blacklist", "nobody", "Whom to add to blacklist: `worker`, `master` or `nobody`")
 
 	changeRequestCreateCmd.PersistentFlags().StringVar(&crNewDurationFlag, "new-duration", "", "Propose new duration for a deal")
@@ -75,7 +74,7 @@ var dealListCmd = &cobra.Command{
 		}
 		req := &sonm.DealsRequest{
 			AnyUserID: sonm.NewEthAddress(addr),
-			Limit:     dealsSearchCount,
+			Limit:     listLimitFlag,
 			Status:    sonm.DealStatus_DEAL_ACCEPTED,
 			Sortings: []*sonm.SortingOption{{
 				Field: "StartTime",

--- a/cmd/cli/commands/orders.go
+++ b/cmd/cli/commands/orders.go
@@ -8,12 +8,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var (
-	ordersSearchLimit uint64 = 0
-)
-
 func init() {
-	orderListCmd.PersistentFlags().Uint64Var(&ordersSearchLimit, "limit", 10, "Orders count to show")
+	orderListCmd.PersistentFlags().Uint64Var(&listLimitFlag, "limit", defaultListLimit, "Orders count to show")
 
 	orderRootCmd.AddCommand(
 		orderListCmd,
@@ -42,7 +38,7 @@ var orderListCmd = &cobra.Command{
 			return fmt.Errorf("сannot create client connection: %v", err)
 		}
 
-		req := &sonm.Count{Count: ordersSearchLimit}
+		req := &sonm.Count{Count: listLimitFlag}
 		reply, err := market.GetOrders(ctx, req)
 		if err != nil {
 			return fmt.Errorf("cannot receive orders from marketplace: %v", err)


### PR DESCRIPTION
* Default limit for list requests is moved to constant and increased from 10 to 100.
* Limit var moved to global flags to avoid duplication in each *List sub-command.
* Default timeout is defined as constant.