### PR TITLE
fix: use LinkOrCopyStrategy to provision nvidia volumes

### DIFF
--- a/insonmnia/worker/gpu/volume_plugin.go
+++ b/insonmnia/worker/gpu/volume_plugin.go
@@ -53,7 +53,7 @@ func (p *volumePlugin) Create(req *volume.CreateRequest) error {
 	}
 
 	if !ok {
-		return vol.Create(nvidia.LinkStrategy{})
+		return vol.Create(nvidia.LinkOrCopyStrategy{})
 	}
 
 	return nil


### PR DESCRIPTION
Now we're hardlinking .so files and other nvidia related stuff
into the volume. This way isn't working when /var is present in another partition,
we must fallback to Copy in such case.