### PR TITLE
fix: gomod reuseport replacement

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -169,4 +169,4 @@ require (
 
 replace github.com/Sirupsen/logrus v1.1.0 => github.com/sirupsen/logrus v1.1.0
 
-replace github.com/libp2p/go-reuseport v0.1.10 => github.com/libp2p/go-reuseport gx/v0.1.10
+replace github.com/libp2p/go-reuseport v0.1.10 => github.com/libp2p/go-reuseport v0.0.0-20180201025315-5f99154da15f

--- a/go.sum
+++ b/go.sum
@@ -159,6 +159,7 @@ github.com/lann/ps v0.0.0-20150810152359-62de8c46ede0 h1:P6pPBnrTSX3DEVR4fDembhR
 github.com/lann/ps v0.0.0-20150810152359-62de8c46ede0/go.mod h1:vmVJ0l/dxyfGW6FmdpVm2joNMFikkuWg0EoCKLGUMNw=
 github.com/lib/pq v0.0.0-20180327071824-d34b9ff171c2 h1:hRGSmZu7j271trc9sneMrpOW7GN5ngLm8YUZIPzf394=
 github.com/lib/pq v0.0.0-20180327071824-d34b9ff171c2/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
+github.com/libp2p/go-reuseport v0.0.0-20180201025315-5f99154da15f h1:wlz3TmGeMzWGi095pyzd0miiP+m6JRU4B/98WiNhkvQ=
 github.com/libp2p/go-reuseport v0.0.0-20180201025315-5f99154da15f/go.mod h1:UeLFiw50cCfyDHBpU0sXBR8ul1MO/m51mXpRO/SYjCE=
 github.com/libp2p/go-reuseport v0.1.10 h1:luit4a4lmixdyb1MXs8YNHkVe4cZx0ETN630HLqPsws=
 github.com/libp2p/go-reuseport v0.1.10/go.mod h1:UeLFiw50cCfyDHBpU0sXBR8ul1MO/m51mXpRO/SYjCE=


### PR DESCRIPTION
This pr fixes incorrect `github.com/libp2p/go-reuseport` dependency definition.
It's replaces automatically after every build.