### PR TITLE
fix: close QUIC sessions and streams

### DIFF
--- a/insonmnia/npp/puncher_quic.go
+++ b/insonmnia/npp/puncher_quic.go
@@ -224,5 +224,5 @@ func (m *quicPuncher) RemoteAddr() net.Addr {
 }
 
 func (m *quicPuncher) Close() error {
-	return m.rendezvousClient.conn.Close()
+	return m.rendezvousClient.Close()
 }

--- a/insonmnia/npp/puncher_quic.go
+++ b/insonmnia/npp/puncher_quic.go
@@ -224,5 +224,5 @@ func (m *quicPuncher) RemoteAddr() net.Addr {
 }
 
 func (m *quicPuncher) Close() error {
-	return nil
+	return m.rendezvousClient.conn.Close()
 }

--- a/util/xnet/quic.go
+++ b/util/xnet/quic.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/lucas-clemente/quic-go"
 	"github.com/lucas-clemente/quic-go/qerr"
+	"github.com/sonm-io/core/util/multierror"
 )
 
 type quicError struct {
@@ -66,6 +67,18 @@ func (m *QUICConn) LocalAddr() net.Addr {
 
 func (m *QUICConn) RemoteAddr() net.Addr {
 	return m.session.RemoteAddr()
+}
+
+func (m *QUICConn) Close() error {
+	errs := multierror.NewMultiError()
+	if err := m.Stream.Close(); err != nil {
+		errs = multierror.Append(errs, err)
+	}
+	if err := m.session.Close(); err != nil {
+		errs = multierror.Append(errs, err)
+	}
+
+	return errs.ErrorOrNil()
 }
 
 func ListenQUIC(network, address string, tlsConfig *tls.Config, config *quic.Config) (*QUICListener, error) {

--- a/util/xnet/quic.go
+++ b/util/xnet/quic.go
@@ -71,9 +71,11 @@ func (m *QUICConn) RemoteAddr() net.Addr {
 
 func (m *QUICConn) Close() error {
 	errs := multierror.NewMultiError()
+
 	if err := m.Stream.Close(); err != nil {
 		errs = multierror.Append(errs, err)
 	}
+
 	if err := m.session.Close(); err != nil {
 		errs = multierror.Append(errs, err)
 	}


### PR DESCRIPTION
This fixes the memory leak in Rendezvous, Node and Worker components.