### PR TITLE
fix: do not hang on deal cancellation

### DIFF
--- a/insonmnia/worker/overseer.go
+++ b/insonmnia/worker/overseer.go
@@ -616,7 +616,7 @@ func (o *overseer) Stop(ctx context.Context, containerid string) error {
 }
 
 func (o *overseer) OnDealFinish(ctx context.Context, containerID string) error {
-	log.S(o.ctx).Debugf("overseer cleaning up %s on deal finish", containerID)
+	log.S(ctx).Debugf("overseer cleaning up %s on deal finish", containerID)
 	var isRunning bool
 	if info, err := o.client.ContainerInspect(ctx, containerID); err != nil {
 		return fmt.Errorf("failed to inspect container %s: %v", containerID, err)

--- a/insonmnia/worker/salesman/options.go
+++ b/insonmnia/worker/salesman/options.go
@@ -4,6 +4,8 @@ import (
 	"crypto/ecdsa"
 	"errors"
 
+	"context"
+
 	"github.com/sonm-io/core/blockchain"
 	"github.com/sonm-io/core/insonmnia/cgroups"
 	"github.com/sonm-io/core/insonmnia/hardware"
@@ -16,7 +18,7 @@ import (
 )
 
 type DealDestroyer interface {
-	CancelDealTasks(dealID *sonm.BigInt) error
+	CancelDealTasks(ctx context.Context, dealID *sonm.BigInt) error
 }
 
 type options struct {

--- a/insonmnia/worker/salesman/options.go
+++ b/insonmnia/worker/salesman/options.go
@@ -1,10 +1,9 @@
 package salesman
 
 import (
+	"context"
 	"crypto/ecdsa"
 	"errors"
-
-	"context"
 
 	"github.com/sonm-io/core/blockchain"
 	"github.com/sonm-io/core/insonmnia/cgroups"

--- a/insonmnia/worker/salesman/salesman.go
+++ b/insonmnia/worker/salesman/salesman.go
@@ -44,11 +44,12 @@ type Config struct {
 }
 
 type YAMLConfig struct {
-	RegularBillPeriod    time.Duration `yaml:"regular_deal_bill_period" default:"24h"`
-	SpotBillPeriod       time.Duration `yaml:"spot_deal_bill_period" default:"1h"`
-	SyncStepTimeout      time.Duration `yaml:"sync_step_timeout" default:"2m"`
-	SyncInterval         time.Duration `yaml:"sync_interval" default:"10s"`
-	MatcherRetryInterval time.Duration `yaml:"matcher_retry_interval" default:"10s"`
+	RegularBillPeriod       time.Duration `yaml:"regular_deal_bill_period" default:"24h"`
+	SpotBillPeriod          time.Duration `yaml:"spot_deal_bill_period" default:"1h"`
+	SyncStepTimeout         time.Duration `yaml:"sync_step_timeout" default:"5m"`
+	SyncInterval            time.Duration `yaml:"sync_interval" default:"10s"`
+	MatcherRetryInterval    time.Duration `yaml:"matcher_retry_interval" default:"10s"`
+	DealCancellationTimeout time.Duration `yaml:"deal_cancellation_timeout" default:"3m"`
 }
 
 type Salesman struct {
@@ -218,11 +219,25 @@ func (m *Salesman) PurgeAskPlans(ctx context.Context) (*sonm.ErrorByStringID, er
 	return status.Unwrap(), nil
 }
 
+func (m *Salesman) markAskPlanForDeletion(planID string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	ask, ok := m.askPlans[planID]
+	if !ok {
+		return
+	}
+	ask.Status = sonm.AskPlan_PENDING_DELETION
+	if err := m.askPlanStorage.Save(m.askPlans); err != nil {
+		m.log.Errorf("failed to mark ask plan %s for deletion: failed to save ask plans state in storage: %s", planID, err)
+	}
+}
+
 func (m *Salesman) RemoveAskPlan(ctx context.Context, planID string) error {
 	ask, err := m.AskPlan(planID)
 	if err != nil {
 		return err
 	}
+	m.markAskPlanForDeletion(planID)
 
 	wasEmpty := false
 	if !ask.DealID.IsZero() {
@@ -330,7 +345,11 @@ func (m *Salesman) syncPlanWithBlockchain(ctx context.Context, plan *sonm.AskPla
 	dealId := plan.GetDealID()
 	ctxWithTimeout, cancel := context.WithTimeout(ctx, m.config.SyncStepTimeout)
 	defer cancel()
-	if !dealId.IsZero() {
+	if plan.Status == sonm.AskPlan_PENDING_DELETION {
+		if err := m.RemoveAskPlan(ctx, plan.GetID()); err != nil {
+			m.log.Warnf("could not remove ask plan %s which was pending deletion: %s", plan.ID, err)
+		}
+	} else if !dealId.IsZero() {
 		if err := m.checkDeal(ctxWithTimeout, plan); err != nil {
 			m.log.Warnf("could not check deal %s for plan %s: %s", dealId.Unwrap().String(), plan.ID, err)
 		}
@@ -470,7 +489,9 @@ func (m *Salesman) closeDeal(ctx context.Context, dealID *sonm.BigInt) error {
 		}
 	}
 
-	if err := m.dealDestroyer.CancelDealTasks(dealID); err != nil {
+	cancellationCtx, cancel := context.WithTimeout(ctx, m.config.DealCancellationTimeout)
+	defer cancel()
+	if err := m.dealDestroyer.CancelDealTasks(cancellationCtx, dealID); err != nil {
 		return fmt.Errorf("failed to cancel deal's %s tasks: %s", dealID, err)
 	}
 	m.mu.Lock()
@@ -614,18 +635,8 @@ func (m *Salesman) onDealOpened(ctx context.Context, planID string, deal *sonm.D
 func (m *Salesman) ejectAskPlans(ctx context.Context, ejectedPlans []string) error {
 	// Anyway check if any plans were ejected
 	for _, planID := range ejectedPlans {
-		m.RemoveAskPlan(ctx, planID)
-		plan, ok := m.askPlans[planID]
-		if !ok {
-			m.log.Errorf("ejected ask plan with ID %s is not found", planID)
-			continue
-		}
-		if !plan.GetDealID().IsZero() {
-			m.RemoveAskPlan(ctx, planID)
-			plan.Status = sonm.AskPlan_PENDING_DELETION
-			m.closeDeal(ctx, plan.DealID)
-		} else {
-			m.log.Errorf("ejected ask plan with ID %s has no deal", planID)
+		if err := m.RemoveAskPlan(ctx, planID); err != nil {
+			m.log.Errorf("failed to eject ask-plan %s: %s", planID, err)
 		}
 	}
 

--- a/insonmnia/worker/server.go
+++ b/insonmnia/worker/server.go
@@ -60,6 +60,7 @@ import (
 	"github.com/sonm-io/core/util/defergroup"
 	"github.com/sonm-io/core/util/multierror"
 	"github.com/sonm-io/core/util/netutil"
+	"github.com/sonm-io/core/util/xconcurrency"
 	"github.com/sonm-io/core/util/xdocker"
 	"github.com/sonm-io/core/util/xgrpc"
 	"github.com/sonm-io/core/util/xnet"
@@ -855,8 +856,8 @@ func (m *Worker) setupHardware() error {
 	return nil
 }
 
-func (m *Worker) CancelDealTasks(dealID *sonm.BigInt) error {
-	log.S(m.ctx).Debugf("canceling deal's %s tasks", dealID)
+func (m *Worker) CancelDealTasks(ctx context.Context, dealID *sonm.BigInt) error {
+	log.S(ctx).Debugf("canceling deal's %s tasks", dealID)
 	var toDelete []*ContainerInfo
 
 	m.mu.Lock()
@@ -868,18 +869,19 @@ func (m *Worker) CancelDealTasks(dealID *sonm.BigInt) error {
 	}
 	m.mu.Unlock()
 
-	result := multierror.NewMultiError()
-	for _, container := range toDelete {
-		if err := m.ovs.OnDealFinish(m.ctx, container.ID); err != nil {
-			result = multierror.Append(result, err)
+	result := multierror.NewTSMultiError()
+	xconcurrency.Run(32, toDelete, func(elem interface{}) {
+		container := elem.(*ContainerInfo)
+		if err := m.ovs.OnDealFinish(ctx, container.ID); err != nil {
+			result.Append(err)
 		}
 		if err := m.resources.OnDealFinish(container.TaskId); err != nil {
-			result = multierror.Append(result, err)
+			result.Append(err)
 		}
 		if _, err := m.storage.Remove(container.ID); err != nil {
-			result = multierror.Append(result, err)
+			result.Append(err)
 		}
-	}
+	})
 	return result.ErrorOrNil()
 }
 
@@ -1278,7 +1280,7 @@ func (m *Worker) StartTask(ctx context.Context, request *sonm.StartTaskRequest) 
 	deal, err := m.salesman.Deal(dealID)
 	if err != nil || deal.Status != sonm.DealStatus_DEAL_ACCEPTED {
 		log.G(m.ctx).Warn("deal was closed before task was spawned")
-		if err := m.CancelDealTasks(dealID); err != nil {
+		if err := m.CancelDealTasks(ctx, dealID); err != nil {
 			log.S(m.ctx).Errorf("failed to drop tasks of closed deals: %s", err)
 		}
 		return nil, status.Errorf(codes.Internal, "failed to start task: corresponding deal was closed")
@@ -1584,7 +1586,7 @@ func (m *Worker) setupRunningContainers() error {
 	}
 
 	for _, deal := range closedDeals {
-		if err := m.CancelDealTasks(deal.GetId()); err != nil {
+		if err := m.CancelDealTasks(m.ctx, deal.GetId()); err != nil {
 			return fmt.Errorf("failed to cancel tasks for deal %s: %v", deal.Id.Unwrap().String(), err)
 		}
 	}


### PR DESCRIPTION
This PR introduces timeouts during deal cancellation in order not to hang forever if something(e.g. in docker) goes wrong