### PR TITLE
fix: wrong streaming authorization check

### DIFF
--- a/util/xgrpc/options.go
+++ b/util/xgrpc/options.go
@@ -230,7 +230,7 @@ func (m *wrappedAuthStream) RecvMsg(msg interface{}) error {
 		return err
 	}
 
-	if !m.processed.CAS(false, true) {
+	if m.processed.CAS(false, true) {
 		if err := m.router.Authorize(m.ServerStream.Context(), auth.Event(m.info.FullMethod), msg); err != nil {
 			return err
 		}


### PR DESCRIPTION
Previously streaming gRPC authorization always ignored the first
chunk for the incoming stream and checked for others. This is wrong for
methods which stream only back because the entire authorization
mechanism is suppressed at all.

This commit fixes such behavior by forcing the auth routing to check for
the first incoming message.