### PR TITLE
fix: human-readable TC initialization error

### DIFF
--- a/insonmnia/worker/network/tc/ifb.go
+++ b/insonmnia/worker/network/tc/ifb.go
@@ -3,6 +3,7 @@ package tc
 import (
 	"fmt"
 	"os/exec"
+	"strings"
 )
 
 const (
@@ -44,5 +45,9 @@ func execModProbe(args ...string) error {
 
 	cmd := exec.Command(bin, args...)
 
-	return cmd.Run()
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed to execute `modprobe %s`: %v", strings.Join(args, " "), err)
+	}
+
+	return nil
 }


### PR DESCRIPTION
Failing while initializing ifb device resulted in printing "Exit status 1", which is not obvious to understang what's going on. Now we will report at least which command we're trying to execute.