### PR TITLE
fix: proper error type in ErrorOrNil

### DIFF
--- a/insonmnia/worker/salesman/salesman.go
+++ b/insonmnia/worker/salesman/salesman.go
@@ -346,8 +346,12 @@ func (m *Salesman) syncPlanWithBlockchain(ctx context.Context, plan *sonm.AskPla
 	if plan.Status == sonm.AskPlan_PENDING_DELETION {
 		if err := m.RemoveAskPlan(ctx, plan.GetID()); err != nil {
 			m.log.Warnf("could not remove ask plan %s which was pending deletion: %s", plan.ID, err)
+		} else {
+			return
 		}
-	} else if !dealId.IsZero() {
+	}
+
+	if !dealId.IsZero() {
 		if err := m.checkDeal(ctxWithTimeout, plan); err != nil {
 			m.log.Warnf("could not check deal %s for plan %s: %s", dealId.Unwrap().String(), plan.ID, err)
 		}

--- a/util/multierror/error.go
+++ b/util/multierror/error.go
@@ -49,9 +49,6 @@ func (m *TSMultiError) Append(errs ...error) {
 	m.inner = multierror.Append(m.inner, errs...)
 }
 
-func (m *TSMultiError) ErrorOrNil() *multierror.Error {
-	if err := m.inner.ErrorOrNil(); err == nil {
-		return nil
-	}
-	return m.inner
+func (m *TSMultiError) ErrorOrNil() error {
+	return m.inner.ErrorOrNil()
 }


### PR DESCRIPTION
Fixxed bug with task cancellation:
  * process ask-plan which are pending for deletion in a usual pipeline to update order info in case ask-plan can not be deleted right now
  * return proper type from ErrorOrNil function to fix this https://golang.org/doc/faq#nil_error behaviour