### PR TITLE
fix: reduce noise while logging RPC calls

### DIFF
--- a/util/xgrpc/options.go
+++ b/util/xgrpc/options.go
@@ -22,6 +22,7 @@ import (
 	"github.com/rcrowley/go-metrics"
 	"github.com/sonm-io/core/insonmnia/auth"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
@@ -108,6 +109,8 @@ func newOptions(logger *zap.Logger, extraOpts ...ServerOption) *options {
 	// These must be set before other interceptors to avoid losing logs
 	// because of improper interceptor implementation.
 	if logger != nil {
+		logger = zap.New(logger.Core(), zap.AddStacktrace(zapcore.FatalLevel))
+
 		opts.interceptors.u = append(opts.interceptors.u, grpc_zap.UnaryServerInterceptor(logger))
 		opts.interceptors.s = append(opts.interceptors.s, grpc_zap.StreamServerInterceptor(logger))
 	}


### PR DESCRIPTION
Currently we print stacktraces for any error that is logged. This is
actually useful, but there are cases where it's more annoying than
useful. For example - messages after RPC calls, where stacktraces are
the same and completely useless.
After this change we should no longer print those stacktraces in audit
logs.