### PR TITLE
fix: randomly place asterix char before the structs

### DIFF
--- a/insonmnia/worker/gpu/metrics.go
+++ b/insonmnia/worker/gpu/metrics.go
@@ -69,7 +69,7 @@ func (m *nvidiaMetrics) Close() error {
 
 type radeonMetrics struct {
 	mu      sync.Mutex
-	devices []DRICard
+	devices []*DRICard
 }
 
 func newRadeonMetricsHandler() (MetricsHandler, error) {


### PR DESCRIPTION
Introduced in #1776

Changelog: exclude