### PR TITLE
fix: enable interceptor for REST interface on DWH

### DIFF
--- a/insonmnia/dwh/server.go
+++ b/insonmnia/dwh/server.go
@@ -152,7 +152,11 @@ func (m *DWH) serveHTTP() error {
 		m.mu.Lock()
 		defer m.mu.Unlock()
 
-		options := []rest.Option{rest.WithLog(m.logger)}
+		options := []rest.Option{
+			rest.WithLog(m.logger),
+			rest.WithInterceptors(m.unaryInterceptor),
+		}
+
 		lis, err := net.Listen("tcp", m.cfg.HTTPListenAddr)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create http listener: %v", err)


### PR DESCRIPTION
At least we also should notify a user about the "out of sync" state.