### PR TITLE
fix: dwh tests

### DIFF
--- a/insonmnia/dwh/setup_test.go
+++ b/insonmnia/dwh/setup_test.go
@@ -204,7 +204,7 @@ func checkPostgresReadiness(db *sql.DB) error {
 		fmt.Printf("postgres container not ready, %d retries left\n", numRetries)
 		time.Sleep(time.Second)
 	}
-	err := fmt.Errorf("postgress not started with %d retries", checkDatabaseReadinessRetry)
+	err := fmt.Errorf("postgress not started after %d retries", checkDatabaseReadinessRetry)
 
 	return fmt.Errorf("failed to connect to postgres container: %v", err)
 }


### PR DESCRIPTION
This PR fixes behavior with dwh test suite:
* add required for run `POSTGRES_PASSWORD` environment
* returns an error when Postgres not started any times, not null
* format touched file imports