### PR TITLE
fix: properly detect for "red" cards in monitoring handler

### DIFF
--- a/insonmnia/worker/gpu/metrics.go
+++ b/insonmnia/worker/gpu/metrics.go
@@ -73,7 +73,7 @@ type radeonMetrics struct {
 }
 
 func newRadeonMetricsHandler() (MetricsHandler, error) {
-	devices, err := CollectDRICardDevices()
+	devices, err := collectDRICardsWithOpenCL()
 	if err != nil {
 		return nil, fmt.Errorf("failed to collect DRI devices: %v", err)
 	}


### PR DESCRIPTION
Now we have a situation when we have on-board and external video on the machine.
Embedded graphics adapter also can be detected as DRI device, but does not provide any metrics interface.
For GPU tuner plugin we're using a crutch: detecting device twice, via DRI and OpenCL, then comparing the results.
This commit re-use that code to collect cards for monitoring interface.