### PR TITLE
fix: proper reaching "out of sync" state

### DIFF
--- a/blockchain/api.go
+++ b/blockchain/api.go
@@ -1512,22 +1512,13 @@ func (api *BasicEventsAPI) fetchAndProcessLogs(ctx context.Context, filter simpl
 	}
 
 	// no logs within the required range,
-	// just push NoEvent data.
+	// just push NoEvent data with last observed
+	// block number.
 	if len(logs) == 0 && filter.EmitNoEvent {
-		for blockNumber := filter.FromBlock; blockNumber <= filter.ToBlock; blockNumber++ {
-			block, err := api.client.BlockByNumber(ctx, big.NewInt(0).SetUint64(blockNumber))
-			if err != nil {
-				ctxlog.S(ctx).Warn("failed to get block timestamp", zap.Uint64("block", blockNumber), zap.Error(err))
-				continue
-			}
-
-			receiver <- &Event{
-				BlockNumber: blockNumber,
-				Data:        &NoEventsData{},
-				TS:          block.Time().Uint64(),
-			}
+		receiver <- &Event{
+			BlockNumber: filter.ToBlock,
+			Data:        &NoEventsData{},
 		}
-
 		return nil
 	}
 

--- a/blockchain/types.go
+++ b/blockchain/types.go
@@ -35,6 +35,8 @@ func (m *Event) PrecedesOrEquals(other *Event) bool {
 	return false
 }
 
+type NoEventsData struct{}
+
 type DealOpenedData struct {
 	ID *big.Int
 }

--- a/insonmnia/dwh/processor.go
+++ b/insonmnia/dwh/processor.go
@@ -119,7 +119,7 @@ func (m *L1Processor) watchMarketEvents() error {
 	}
 
 	m.logger.Info("starting from block", zap.Uint64("block_number", m.lastEvent.BlockNumber))
-	filter := m.blockchain.Events().GetMarketFilter(big.NewInt(0).SetUint64(m.lastEvent.BlockNumber))
+	filter := m.blockchain.Events().GetMarketFilter(big.NewInt(0).SetUint64(m.lastEvent.BlockNumber)).WithEmitNoEvents()
 	events, err := m.blockchain.Events().GetEvents(m.ctx, filter)
 	if err != nil {
 		return err

--- a/insonmnia/dwh/processor.go
+++ b/insonmnia/dwh/processor.go
@@ -832,8 +832,6 @@ func (m *L1Processor) onCertificateUpdated(certID *big.Int) error {
 }
 
 func (m *L1Processor) onEmptyEventData(event *blockchain.Event) error {
-	ts := time.Unix(int64(event.TS), 0)
-	m.logger.Sugar().Debugf("no events at block %d (ts = %s)", event.BlockNumber, ts)
 	return nil
 }
 


### PR DESCRIPTION
This commit fixes random "out of sync" state reaching when there are no events has been produced in the chain.
Now if the blockchain's `GetEvents` method returns no logs entities - we're emitting `NoEventsData` event which is processing as any other events. Event triggers an update of the lastBlock counter, and the "out of sync" state does not appear.

Closes #1689.