### PR TITLE
fix: avoid duplicated driver volumes for GPUs

### DIFF
--- a/insonmnia/worker/gpu/utils.go
+++ b/insonmnia/worker/gpu/utils.go
@@ -31,6 +31,7 @@ func newVolumeMount(src, dst, name string) mount.Mount {
 
 func tuneContainer(hostconfig *container.HostConfig, devices map[GPUID]*sonm.GPUDevice, ids []GPUID) error {
 	var cardsToBind = make(map[GPUID]*sonm.GPUDevice)
+	var volumeMapping = make(map[string]mount.Mount)
 	for _, id := range ids {
 		card, ok := devices[id]
 		if !ok {
@@ -55,8 +56,12 @@ func tuneContainer(hostconfig *container.HostConfig, devices map[GPUID]*sonm.GPU
 				return fmt.Errorf("malformed driver mount-point `%s`", pair)
 			}
 
-			hostconfig.Mounts = append(hostconfig.Mounts, newVolumeMount(srcDst[0], srcDst[1], name))
+			volumeMapping[srcDst[1]] = newVolumeMount(srcDst[0], srcDst[1], name)
 		}
+	}
+
+	for _, mnt := range volumeMapping {
+		hostconfig.Mounts = append(hostconfig.Mounts, mnt)
 	}
 
 	return nil


### PR DESCRIPTION
Now we're storing whole information required to mount single GPU into a container inside the `sonm.GPUDevice` structure. and now we can turn up into a situation, when we're trying to mount more than one GPU with the same type. The Tuner will try to attach more than one (absolutely same) volume to the container. In that case, it will lead to the container' start failure.

This PR fixes that behavior by collecting proposed mount points into the set, and then applying only non-repeated ones.