### PR TITLE
feat: multiple gRPC compressions

### DIFF
--- a/util/xgrpc/server.go
+++ b/util/xgrpc/server.go
@@ -4,14 +4,13 @@ import (
 	"github.com/grpc-ecosystem/go-grpc-middleware"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
+	_ "google.golang.org/grpc/encoding/gzip"
 )
 
 func NewServer(logger *zap.Logger, extraOpts ...ServerOption) *grpc.Server {
 	opts := newOptions(logger, extraOpts...)
 	srv := grpc.NewServer(
 		append([]grpc.ServerOption{
-			grpc.RPCCompressor(grpc.NewGZIPCompressor()),
-			grpc.RPCDecompressor(grpc.NewGZIPDecompressor()),
 			grpc.UnaryInterceptor(grpc_middleware.ChainUnaryServer(opts.interceptors.u...)),
 			grpc.StreamInterceptor(grpc_middleware.ChainStreamServer(opts.interceptors.s...)),
 		}, opts.options...)...,


### PR DESCRIPTION
Before the only gzip compression was always used, which caused troubles with gRPC clients without compression support.
This commit allows selecting how to compress the response depending on request compression type.