### PR TITLE
feat: version checking for core components

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ ifeq ($(WITH_NL),true)
     NL_TAGS := nl
 endif
 
-LDFLAGS = -X github.com/sonm-io/core/cmd.AppVersion=$(FULL_VERSION)
+LDFLAGS = -X github.com/sonm-io/core/insonmnia/version.Version=$(FULL_VERSION)
 
 .PHONY: fmt vet test
 
@@ -190,6 +190,7 @@ mock: build_mockgen
 	mockgen -package sonm -destination proto/marketplace_mock.go  -source proto/marketplace.pb.go
 	mockgen -package sonm -destination proto/dwh_mock.go  -source proto/dwh.pb.go
 	mockgen -package node -destination insonmnia/node/server_mock.go -source insonmnia/node/server.go
+	mockgen -package version -destination insonmnia/version/version_mock.go -source insonmnia/version/version.go
 
 clean:
 	rm -f ${WORKER} ${CLI} ${NODE} ${AUTOCLI} ${RENDEZVOUS}

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -3,12 +3,12 @@ package main
 import (
 	"os"
 
-	"github.com/sonm-io/core/cmd"
 	"github.com/sonm-io/core/cmd/cli/commands"
+	"github.com/sonm-io/core/insonmnia/version"
 )
 
 func main() {
-	root := commands.Root(cmd.AppVersion)
+	root := commands.Root(version.Version)
 	if err := root.Execute(); err != nil {
 		commands.ShowError(root, err.Error(), nil)
 		os.Exit(1)

--- a/cmd/cobra.go
+++ b/cmd/cobra.go
@@ -7,16 +7,16 @@ import (
 	"strings"
 
 	"github.com/mitchellh/go-homedir"
+	"github.com/sonm-io/core/insonmnia/version"
 	"github.com/sonm-io/core/util"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
 
 var (
-	AppVersion string
-	app        = AppContext{
+	app = AppContext{
 		Name:    path.Base(os.Args[0]),
-		Version: AppVersion,
+		Version: version.Version,
 	}
 	showVersion bool
 )

--- a/cmd/node/main.go
+++ b/cmd/node/main.go
@@ -8,6 +8,7 @@ import (
 	"github.com/sonm-io/core/cmd"
 	"github.com/sonm-io/core/insonmnia/logging"
 	"github.com/sonm-io/core/insonmnia/node"
+	"github.com/sonm-io/core/insonmnia/version"
 	"github.com/sonm-io/core/util/metrics"
 	"golang.org/x/sync/errgroup"
 )
@@ -28,6 +29,7 @@ func run(app cmd.AppContext) error {
 	}
 
 	ctx := ctxlog.WithLogger(context.Background(), log)
+	version.ValidateVersion(ctx, version.NewLogObserver(log.Sugar()))
 
 	wg, ctx := errgroup.WithContext(ctx)
 	wg.Go(func() error {

--- a/cmd/optimus/main.go
+++ b/cmd/optimus/main.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/noxiouz/zapctx/ctxlog"
 	"github.com/sonm-io/core/cmd"
+	"github.com/sonm-io/core/insonmnia/version"
 	"github.com/sonm-io/core/optimus"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
@@ -45,6 +46,7 @@ func run(app cmd.AppContext) error {
 	}
 
 	ctx := ctxlog.WithLogger(context.Background(), log)
+	version.ValidateVersion(ctx, version.NewLogObserver(log.Sugar()))
 	bot, err := optimus.NewOptimus(cfg, optimus.WithVersion(app.Version), optimus.WithLog(log.Sugar()))
 	if err != nil {
 		return fmt.Errorf("failed to create Optimus: %v", err)

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -11,6 +11,7 @@ import (
 	"github.com/sonm-io/core/cmd"
 	"github.com/sonm-io/core/insonmnia/logging"
 	"github.com/sonm-io/core/insonmnia/state"
+	"github.com/sonm-io/core/insonmnia/version"
 	"github.com/sonm-io/core/insonmnia/worker"
 	"github.com/sonm-io/core/util/metrics"
 	"go.uber.org/zap"
@@ -34,6 +35,7 @@ func run(app cmd.AppContext) error {
 		return fmt.Errorf("failed to build logger instance: %s", err)
 	}
 	ctx = log.WithLogger(ctx, logger)
+	version.ValidateVersion(ctx, version.NewLogObserver(logger.Sugar()))
 
 	storage, err := state.NewState(ctx, &cfg.Storage)
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/asaskevich/govalidator v0.0.0-20180319081651-7d2e70ef918f
 	github.com/beorn7/perks v0.0.0-20160804104726-4c0e84591b9a
 	github.com/bifurcation/mint v0.0.0-20181105071958-a14404e9a861 // indirect
+	github.com/blang/semver v3.5.1+incompatible
 	github.com/boltdb/bolt v1.3.1
 	github.com/btcsuite/btcd v0.0.0-20171023093315-c7588cbf7690
 	github.com/c2h5oh/datasize v0.0.0-20171227191756-4eba002a5eae

--- a/go.sum
+++ b/go.sum
@@ -24,6 +24,8 @@ github.com/beorn7/perks v0.0.0-20160804104726-4c0e84591b9a h1:BtpsbiV638WQZwhA98
 github.com/beorn7/perks v0.0.0-20160804104726-4c0e84591b9a/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/bifurcation/mint v0.0.0-20181105071958-a14404e9a861 h1:x17NvoJaphEzay72TFej4OSSsgu3xRYBLkbIwdofS/4=
 github.com/bifurcation/mint v0.0.0-20181105071958-a14404e9a861/go.mod h1:zVt7zX3K/aDCk9Tj+VM7YymsX66ERvzCJzw8rFCX2JU=
+github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdnnjpJbkM4JQ=
+github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/boltdb/bolt v1.3.1 h1:JQmyP4ZBrce+ZQu0dY660FMfatumYDLun9hBCUVIkF4=
 github.com/boltdb/bolt v1.3.1/go.mod h1:clJnj/oiGkjum5o1McbSZDSLxVThjynRyGBgiAx27Ps=
 github.com/btcsuite/btcd v0.0.0-20171023093315-c7588cbf7690 h1:YSTjdPEsX8T2D31S9U7c4xxo0sQGa6TZ65cpCd7yVqU=

--- a/insonmnia/version/version.go
+++ b/insonmnia/version/version.go
@@ -1,0 +1,431 @@
+package version
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/blang/semver"
+	"github.com/mitchellh/go-homedir"
+	"go.uber.org/zap"
+	"gopkg.in/yaml.v2"
+)
+
+const (
+	versionFilePath = "~/.sonm/version.yaml"
+	versionURI      = "https://api.github.com/repos/sonm-io/core/git/refs/tags"
+)
+
+// Version shows the current SONM platform version.
+//
+// Components like Node, Worker, CLI, etc. share the same version number.
+var Version string
+
+type Observer interface {
+	OnError(err error)
+	OnDeprecatedVersion(version, latestVersion semver.Version)
+	OnBleedingEdgeVersion(version, latestVersion semver.Version)
+}
+
+type LogObserver struct {
+	log *zap.SugaredLogger
+}
+
+func NewLogObserver(log *zap.SugaredLogger) *LogObserver {
+	return &LogObserver{
+		log: log,
+	}
+}
+
+func (m *LogObserver) OnError(err error) {
+	m.log.Warnw("failed to validate version", zap.Error(err))
+}
+
+func (m *LogObserver) OnDeprecatedVersion(version, latestVersion semver.Version) {
+	m.log.Warnf("current version %s is OUTDATED, consider update to %s", version.String(), latestVersion.String())
+}
+
+func (m *LogObserver) OnBleedingEdgeVersion(version, latestVersion semver.Version) {
+	m.log.Warnf("current version %s is UNSTABLE, consider using stable %s version", version.String(), latestVersion.String())
+}
+
+// ValidateVersion performs the current component's version validation.
+// The idea is to notify whether the current version is either outdated or
+// unstable.
+func ValidateVersion(ctx context.Context, observer Observer) {
+	path, err := homedir.Expand(versionFilePath)
+	if err != nil {
+		observer.OnError(err)
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	defer cancel()
+
+	manager := NewVersionManager(&fs{path: path})
+	if err := manager.ValidateCurrentVersion(ctx); err != nil {
+		switch e := err.(type) {
+		case *OSError:
+			observer.OnError(e)
+		case *VersionMismatchError:
+			if e.IsDeprecated() {
+				observer.OnDeprecatedVersion(e.Version, e.LatestVersion)
+			}
+			if e.IsBleedingEdge() {
+				observer.OnBleedingEdgeVersion(e.Version, e.LatestVersion)
+			}
+		default:
+		}
+	}
+}
+
+// OSError represents an OS error that is occurred during version checking.
+type OSError struct {
+	error
+}
+
+// Unwrap unwraps the underlying error.
+//
+// This is useful for further error kind checking, for example using "os.IsPermission(err)".
+func (m *OSError) Unwrap() error {
+	return m.error
+}
+
+// CodecError represents an en/decoding error while deserializing a version
+// file content into structured representation.
+type CodecError struct {
+	error
+}
+
+// UpdateError is an error that can occur while updating the latest known
+// version.
+type UpdateError struct {
+	error
+}
+
+// VersionMismatchError indicates about version mismatch with the latest one.
+type VersionMismatchError struct {
+	Version       semver.Version
+	LatestVersion semver.Version
+}
+
+func (m *VersionMismatchError) IsDeprecated() bool {
+	return m.Version.LT(m.LatestVersion)
+}
+
+func (m *VersionMismatchError) IsBleedingEdge() bool {
+	return m.Version.GT(m.LatestVersion)
+}
+
+func (m *VersionMismatchError) Error() string {
+	return fmt.Sprintf("version mismatch: %s != %s", m.Version.String(), m.LatestVersion.String())
+}
+
+// Option is a type alias for configuring version manager.
+type Option func(o *options)
+
+// WithClock allows to assign a specific clock to the version manager.
+//
+// By default the "time.Now" is used.
+func WithClock(clock func() time.Time) Option {
+	return func(o *options) {
+		o.Clock = clock
+	}
+}
+
+// WithVersionFetcher allows to specify version fetcher.
+//
+// By default the GitHub tag fetcher is used.
+func WithVersionFetcher(versionFetcher VersionFetcher) Option {
+	return func(o *options) {
+		o.VersionFetcher = versionFetcher
+	}
+}
+
+// WithVersion allows to specify an application version.
+//
+// By default the version obtained through link parameters is used.
+func WithVersion(version semver.Version) Option {
+	return func(o *options) {
+		o.Version = version
+	}
+}
+
+type options struct {
+	Version        semver.Version
+	Clock          func() time.Time
+	ExpireDuration time.Duration
+	VersionFetcher VersionFetcher
+}
+
+func newOptions() *options {
+	version, err := semver.ParseTolerant(Version)
+	if err != nil {
+		// This should never happen unless we change the version format
+		// in Makefile.
+		panic(fmt.Sprintf("failed to parse linked application version: %v", err))
+	}
+
+	version.Build = nil
+	version.Pre = nil
+
+	return &options{
+		Version:        version,
+		Clock:          time.Now,
+		ExpireDuration: 24 * time.Hour,
+		VersionFetcher: newVersionFetcher(versionURI),
+	}
+}
+
+// File represents a file handle.
+//
+// Exists primarily for testing purposes.
+type File interface {
+	Read(p []byte) (int, error)
+	Write(p []byte) (int, error)
+	Close() error
+}
+
+// VersionFetcher is a thing that can update the current latest version number
+// from external sources.
+type VersionFetcher interface {
+	Update(ctx context.Context) (semver.Version, error)
+}
+
+type gitTag struct {
+	Ref string
+}
+
+type versionFetcher struct {
+	url string
+}
+
+func newVersionFetcher(url string) *versionFetcher {
+	return &versionFetcher{
+		url: url,
+	}
+}
+
+func (m *versionFetcher) Update(ctx context.Context) (semver.Version, error) {
+	response, err := http.Get(m.url)
+	if err != nil {
+		return semver.Version{}, err
+	}
+	defer response.Body.Close()
+
+	data, err := ioutil.ReadAll(response.Body)
+	if err != nil {
+		return semver.Version{}, err
+	}
+
+	var tags []*gitTag
+	if err := json.Unmarshal(data, &tags); err != nil {
+		return semver.Version{}, err
+	}
+
+	if len(tags) == 0 {
+		return semver.Version{}, fmt.Errorf("no versions found")
+	}
+
+	version := strings.Replace(tags[len(tags)-1].Ref, "refs/tags/v", "", -1)
+
+	return semver.Parse(version)
+}
+
+// FS encapsulates platform dependent filesystem functions.
+type FS interface {
+	// Open opens the version file for reading.
+	Open() (File, error)
+	// Create creates the version file with mode 0666.
+	Create() (File, error)
+}
+
+type fs struct {
+	path string
+}
+
+func (m *fs) Open() (File, error) {
+	return os.Open(m.path)
+}
+
+func (m *fs) Create() (File, error) {
+	return os.Create(m.path)
+}
+
+type versionData struct {
+	Version semver.Version
+	Updated time.Time
+}
+
+type versionRawData struct {
+	Version string
+	Updated string
+}
+
+func (m *versionData) MarshalYAML() (interface{}, error) {
+	return &versionRawData{
+		Version: m.Version.String(),
+		Updated: m.Updated.Format(time.RFC3339),
+	}, nil
+}
+
+func (m *versionData) UnmarshalYAML(decoder func(interface{}) error) error {
+	var content versionRawData
+	if err := decoder(&content); err != nil {
+		return &CodecError{error: err}
+	}
+
+	if len(content.Version) == 0 {
+		return &CodecError{error: fmt.Errorf(`missing "version" field`)}
+	}
+
+	if len(content.Updated) == 0 {
+		return &CodecError{error: fmt.Errorf(`missing "updated" field`)}
+	}
+
+	if strings.HasPrefix(content.Version, "v") {
+		content.Version = content.Version[1:]
+	}
+
+	version, err := semver.Parse(content.Version)
+	if err != nil {
+		return &CodecError{error: err}
+	}
+
+	m.Version = version
+
+	updated, err := time.Parse(time.RFC3339, content.Updated)
+	if err != nil {
+		return &CodecError{error: err}
+	}
+
+	m.Updated = updated
+
+	return nil
+}
+
+type VersionManager struct {
+	fs             FS
+	clock          func() time.Time
+	version        semver.Version
+	versionFetcher VersionFetcher
+	expireDuration time.Duration
+}
+
+func NewVersionManager(fs FS, options ...Option) *VersionManager {
+	opts := newOptions()
+	for _, o := range options {
+		o(opts)
+	}
+
+	m := &VersionManager{
+		fs:             fs,
+		clock:          opts.Clock,
+		version:        opts.Version,
+		versionFetcher: opts.VersionFetcher,
+		expireDuration: opts.ExpireDuration,
+	}
+
+	return m
+}
+
+// ValidateCurrentVersion validates that the current application version is
+// the latest, reporting errors otherwise.
+//
+// Is is possible that this method fails to open the version file for some
+// reasons, for example because of permissions. It's the user's responsibility
+// either to handle or to ignore the error returned. It's a good idea is to log
+// such errors as warnings, but do not terminate the program.
+func (m *VersionManager) ValidateCurrentVersion(ctx context.Context) error {
+	latestVersion, err := m.latestVersion(ctx)
+	if err != nil {
+		return err
+	}
+
+	if m.version.Compare(latestVersion) != 0 {
+		return &VersionMismatchError{
+			Version:       m.version,
+			LatestVersion: latestVersion,
+		}
+	}
+
+	return nil
+}
+
+func (m *VersionManager) latestVersion(ctx context.Context) (semver.Version, error) {
+	versionDataValue, err := m.versionData()
+	if err != nil {
+		return semver.Version{}, err
+	}
+
+	if versionDataValue == nil {
+		versionDataValue = &versionData{}
+	}
+
+	if m.isExpired(versionDataValue.Updated) {
+		version, err := m.versionFetcher.Update(ctx)
+		if err != nil {
+			return semver.Version{}, &UpdateError{error: err}
+		}
+
+		versionDataValue = &versionData{
+			Version: version,
+			Updated: m.clock(),
+		}
+
+		file, err := m.fs.Create()
+		if err != nil {
+			return semver.Version{}, &OSError{error: err}
+		}
+		defer file.Close()
+
+		data, err := yaml.Marshal(versionDataValue)
+		if err != nil {
+			return semver.Version{}, &CodecError{error: err}
+		}
+
+		n, err := file.Write(data)
+		if err != nil {
+			return semver.Version{}, &OSError{error: err}
+		}
+		if n < len(data) {
+			return semver.Version{}, &OSError{error: io.ErrShortWrite}
+		}
+	}
+
+	return versionDataValue.Version, nil
+}
+
+func (m *VersionManager) versionData() (*versionData, error) {
+	file, err := m.fs.Open()
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+
+		return nil, &OSError{error: err}
+	}
+	defer file.Close()
+
+	data, err := ioutil.ReadAll(file)
+	if err != nil {
+		return nil, &OSError{error: err}
+	}
+
+	var content versionData
+	if err := yaml.Unmarshal(data, &content); err != nil {
+		return nil, &CodecError{error: err}
+	}
+
+	return &content, nil
+}
+
+func (m *VersionManager) isExpired(time time.Time) bool {
+	return time.Add(m.expireDuration).Before(m.clock())
+}

--- a/insonmnia/version/version_test.go
+++ b/insonmnia/version/version_test.go
@@ -1,0 +1,390 @@
+package version
+
+import (
+	"context"
+	"io"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/blang/semver"
+	"github.com/golang/mock/gomock"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
+)
+
+func init() {
+	Version = "v0.4.0-f6461c2a"
+}
+
+func TestVersionManagerErrFileFailedToOpen(t *testing.T) {
+	c := gomock.NewController(t)
+	defer c.Finish()
+
+	fs := NewMockFS(c)
+	fs.EXPECT().Open().Return(nil, os.ErrPermission)
+
+	m := NewVersionManager(fs)
+	err := m.ValidateCurrentVersion(context.Background())
+
+	require.Error(t, err)
+	osErr, ok := err.(*OSError)
+	require.True(t, ok)
+	require.True(t, os.IsPermission(osErr.Unwrap()))
+}
+
+func TestVersionManagerErrFileRead(t *testing.T) {
+	c := gomock.NewController(t)
+	defer c.Finish()
+
+	file := NewMockFile(c)
+	file.EXPECT().Close().Times(1)
+	file.EXPECT().Read(gomock.Any()).Return(0, os.ErrPermission)
+	fs := NewMockFS(c)
+	fs.EXPECT().Open().Return(file, nil)
+
+	m := NewVersionManager(fs)
+	err := m.ValidateCurrentVersion(context.Background())
+
+	require.Error(t, err)
+	osErr, ok := err.(*OSError)
+	require.True(t, ok)
+	require.True(t, os.IsPermission(osErr.Unwrap()))
+}
+
+func TestVersionManagerErrFileInvalidFormat(t *testing.T) {
+	c := gomock.NewController(t)
+	defer c.Finish()
+
+	content := `}{`
+
+	file := NewMockFile(c)
+	file.EXPECT().Close().Times(1)
+	file.EXPECT().Read(gomock.Any()).Do(func(buf []byte) {
+		copy(buf, []byte(content))
+	}).Return(len(content), io.EOF)
+	fs := NewMockFS(c)
+	fs.EXPECT().Open().Return(file, nil)
+
+	m := NewVersionManager(fs)
+	err := m.ValidateCurrentVersion(context.Background())
+
+	require.Error(t, err)
+	osErr, ok := err.(*CodecError)
+	require.True(t, ok)
+	require.Error(t, osErr)
+}
+
+func TestVersionManagerErrFileMissingVersion(t *testing.T) {
+	c := gomock.NewController(t)
+	defer c.Finish()
+
+	content := `{"updated": "2018-11-27 09:55:21+00:00"}`
+
+	file := NewMockFile(c)
+	file.EXPECT().Close().Times(1)
+	file.EXPECT().Read(gomock.Any()).Do(func(buf []byte) {
+		copy(buf, []byte(content))
+	}).Return(len(content), io.EOF)
+	fs := NewMockFS(c)
+	fs.EXPECT().Open().Return(file, nil)
+
+	m := NewVersionManager(fs)
+	err := m.ValidateCurrentVersion(context.Background())
+
+	require.Error(t, err)
+	osErr, ok := err.(*CodecError)
+	require.True(t, ok)
+	require.Error(t, osErr)
+}
+
+func TestVersionManagerErrFileMissingUpdated(t *testing.T) {
+	c := gomock.NewController(t)
+	defer c.Finish()
+
+	content := `{"version": "v0.4.16"}`
+
+	file := NewMockFile(c)
+	file.EXPECT().Close().Times(1)
+	file.EXPECT().Read(gomock.Any()).Do(func(buf []byte) {
+		copy(buf, []byte(content))
+	}).Return(len(content), io.EOF)
+	fs := NewMockFS(c)
+	fs.EXPECT().Open().Return(file, nil)
+
+	m := NewVersionManager(fs)
+	err := m.ValidateCurrentVersion(context.Background())
+
+	require.Error(t, err)
+	osErr, ok := err.(*CodecError)
+	require.True(t, ok)
+	require.Error(t, osErr)
+}
+
+func TestVersionManagerErrFileInvalidVersion(t *testing.T) {
+	c := gomock.NewController(t)
+	defer c.Finish()
+
+	content := `{"version": "vvv", "updated": "2018-11-27 09:55:21+00:00"}`
+
+	file := NewMockFile(c)
+	file.EXPECT().Close().Times(1)
+	file.EXPECT().Read(gomock.Any()).Do(func(buf []byte) {
+		copy(buf, []byte(content))
+	}).Return(len(content), io.EOF)
+	fs := NewMockFS(c)
+	fs.EXPECT().Open().Return(file, nil)
+
+	m := NewVersionManager(fs)
+	err := m.ValidateCurrentVersion(context.Background())
+
+	require.Error(t, err)
+	osErr, ok := err.(*CodecError)
+	require.True(t, ok)
+	require.Error(t, osErr)
+}
+
+func TestVersionManagerErrFileInvalidUpdated(t *testing.T) {
+	c := gomock.NewController(t)
+	defer c.Finish()
+
+	content := `{"version": "v0.4.16", "updated": "2018-11-27"}`
+
+	file := NewMockFile(c)
+	file.EXPECT().Close().Times(1)
+	file.EXPECT().Read(gomock.Any()).Do(func(buf []byte) {
+		copy(buf, []byte(content))
+	}).Return(len(content), io.EOF)
+	fs := NewMockFS(c)
+	fs.EXPECT().Open().Return(file, nil)
+
+	m := NewVersionManager(fs)
+	err := m.ValidateCurrentVersion(context.Background())
+
+	require.Error(t, err)
+	osErr, ok := err.(*CodecError)
+	require.True(t, ok)
+	require.Error(t, osErr)
+}
+
+func TestVersionManagerErrUpdateWhenExpired(t *testing.T) {
+	c := gomock.NewController(t)
+	defer c.Finish()
+
+	content := `{"version": "v0.4.16", "updated": "2018-11-20T00:00:00+00:00"}`
+
+	file := NewMockFile(c)
+	file.EXPECT().Close().Times(1)
+	file.EXPECT().Read(gomock.Any()).Do(func(buf []byte) {
+		copy(buf, []byte(content))
+	}).Return(len(content), io.EOF)
+
+	fs := NewMockFS(c)
+	fs.EXPECT().Open().Return(file, nil)
+
+	versionFetcher := NewMockVersionFetcher(c)
+	versionFetcher.EXPECT().Update(context.Background()).Return(semver.Version{}, errors.New("no"))
+
+	clock := func() time.Time {
+		now, err := time.Parse(time.RFC3339, "2018-11-22T00:00:00+00:00")
+		require.NoError(t, err)
+		return now
+	}
+	m := NewVersionManager(fs, WithClock(clock), WithVersionFetcher(versionFetcher))
+	err := m.ValidateCurrentVersion(context.Background())
+
+	require.Error(t, err)
+	osErr, ok := err.(*UpdateError)
+	require.True(t, ok)
+	require.Error(t, osErr)
+}
+
+func TestVersionManagerErrUpdateWhenExpiredThenWhenCreate(t *testing.T) {
+	c := gomock.NewController(t)
+	defer c.Finish()
+
+	content := `{"version": "v0.4.16", "updated": "2018-11-20T00:00:00+00:00"}`
+
+	file := NewMockFile(c)
+	file.EXPECT().Close().Times(1)
+	file.EXPECT().Read(gomock.Any()).Do(func(buf []byte) {
+		copy(buf, []byte(content))
+	}).Return(len(content), io.EOF)
+
+	fs := NewMockFS(c)
+	fs.EXPECT().Open().Return(file, nil)
+	fs.EXPECT().Create().Return(nil, os.ErrPermission)
+
+	versionFetcher := NewMockVersionFetcher(c)
+	versionFetcher.EXPECT().Update(context.Background()).Return(semver.Version{Minor: 4, Patch: 17}, nil)
+
+	clock := func() time.Time {
+		now, err := time.Parse(time.RFC3339, "2018-11-22T00:00:00+00:00")
+		require.NoError(t, err)
+		return now
+	}
+	m := NewVersionManager(fs, WithClock(clock), WithVersionFetcher(versionFetcher))
+	err := m.ValidateCurrentVersion(context.Background())
+
+	require.Error(t, err)
+	osErr, ok := err.(*OSError)
+	require.True(t, ok)
+	require.Error(t, osErr)
+}
+
+func TestVersionManagerErrUpdateWhenExpiredThenWhenSave(t *testing.T) {
+	c := gomock.NewController(t)
+	defer c.Finish()
+
+	content := `{"version": "v0.4.16", "updated": "2018-11-20T00:00:00+00:00"}`
+	expectedContent := `version: 0.4.17
+updated: "2018-11-22T00:00:00Z"
+`
+
+	file := NewMockFile(c)
+	file.EXPECT().Close().Times(2)
+	file.EXPECT().Read(gomock.Any()).Do(func(buf []byte) {
+		copy(buf, []byte(content))
+	}).Return(len(content), io.EOF)
+	file.EXPECT().Write([]byte(expectedContent)).Return(len(expectedContent), os.ErrPermission)
+
+	fs := NewMockFS(c)
+	fs.EXPECT().Open().Return(file, nil)
+	fs.EXPECT().Create().Return(file, nil)
+
+	versionFetcher := NewMockVersionFetcher(c)
+	versionFetcher.EXPECT().Update(context.Background()).Return(semver.Version{Minor: 4, Patch: 17}, nil)
+
+	clock := func() time.Time {
+		now, err := time.Parse(time.RFC3339, "2018-11-22T00:00:00+00:00")
+		require.NoError(t, err)
+		return now
+	}
+	m := NewVersionManager(fs, WithClock(clock), WithVersionFetcher(versionFetcher))
+	err := m.ValidateCurrentVersion(context.Background())
+
+	require.Error(t, err)
+	osErr, ok := err.(*OSError)
+	require.True(t, ok)
+	require.Error(t, osErr)
+}
+
+func TestVersionManagerErrVersionMismatchAfterUpdate(t *testing.T) {
+	c := gomock.NewController(t)
+	defer c.Finish()
+
+	content := `{"version": "v0.4.16", "updated": "2018-11-20T00:00:00+00:00"}`
+
+	file := NewMockFile(c)
+	file.EXPECT().Close().Times(2)
+	file.EXPECT().Read(gomock.Any()).Do(func(buf []byte) {
+		copy(buf, []byte(content))
+	}).Return(len(content), io.EOF)
+	file.EXPECT().Write(gomock.Any()).Return(48, nil)
+
+	fs := NewMockFS(c)
+	fs.EXPECT().Open().Return(file, nil)
+	fs.EXPECT().Create().Return(file, nil)
+
+	versionFetcher := NewMockVersionFetcher(c)
+	versionFetcher.EXPECT().Update(context.Background()).Return(semver.Version{Minor: 4, Patch: 17}, nil)
+
+	clock := func() time.Time {
+		now, err := time.Parse(time.RFC3339, "2018-11-22T00:00:00+00:00")
+		require.NoError(t, err)
+		return now
+	}
+	m := NewVersionManager(fs, WithClock(clock), WithVersionFetcher(versionFetcher))
+	err := m.ValidateCurrentVersion(context.Background())
+
+	require.Error(t, err)
+	versionErr, ok := err.(*VersionMismatchError)
+	require.True(t, ok)
+	require.Error(t, versionErr)
+}
+
+func TestVersionManagerErrVersionMismatchWhenUpdateNotRequired(t *testing.T) {
+	c := gomock.NewController(t)
+	defer c.Finish()
+
+	content := `{"version": "v0.4.16", "updated": "2018-11-22T00:00:00+00:00"}`
+
+	file := NewMockFile(c)
+	file.EXPECT().Close().Times(1)
+	file.EXPECT().Read(gomock.Any()).Do(func(buf []byte) {
+		copy(buf, []byte(content))
+	}).Return(len(content), io.EOF)
+
+	fs := NewMockFS(c)
+	fs.EXPECT().Open().Return(file, nil)
+
+	versionFetcher := NewMockVersionFetcher(c)
+
+	clock := func() time.Time {
+		now, err := time.Parse(time.RFC3339, "2018-11-20T12:00:00+00:00")
+		require.NoError(t, err)
+		return now
+	}
+	m := NewVersionManager(fs, WithClock(clock), WithVersionFetcher(versionFetcher))
+	err := m.ValidateCurrentVersion(context.Background())
+
+	require.Error(t, err)
+	versionErr, ok := err.(*VersionMismatchError)
+	require.True(t, ok)
+	require.Error(t, versionErr)
+}
+
+func TestVersionManagerErrVersionMismatchWhenVersionFileNotExists(t *testing.T) {
+	c := gomock.NewController(t)
+	defer c.Finish()
+
+	file := NewMockFile(c)
+	file.EXPECT().Close().Times(1)
+	file.EXPECT().Write(gomock.Any()).Return(48, nil)
+
+	fs := NewMockFS(c)
+	fs.EXPECT().Open().Return(nil, os.ErrNotExist)
+	fs.EXPECT().Create().Return(file, nil)
+
+	versionFetcher := NewMockVersionFetcher(c)
+	versionFetcher.EXPECT().Update(context.Background()).Return(semver.Version{Minor: 4, Patch: 17}, nil)
+
+	clock := func() time.Time {
+		now, err := time.Parse(time.RFC3339, "2018-11-20T12:00:00+00:00")
+		require.NoError(t, err)
+		return now
+	}
+	m := NewVersionManager(fs, WithClock(clock), WithVersionFetcher(versionFetcher))
+	err := m.ValidateCurrentVersion(context.Background())
+
+	require.Error(t, err)
+	versionErr, ok := err.(*VersionMismatchError)
+	require.True(t, ok)
+	require.Error(t, versionErr)
+}
+
+func TestVersionManager(t *testing.T) {
+	c := gomock.NewController(t)
+	defer c.Finish()
+
+	file := NewMockFile(c)
+	file.EXPECT().Close().Times(1)
+	file.EXPECT().Write(gomock.Any()).Return(48, nil)
+
+	fs := NewMockFS(c)
+	fs.EXPECT().Open().Return(nil, os.ErrNotExist)
+	fs.EXPECT().Create().Return(file, nil)
+
+	versionFetcher := NewMockVersionFetcher(c)
+	versionFetcher.EXPECT().Update(context.Background()).Return(semver.Version{Minor: 4, Patch: 17}, nil)
+
+	clock := func() time.Time {
+		now, err := time.Parse(time.RFC3339, "2018-11-20T12:00:00+00:00")
+		require.NoError(t, err)
+		return now
+	}
+	m := NewVersionManager(fs, WithVersion(semver.Version{Minor: 4, Patch: 17}), WithClock(clock), WithVersionFetcher(versionFetcher))
+	err := m.ValidateCurrentVersion(context.Background())
+
+	require.NoError(t, err)
+}


### PR DESCRIPTION
Currently we often have a situation when our clients (both suppliers and customers) don't know whether a new version of the platform has been released. To avoid this we've done a simple console notification as a warning about whether it's time to update.